### PR TITLE
Some temporary folder stuff

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -7,5 +7,5 @@ type Environment struct {
 	//TODO: Add some sort of interface to the system logger
 	//TODO: Add some interface to submit statistics for influxdb/signalfx
 	//TODO: Add some interface to attach a http.Handler to public facing server
-	//TODO: Add some interface to create a temporary folder and remove it again...
+	TemporaryStorage TemporaryStorage
 }

--- a/runtime/tempfolder.go
+++ b/runtime/tempfolder.go
@@ -1,0 +1,86 @@
+package runtime
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/taskcluster/slugid-go/slugid"
+)
+
+// TemporaryStorage can create temporary folders and files.
+type TemporaryStorage interface {
+	NewFolder() (TemporaryFolder, error)
+	NewFile() (TemporaryFile, error)
+}
+
+// TemporaryFolder is a temporary folder that is backed by the filesystem.
+// User are nicely asked to stay with the folder they've been issued.
+//
+// We don't really mock the file system interface as we need to integrate with
+// other applications like docker, so we have to expose real file paths.
+type TemporaryFolder interface {
+	TemporaryStorage
+	Path() string
+	Remove() error
+}
+
+// TemporaryFile is a temporary file that will be removed when closed.
+type TemporaryFile interface {
+	io.ReadWriteSeeker
+	io.Closer
+	Path() string
+}
+
+type temporaryFolder struct {
+	path string
+}
+
+type temporaryFile struct {
+	*os.File
+	path string
+}
+
+// NewTemporaryStorage TemporaryStorage rooted in the given path.
+func NewTemporaryStorage(path string) (TemporaryStorage, error) {
+	err := os.MkdirAll(path, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &temporaryFolder{path: path}, nil
+}
+
+func (s *temporaryFolder) Path() string {
+	return s.path
+}
+
+func (s *temporaryFolder) NewFolder() (TemporaryFolder, error) {
+	path := filepath.Join(s.path, slugid.V4())
+	err := os.Mkdir(path, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &temporaryFolder{path: path}, nil
+}
+
+func (s temporaryFolder) NewFile() (TemporaryFile, error) {
+	path := filepath.Join(s.path, slugid.V4())
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return &temporaryFile{file, path}, nil
+}
+
+func (s *temporaryFolder) Remove() error {
+	return os.RemoveAll(s.path)
+}
+
+func (f *temporaryFile) Path() string {
+	return f.path
+}
+
+func (f *temporaryFile) Close() error {
+	f.File.Close()
+	return os.Remove(f.path)
+}


### PR DESCRIPTION
We can't really do a virtual file system, like this:
https://godoc.org/golang.org/x/tools/godoc/vfs#FileSystem

Because many of the things we pass files to actually needs real file.. .Ie. docker, so I suggest we just give up and build some abstractions like these.. .This way at least we won't have to deal with the names of temporary files and folders...

Some things like our livelog could probably use a virtual file system in testing... but I suspect it's  not worth it as many other things will need real files anyways...

----
The idea behind this is that many plugins, engines, etc.. will need to use temprorary files. So having a generic interface for creating, naming and removing those files seems to make sense... Rather than each plugin trying to guess where it can create a temp file...