### PR TITLE
Made logging level parsing error message clearer

### DIFF
--- a/plugins/extpoints/interfaces.go
+++ b/plugins/extpoints/interfaces.go
@@ -12,10 +12,6 @@ import (
 //
 // We wrap all arguments so that we can add additional properties without
 // breaking source compatibility with older plugins.
-// Note: This is passed by-value for efficiency (and to prohibit nil), if
-// adding any large fields please consider adding them as pointers.
-// Note: This is intended to be a simple argument wrapper, do not add methods
-// to this struct.
 type PluginOptions struct {
 	environment *runtime.Environment
 	engine      *engines.Engine

--- a/runtime/log.go
+++ b/runtime/log.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
-// Create a logger that can be passed around through the environment.
+// CreateLogger returns a new logger that can be passed around through the environment.
 // Loggers can be created based on the one returned from this method by calling
 // WithField or WithFields and specifying additional fields that the package
 // would like.
@@ -17,7 +17,7 @@ func CreateLogger(level string) (*logrus.Logger, error) {
 
 	lvl, err := logrus.ParseLevel(level)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse logging level: %s\n", level)
+		return nil, fmt.Errorf("Error: Invalid logging level '%s'.\n", level)
 	}
 
 	logger := logrus.New()


### PR DESCRIPTION
Just addressing two comments from the last PR. 

1. Made error message clearer when parsing log messages.  In this case, I don't think we need to include the error from logrus as it pretty much states the same thing we're saying here.  I just chose to wrap this error so that we remove the wording 'logrus' from the error message since the user would not really have an idea what that is.
2. Updated doc for createLogger
3. Moved the source comment in PluginOptions.