### PR TITLE
Refector queue service

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,9 +115,5 @@ func main() {
 		logger.Fatalf("Could not create worker. %s", err)
 	}
 
-	err = w.Start()
-	if err != nil {
-		os.Stderr.WriteString(err.Error())
-		os.Exit(1)
-	}
+	w.Start()
 }

--- a/worker/queueservice.go
+++ b/worker/queueservice.go
@@ -18,6 +18,7 @@ import (
 	"github.com/taskcluster/httpbackoff"
 	tcqueue "github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
 )
 
 type (
@@ -58,78 +59,102 @@ type (
 	// QueueService is an interface describing the methods responsible for claiming
 	// work from Azure queues.
 	QueueService interface {
-		ClaimWork(int) []*TaskRun
+		Done()
+		Start() <-chan *TaskRun
+		Stop()
 	}
 
 	queueService struct {
-		mu               sync.Mutex
+		mu               sync.RWMutex
+		capacity         int
+		interval         int
+		tc               chan *TaskRun
 		queues           []taskQueue
-		Expires          tcclient.Time
-		ExpirationOffset int
+		expires          tcclient.Time
+		expirationOffset int
 		client           queueClient
-		ProvisionerID    string
-		WorkerType       string
-		WorkerID         string
-		WorkerGroup      string
-		Log              *logrus.Entry
+		provisionerID    string
+		workerType       string
+		workerID         string
+		workerGroup      string
+		log              *logrus.Entry
+		halt             atomics.Bool
 	}
 )
 
-// Given a number of tasks needed, the Azure task queues will be polled in order
-// of priority until either there are no more tasks to claim, or the given number of
-// tasks has been fulfilled.
-func (q *queueService) ClaimWork(ntasks int) []*TaskRun {
-	q.Log.Debugf("Attempting to claim %d tasks.", ntasks)
-	tasks := []*TaskRun{}
-	taskRuns, err := q.retrieveTasksFromQueue(ntasks)
-	if err != nil {
-		// Log the error but just return an empty set of Task Runs.
-		q.Log.WithField("error", err).Error("Error retrieving tasks to execute.")
-		return []*TaskRun{}
-	}
+// Start will begin the task claiming loop and claim as many tasks as the worker
+// capacity allows.  Claimed tasks will be returned on a channel for consumers
+// to run.
+func (q *queueService) Start() <-chan *TaskRun {
+	q.tc = make(chan *TaskRun)
 
-	tasks = q.claimTasks(taskRuns)
-	return tasks
+	go func() {
+		for !q.halt.Get() {
+			q.mu.RLock()
+			capacity := q.capacity
+			q.mu.RUnlock()
+			tasks := q.retrieveTasksFromQueue(capacity)
+			q.claimTasks(tasks)
+			time.Sleep(time.Duration(q.interval) * time.Second)
+		}
+		close(q.tc)
+	}()
+	return q.tc
 }
 
-func (q *queueService) claimTasks(tasks []*TaskRun) []*TaskRun {
+// Stop will set the current capacity to 0 so no tasks are claimed.
+func (q *queueService) Stop() {
+	q.halt.Set(true)
+	return
+}
+
+// Done is called each time a task is completed.  Current capacity will be incremented
+// each time Done is called.
+func (q *queueService) Done() {
+	q.mu.Lock()
+	q.capacity++
+	q.mu.Unlock()
+}
+
+func (q *queueService) claimTasks(tasks []*TaskRun) {
 	var wg sync.WaitGroup
-	claims := []*TaskRun{}
-	claimed := make(chan *TaskRun, len(tasks))
 	wg.Add(len(tasks))
 	for _, task := range tasks {
 		go func(task *TaskRun) {
 			defer wg.Done()
-			success := q.claimTask(task)
-			if success {
-				claimed <- task
+			err := q.claimTask(task)
+			if err != nil {
+				q.log.WithFields(logrus.Fields{
+					"taskID": task.TaskID,
+					"runID":  task.RunID,
+					"error":  err.Error(),
+				}).Warn("Could not claim task")
+				return
 			}
+			q.mu.Lock()
+			q.capacity--
+			q.mu.Unlock()
+			q.tc <- task
 		}(task)
 	}
 	wg.Wait()
-	close(claimed)
-
-	for claim := range claimed {
-		claims = append(claims, claim)
-	}
-
-	return claims
+	return
 }
 
-func (q *queueService) claimTask(task *TaskRun) bool {
-	err := claimTask(q.client, task, q.WorkerID, q.WorkerGroup, q.Log)
+func (q *queueService) claimTask(task *TaskRun) error {
+	err := claimTask(q.client, task, q.workerID, q.workerGroup, q.log)
 	if err != nil {
 		if err.statusCode == 401 || err.statusCode == 403 || err.statusCode >= 500 {
 			// Do not delete the message if task could not be claimed because of server
 			// or authorization failures
-			return false
+			return errors.New("Error when attempting to claim task.  Task was *not* deleted from Azure.")
 		}
 
 		_ = q.deleteFromAzure(task.SignedDeleteURL)
-		return false
+		return errors.New("Error when attempting to claim task.  Error is non-recoverable so task was deleted from Azure.")
 	}
 	_ = q.deleteFromAzure(task.SignedDeleteURL)
-	return true
+	return nil
 }
 
 // deleteFromAzure will attempt to delete a task from the Azure queue and
@@ -145,7 +170,7 @@ func (q *queueService) deleteFromAzure(deleteURL string) error {
 	// either case the worker should delete the message as we don't want
 	// another worker to receive message later.
 
-	q.Log.Info("Deleting task from Azure queue")
+	q.log.Info("Deleting task from Azure queue")
 	httpCall := func() (*http.Response, error, error) {
 		req, err := http.NewRequest("DELETE", deleteURL, nil)
 		if err != nil {
@@ -168,14 +193,14 @@ func (q *queueService) deleteFromAzure(deleteURL string) error {
 	// reasons outlined above it's strongly advised that workers logs failures
 	// to delete messages from Azure queues.
 	if err != nil {
-		q.Log.WithFields(logrus.Fields{
+		q.log.WithFields(logrus.Fields{
 			"error": err,
 			"url":   deleteURL,
 		}).Warn("Not able to delete task from azure queue")
 		return err
 	}
 
-	q.Log.Info("Successfully deleted task from azure queue")
+	q.log.Info("Successfully deleted task from azure queue")
 	return nil
 }
 
@@ -216,7 +241,7 @@ func (q *queueService) pollTaskURL(taskQueue *taskQueue, ntasks int) ([]*TaskRun
 	data, err := ioutil.ReadAll(resp.Body)
 	if err := xml.Unmarshal(data, &r); err != nil {
 		//if err := xml.NewDecoder(resp.Body).Decode(&queueMessagesList); err != nil {
-		q.Log.WithFields(logrus.Fields{
+		q.log.WithFields(logrus.Fields{
 			"body":  resp.Body,
 			"error": err.Error(),
 		}).Debugf("Not able to xml decode the response from the Azure queue")
@@ -224,7 +249,7 @@ func (q *queueService) pollTaskURL(taskQueue *taskQueue, ntasks int) ([]*TaskRun
 	}
 
 	if len(r.QueueMessages) == 0 {
-		q.Log.Debug("Zero tasks returned in Azure XML queueMessagesList")
+		q.log.Debug("Zero tasks returned in Azure XML queueMessagesList")
 		return []*TaskRun{}, nil
 	}
 
@@ -258,10 +283,10 @@ func (q *queueService) pollTaskURL(taskQueue *taskQueue, ntasks int) ([]*TaskRun
 		// that alert the operator if a message has been dequeued a significant
 		// number of times, for example 15 or more.
 		if qm.DequeueCount >= 15 {
-			q.Log.Warnf("Queue Message with message id %v has been dequeued %v times!", qm.MessageID, qm.DequeueCount)
+			q.log.Warnf("Queue Message with message id %v has been dequeued %v times!", qm.MessageID, qm.DequeueCount)
 			err := q.deleteFromAzure(SignedDeleteURL)
 			if err != nil {
-				q.Log.Warnf("Not able to call Azure delete URL %v. %v", SignedDeleteURL, err)
+				q.log.Warnf("Not able to call Azure delete URL %v. %v", SignedDeleteURL, err)
 			}
 		}
 
@@ -272,11 +297,11 @@ func (q *queueService) pollTaskURL(taskQueue *taskQueue, ntasks int) ([]*TaskRun
 		if err != nil {
 			// try to delete from Azure, if it fails, nothing we can do about it
 			// not very serious - another worker will try to delete it
-			q.Log.WithField("messageText", qm.MessageText).Errorf("Not able to base64 decode the Message Text in Azure message response.")
-			q.Log.WithField("messageID", qm.MessageID).Info("Deleting from Azure queue as other workers will have the same problem.")
+			q.log.WithField("messageText", qm.MessageText).Errorf("Not able to base64 decode the Message Text in Azure message response.")
+			q.log.WithField("messageID", qm.MessageID).Info("Deleting from Azure queue as other workers will have the same problem.")
 			err := q.deleteFromAzure(SignedDeleteURL)
 			if err != nil {
-				q.Log.WithFields(logrus.Fields{
+				q.log.WithFields(logrus.Fields{
 					"messageID": qm.MessageID,
 					"url":       SignedDeleteURL,
 					"error":     err,
@@ -293,13 +318,13 @@ func (q *queueService) pollTaskURL(taskQueue *taskQueue, ntasks int) ([]*TaskRun
 		// now populate remaining json fields of TaskRun from json string m
 		err = json.Unmarshal(m, &taskRun)
 		if err != nil {
-			q.Log.WithFields(logrus.Fields{
+			q.log.WithFields(logrus.Fields{
 				"error":   err,
 				"message": m,
 			}).Warn("Not able to unmarshal json from base64 decoded MessageText")
 			err := q.deleteFromAzure(SignedDeleteURL)
 			if err != nil {
-				q.Log.WithFields(logrus.Fields{
+				q.log.WithFields(logrus.Fields{
 					"url":   SignedDeleteURL,
 					"error": err,
 				}).Warn("Not able to call Azure delete URL")
@@ -321,11 +346,11 @@ func (q *queueService) refreshTaskQueueUrls() error {
 		return nil
 	}
 
-	q.Log.Debug("Refreshing Azure queue task urls")
+	q.log.Debug("Refreshing Azure queue task urls")
 
-	signedURLs, _, err := q.client.PollTaskUrls(q.ProvisionerID, q.WorkerType)
+	signedURLs, _, err := q.client.PollTaskUrls(q.provisionerID, q.workerType)
 	if err != nil {
-		q.Log.WithField("error", err).Warn("Error retrieving task urls.")
+		q.log.WithField("error", err).Warn("Error retrieving task urls.")
 		return errors.New("Error retrieving task urls.")
 	}
 
@@ -336,19 +361,16 @@ func (q *queueService) refreshTaskQueueUrls() error {
 
 	q.mu.Lock()
 	q.queues = taskQueues
-	q.Expires = signedURLs.Expires
+	q.expires = signedURLs.Expires
 	q.mu.Unlock()
-	q.Log.Debugf("Refreshed %d Azure queue task urls", len(taskQueues))
+	q.log.Debugf("Refreshed %d Azure queue task urls", len(taskQueues))
 	return nil
 }
 
-func (q *queueService) retrieveTasksFromQueue(ntasks int) ([]*TaskRun, error) {
-	err := q.refreshTaskQueueUrls()
-	if err != nil {
-		return nil, err
-	}
-
+func (q *queueService) retrieveTasksFromQueue(ntasks int) []*TaskRun {
+	_ = q.refreshTaskQueueUrls()
 	tasks := []*TaskRun{}
+
 	for _, queue := range q.queues {
 		// Continue polling the Azure queue until either enough messages have been retrieved
 		// or the queue has no more messages.
@@ -356,11 +378,11 @@ func (q *queueService) retrieveTasksFromQueue(ntasks int) ([]*TaskRun, error) {
 			// It hopefully would never be greater, but just incase, we would want to return
 			// and run what tasks we do have.
 			if len(tasks) >= ntasks {
-				return tasks, nil
+				return tasks
 			}
 			taskRuns, err := q.pollTaskURL(&queue, ntasks-len(tasks))
 			if err != nil {
-				q.Log.Warnf("Could not retrieve tasks from the Azure queue. %s", err)
+				q.log.Warnf("Could not retrieve tasks from the Azure queue. %s", err)
 				break
 			}
 
@@ -372,7 +394,7 @@ func (q *queueService) retrieveTasksFromQueue(ntasks int) ([]*TaskRun, error) {
 		}
 
 	}
-	return tasks, nil
+	return tasks
 }
 
 // Evaluate if the current time is getting close to the url expiration as decided
@@ -383,7 +405,7 @@ func (q *queueService) shouldRefreshQueueUrls() bool {
 	}
 	// If the duration between Expiration and current time is less than the expiration
 	// off set then it's time to refresh the urls
-	if int(time.Time(q.Expires).Sub(time.Now()).Seconds()) < q.ExpirationOffset {
+	if int(time.Time(q.expires).Sub(time.Now()).Seconds()) < q.expirationOffset {
 		return true
 	}
 	return false

--- a/worker/queueservice_test.go
+++ b/worker/queueservice_test.go
@@ -27,10 +27,10 @@ func TestRetrievePollTaskUrls(t *testing.T) {
 	mockedQueue := &MockQueue{}
 	service := queueService{
 		client:           mockedQueue,
-		ProvisionerID:    ProvisionerID,
-		WorkerType:       WorkerType,
-		Log:              logger.WithField("component", "Queue Service"),
-		ExpirationOffset: 300,
+		provisionerID:    ProvisionerID,
+		workerType:       WorkerType,
+		log:              logger.WithField("component", "Queue Service"),
+		expirationOffset: 300,
 	}
 	mockedQueue.On(
 		"PollTaskUrls",
@@ -70,10 +70,10 @@ func TestRetrievePollTaskUrlsErrorCaught(t *testing.T) {
 	mockedQueue := &MockQueue{}
 	service := queueService{
 		client:           mockedQueue,
-		ProvisionerID:    ProvisionerID,
-		WorkerType:       WorkerType,
-		Log:              logger.WithField("component", "Queue Service"),
-		ExpirationOffset: 300,
+		provisionerID:    ProvisionerID,
+		workerType:       WorkerType,
+		log:              logger.WithField("component", "Queue Service"),
+		expirationOffset: 300,
 	}
 
 	mockedQueue.On(
@@ -93,7 +93,7 @@ func TestRetrievePollTaskUrlsErrorCaught(t *testing.T) {
 
 func TestShouldRefreshQueueUrls(t *testing.T) {
 	service := queueService{
-		ExpirationOffset: 300,
+		expirationOffset: 300,
 	}
 
 	// Should refresh since there are no queues currently stored
@@ -101,22 +101,22 @@ func TestShouldRefreshQueueUrls(t *testing.T) {
 
 	// When expiration is still within limits, and the queue slice has already been
 	// populated, the queue service should not need to refresh
-	service.Expires = tcclient.Time(time.Now().Add(time.Minute * 6))
+	service.expires = tcclient.Time(time.Now().Add(time.Minute * 6))
 	service.queues = []taskQueue{taskQueue{}, taskQueue{}}
 	assert.Equal(t, false, service.shouldRefreshQueueUrls())
 
 	// Expiration is coming close, need to refresh
-	service.Expires = tcclient.Time(time.Now().Add(time.Minute * 2))
+	service.expires = tcclient.Time(time.Now().Add(time.Minute * 2))
 	assert.Equal(t, true, service.shouldRefreshQueueUrls())
 }
 
 func TestShouldNotRefreshTaskQueueUrls(t *testing.T) {
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		ExpirationOffset: 300,
-		Expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
+		expirationOffset: 300,
+		expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
 		queues:           []taskQueue{taskQueue{}, taskQueue{}},
-		Log:              logger.WithField("component", "Queue Service"),
+		log:              logger.WithField("component", "Queue Service"),
 	}
 
 	// Because the expiration is not close, adn the service already has queues,
@@ -137,7 +137,7 @@ func TestPollTaskUrlInvalidXMLResponse(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log: logger.WithField("component", "Queue Service"),
+		log: logger.WithField("component", "Queue Service"),
 		queues: []taskQueue{{
 			SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
 			SignedPollURL:   fmt.Sprintf("%s/tasks", s.URL),
@@ -159,7 +159,7 @@ func TestPollTaskURLEmptyMessageList(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log: logger.WithField("component", "Queue Service"),
+		log: logger.WithField("component", "Queue Service"),
 		queues: []taskQueue{{
 			SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
 			SignedPollURL:   fmt.Sprintf("%s/tasks", s.URL),
@@ -204,7 +204,7 @@ func TestPollTaskURLNonEmptyMessageList(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log: logger.WithField("component", "Queue Service"),
+		log: logger.WithField("component", "Queue Service"),
 		queues: []taskQueue{{
 			SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
 			SignedPollURL:   fmt.Sprintf("%s/tasks", s.URL),
@@ -244,7 +244,7 @@ func TestPollTaskURLInvalidMessageTextContents(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log: logger.WithField("component", "Queue Service"),
+		log: logger.WithField("component", "Queue Service"),
 		queues: []taskQueue{{
 			SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
 			SignedPollURL:   fmt.Sprintf("%s/tasks", s.URL),
@@ -289,7 +289,7 @@ func TestPollTaskURLInvalidMessageTextEncoding(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log: logger.WithField("component", "Queue Service"),
+		log: logger.WithField("component", "Queue Service"),
 		queues: []taskQueue{{
 			SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
 			SignedPollURL:   fmt.Sprintf("%s/tasks", s.URL),
@@ -313,7 +313,7 @@ func TestSuccessfullyDeleteFromAzureQueue(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log: logger.WithField("component", "Queue Service"),
+		log: logger.WithField("component", "Queue Service"),
 	}
 	err := service.deleteFromAzure(fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL))
 	assert.Nil(t, err)
@@ -328,7 +328,7 @@ func TestErrorCaughtDeleteFromAzureQueueL(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log: logger.WithField("component", "Queue Service"),
+		log: logger.WithField("component", "Queue Service"),
 	}
 	err := service.deleteFromAzure(fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL))
 	assert.NotNil(t, err)
@@ -393,9 +393,9 @@ func TestRetrieveTasksFromQueue(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log:              logger.WithField("component", "Queue Service"),
-		ExpirationOffset: 300,
-		Expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
+		log:              logger.WithField("component", "Queue Service"),
+		expirationOffset: 300,
+		expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
 		queues: []taskQueue{
 			{
 				SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
@@ -408,10 +408,7 @@ func TestRetrieveTasksFromQueue(t *testing.T) {
 		},
 	}
 
-	tasks, err := service.retrieveTasksFromQueue(3)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tasks := service.retrieveTasksFromQueue(3)
 
 	assert.Equal(t, 3, len(tasks))
 	taskIds := []string{"abc", "def", "ghi"}
@@ -477,9 +474,9 @@ func TestRetrieveTasksFromQueueDoesNotQueryLowPriority(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log:              logger.WithField("component", "Queue Service"),
-		ExpirationOffset: 300,
-		Expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
+		log:              logger.WithField("component", "Queue Service"),
+		expirationOffset: 300,
+		expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
 		queues: []taskQueue{
 			{
 				SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
@@ -492,10 +489,7 @@ func TestRetrieveTasksFromQueueDoesNotQueryLowPriority(t *testing.T) {
 		},
 	}
 
-	tasks, err := service.retrieveTasksFromQueue(2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tasks := service.retrieveTasksFromQueue(2)
 
 	// Only two tasks should have been retrieving leaving the third task in the lower
 	// priority queue not being retrieved
@@ -538,9 +532,9 @@ func TestRetrieveTasksFromQueueDequeueChecked(t *testing.T) {
 	defer s.Close()
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
-		Log:              logger.WithField("component", "Queue Service"),
-		ExpirationOffset: 300,
-		Expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
+		log:              logger.WithField("component", "Queue Service"),
+		expirationOffset: 300,
+		expires:          tcclient.Time(time.Now().Add(time.Minute * 10)),
 		queues: []taskQueue{
 			{
 				SignedDeleteURL: fmt.Sprintf("%s/delete/{{messageId}}/{{popReceipt}}", s.URL),
@@ -549,10 +543,7 @@ func TestRetrieveTasksFromQueueDequeueChecked(t *testing.T) {
 		},
 	}
 
-	tasks, err := service.retrieveTasksFromQueue(2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tasks := service.retrieveTasksFromQueue(2)
 
 	assert.Equal(t, 1, len(tasks))
 	assert.True(t, deleteCalled, "Delete should have been called when dequeue count above threshold")
@@ -611,15 +602,15 @@ func TestClaimTask(t *testing.T) {
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
 		client:        mockedQueue,
-		Log:           logger.WithField("component", "Queue Service"),
-		WorkerID:      WorkerID,
-		WorkerGroup:   WorkerType,
-		ProvisionerID: ProvisionerID,
+		log:           logger.WithField("component", "Queue Service"),
+		workerID:      WorkerID,
+		workerGroup:   WorkerType,
+		provisionerID: ProvisionerID,
 	}
 
-	success := service.claimTask(task)
+	err := service.claimTask(task)
 
-	assert.True(t, success)
+	assert.Nil(t, err)
 	assert.True(t, deleteCalled)
 	// Do a quick sanity check to make sure the response was correctly stored in
 	// the task run object
@@ -666,15 +657,15 @@ func TestClaimTaskError(t *testing.T) {
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
 		client:        mockedQueue,
-		Log:           logger.WithField("component", "Queue Service"),
-		WorkerID:      WorkerID,
-		WorkerGroup:   WorkerType,
-		ProvisionerID: ProvisionerID,
+		log:           logger.WithField("component", "Queue Service"),
+		workerID:      WorkerID,
+		workerGroup:   WorkerType,
+		provisionerID: ProvisionerID,
 	}
 
-	success := service.claimTask(task)
+	err := service.claimTask(task)
 
-	assert.False(t, success, "Task should not have been claimed")
+	assert.NotNil(t, err, "Task should not have been claimed")
 	// Delete should not have been called because it was an authorization issue
 	assert.False(t, deleteCalled, "Message should not have been deleted from the queue.")
 }
@@ -756,12 +747,27 @@ func TestClaimTasks(t *testing.T) {
 	logger, _ := runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
 	service := queueService{
 		client:        mockedQueue,
-		Log:           logger.WithField("component", "Queue Service"),
-		WorkerID:      WorkerID,
-		WorkerGroup:   WorkerType,
-		ProvisionerID: ProvisionerID,
+		capacity:      2,
+		tc:            make(chan *TaskRun, 2),
+		log:           logger.WithField("component", "Queue Service"),
+		workerID:      WorkerID,
+		workerGroup:   WorkerType,
+		provisionerID: ProvisionerID,
 	}
 
-	taskClaims := service.claimTasks(tasks)
-	assert.Equal(t, 2, len(taskClaims))
+	claims := []*TaskRun{}
+	service.claimTasks(tasks)
+loop:
+	for len(claims) != 2 {
+		select {
+		case t := <-service.tc:
+			claims = append(claims, t)
+		// Tasks should be claimed in less than 1 second, but set up a timer to timeout
+		// so tests don't run forever waiting.
+		case <-time.NewTimer(1 * time.Second).C:
+			break loop
+		}
+	}
+
+	assert.Equal(t, 2, len(claims), "Not enough task claims received after calling claimTasks")
 }

--- a/worker/queueservice_test.go
+++ b/worker/queueservice_test.go
@@ -612,7 +612,7 @@ func TestClaimTask(t *testing.T) {
 	assert.True(t, deleteCalled)
 	// Do a quick sanity check to make sure the response was correctly stored in
 	// the task run object
-	assert.Equal(t, "1040824383284384", claim.TaskClaim.Credentials.AccessToken)
+	assert.Equal(t, "1040824383284384", claim.taskClaim.Credentials.AccessToken)
 }
 
 func TestClaimTaskError(t *testing.T) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -16,17 +16,17 @@ import (
 // TaskRun represents the task lifecycle once claimed.  TaskRun contains information
 // about the task as well as controllers for executing and resolving the task.
 type TaskRun struct {
-	TaskID        string
-	RunID         uint
-	TaskClaim     queue.TaskClaimResponse
-	TaskReclaim   queue.TaskReclaimResponse
-	Definition    queue.TaskDefinitionResponse
-	QueueClient   queueClient
-	plugin        plugins.TaskPlugin
-	log           *logrus.Entry
-	payload       interface{}
-	pluginPayload interface{}
-	sync.RWMutex
+	TaskID         string
+	RunID          uint
+	taskClaim      queue.TaskClaimResponse
+	taskReclaim    queue.TaskReclaimResponse
+	definition     queue.TaskDefinitionResponse
+	queueClient    queueClient
+	plugin         plugins.TaskPlugin
+	log            *logrus.Entry
+	payload        interface{}
+	pluginPayload  interface{}
+	mu             sync.RWMutex
 	context        *runtime.TaskContext
 	controller     *runtime.TaskContextController
 	sandboxBuilder engines.SandboxBuilder
@@ -41,9 +41,9 @@ func NewTaskRun(claim *taskClaim, log *logrus.Entry) *TaskRun {
 	return &TaskRun{
 		TaskID:      claim.TaskID,
 		RunID:       claim.RunID,
-		TaskClaim:   claim.TaskClaim,
-		Definition:  claim.Definition,
-		QueueClient: claim.QueueClient,
+		taskClaim:   claim.TaskClaim,
+		definition:  claim.Definition,
+		queueClient: claim.QueueClient,
 		log:         log,
 	}
 }
@@ -51,8 +51,8 @@ func NewTaskRun(claim *taskClaim, log *logrus.Entry) *TaskRun {
 // Abort will set the status of the task to aborted and abort the task execution
 // environment if one has been created.
 func (t *TaskRun) Abort() {
-	t.Lock()
-	defer t.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.shutdown = true
 	if t.context != nil {
 		t.context.Abort()
@@ -66,8 +66,8 @@ func (t *TaskRun) Abort() {
 // environment if one has been created.
 func (t *TaskRun) Cancel() {
 	t.log.Info("Cancelling task")
-	t.Lock()
-	defer t.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.context != nil {
 		t.context.Cancel()
 	}
@@ -81,47 +81,47 @@ func (t *TaskRun) Cancel() {
 // life cycle.
 //
 // Tasks that do not complete successfully will be reported as an exception during
-// the ExceptionStage.
+// the exceptionStage.
 func (t *TaskRun) Run(pluginManager plugins.Plugin, engine engines.Engine, context *runtime.TaskContext, contextController *runtime.TaskContextController) {
 	// TODO (garndt): change to NewRun, return &TaskRun{}, introduce task claim concept into queue service
-	t.Lock()
+	t.mu.Lock()
 	t.context = context
 	t.controller = contextController
 	t.engine = engine
-	t.Unlock()
+	t.mu.Unlock()
 
-	defer t.DisposeStage()
+	defer t.disposeStage()
 
-	err := t.ParsePayload(pluginManager, engine)
+	err := t.parsePayload(pluginManager, engine)
 	if err != nil || t.context.IsAborted() || t.context.IsCancelled() {
 		t.context.LogError(fmt.Sprintf("Invalid task payload. %s", err))
-		t.ExceptionStage(err)
+		t.exceptionStage(err)
 		return
 	}
 
-	err = t.CreateTaskPlugins(pluginManager)
+	err = t.createTaskPlugins(pluginManager)
 	if err != nil || t.context.IsAborted() || t.context.IsCancelled() {
 		t.context.LogError(fmt.Sprintf("Invalid task payload. %s", err))
-		t.ExceptionStage(err)
+		t.exceptionStage(err)
 		return
 	}
 
 	stages := []func() error{
-		t.PrepareStage,
-		t.BuildStage,
-		t.StartStage,
-		t.StopStage,
-		t.FinishStage,
+		t.prepareStage,
+		t.buildStage,
+		t.startStage,
+		t.stopStage,
+		t.finishStage,
 	}
 	for _, stage := range stages {
 		err = stage()
 		if err != nil || t.context.IsAborted() || t.context.IsCancelled() {
-			t.ExceptionStage(err)
+			t.exceptionStage(err)
 			return
 		}
 	}
 
-	err = t.ResolveTask()
+	err = t.resolveTask()
 	if err != nil || t.context.IsAborted() || t.context.IsCancelled() {
 		t.log.WithField("error", err.Error()).Warn("Could not resolve task properly")
 		return
@@ -129,12 +129,12 @@ func (t *TaskRun) Run(pluginManager plugins.Plugin, engine engines.Engine, conte
 
 }
 
-// ParsePayload  will parse the task payload, which will validate it against the engine
+// parsePayload  will parse the task payload, which will validate it against the engine
 // and plugin schemas.
-func (t *TaskRun) ParsePayload(pluginManager plugins.Plugin, engine engines.Engine) error {
+func (t *TaskRun) parsePayload(pluginManager plugins.Plugin, engine engines.Engine) error {
 	var err error
 	jsonPayload := map[string]json.RawMessage{}
-	if err = json.Unmarshal([]byte(t.Definition.Payload), &jsonPayload); err != nil {
+	if err = json.Unmarshal([]byte(t.definition.Payload), &jsonPayload); err != nil {
 		return err
 	}
 
@@ -154,8 +154,8 @@ func (t *TaskRun) ParsePayload(pluginManager plugins.Plugin, engine engines.Engi
 	return nil
 }
 
-// CreateTaskPlugins will create a new task plugin to be used during the task lifecycle.
-func (t *TaskRun) CreateTaskPlugins(pluginManager plugins.Plugin) error {
+// createTaskPlugins will create a new task plugin to be used during the task lifecycle.
+func (t *TaskRun) createTaskPlugins(pluginManager plugins.Plugin) error {
 	var err error
 	popts := plugins.TaskPluginOptions{TaskInfo: &runtime.TaskInfo{}, Payload: t.pluginPayload}
 	t.plugin, err = pluginManager.NewTaskPlugin(popts)
@@ -166,8 +166,8 @@ func (t *TaskRun) CreateTaskPlugins(pluginManager plugins.Plugin) error {
 	return nil
 }
 
-// PrepareStage is where task plugins are prepared and a sandboxbuilder is created.
-func (t *TaskRun) PrepareStage() error {
+// prepareStage is where task plugins are prepared and a sandboxbuilder is created.
+func (t *TaskRun) prepareStage() error {
 	t.log.Debug("Preparing task run")
 
 	err := t.plugin.Prepare(t.context)
@@ -176,12 +176,12 @@ func (t *TaskRun) PrepareStage() error {
 		return err
 	}
 
-	t.Lock()
+	t.mu.Lock()
 	t.sandboxBuilder, err = t.engine.NewSandboxBuilder(engines.SandboxOptions{
 		TaskContext: t.context,
 		Payload:     t.payload,
 	})
-	t.Unlock()
+	t.mu.Unlock()
 	if err != nil {
 		t.context.LogError(fmt.Sprintf("Could not create task execution environment. %s", err))
 		return err
@@ -190,8 +190,8 @@ func (t *TaskRun) PrepareStage() error {
 	return nil
 }
 
-// BuildStage is responsible for configuring the environment for building a sandbox (task execution environment).
-func (t *TaskRun) BuildStage() error {
+// buildStage is responsible for configuring the environment for building a sandbox (task execution environment).
+func (t *TaskRun) buildStage() error {
 	t.log.Debug("Building task run")
 
 	err := t.plugin.BuildSandbox(t.sandboxBuilder)
@@ -203,8 +203,8 @@ func (t *TaskRun) BuildStage() error {
 	return nil
 }
 
-// StartStage is responsible for starting the execution environment and waiting for a result.
-func (t *TaskRun) StartStage() error {
+// startStage is responsible for starting the execution environment and waiting for a result.
+func (t *TaskRun) startStage() error {
 	t.log.Debug("Running task")
 
 	sandbox, err := t.sandboxBuilder.StartSandbox()
@@ -212,9 +212,9 @@ func (t *TaskRun) StartStage() error {
 		t.context.LogError(fmt.Sprintf("Could not start task execution environment. %s", err))
 		return err
 	}
-	t.Lock()
+	t.mu.Lock()
 	t.sandbox = sandbox
-	t.Unlock()
+	t.mu.Unlock()
 
 	err = t.plugin.Started(t.sandbox)
 	if err != nil {
@@ -233,9 +233,9 @@ func (t *TaskRun) StartStage() error {
 	return nil
 }
 
-// StopStage will run once the sandbox has terminated.  This stage will be responsible
+// stopStage will run once the sandbox has terminated.  This stage will be responsible
 // for uploading artifacts, cleaning up of resources, etc.
-func (t *TaskRun) StopStage() error {
+func (t *TaskRun) stopStage() error {
 	t.log.Debug("Stopping task execution")
 	var err error
 	t.success, err = t.plugin.Stopped(t.resultSet)
@@ -248,9 +248,9 @@ func (t *TaskRun) StopStage() error {
 	return nil
 }
 
-// FinishStage is responsible for finalizing the execution of a task, close and
+// finishStage is responsible for finalizing the execution of a task, close and
 // upload tasks logs, etc.
-func (t *TaskRun) FinishStage() error {
+func (t *TaskRun) finishStage() error {
 	t.log.Debug("Finishing task run")
 
 	err := t.controller.CloseLog()
@@ -267,10 +267,10 @@ func (t *TaskRun) FinishStage() error {
 	return nil
 }
 
-// ExceptionStage will report a task run as an exception with an appropriate reason.
+// exceptionStage will report a task run as an exception with an appropriate reason.
 // Tasks that have been cancelled will not be reported as an exception as the run
 // has already been resolved.
-func (t *TaskRun) ExceptionStage(taskError error) {
+func (t *TaskRun) exceptionStage(taskError error) {
 	fmt.Println(taskError)
 	var reason runtime.ExceptionReason
 	if t.shutdown {
@@ -299,7 +299,7 @@ func (t *TaskRun) ExceptionStage(taskError error) {
 		return
 	}
 
-	e := reportException(t.QueueClient, t, reason, t.log)
+	e := reportException(t.queueClient, t, reason, t.log)
 	if e != nil {
 		t.log.WithField("error", e.Error()).Warn("Could not resolve task as exception.")
 	}
@@ -307,24 +307,24 @@ func (t *TaskRun) ExceptionStage(taskError error) {
 	return
 }
 
-// ResolveTask will resolve the task as completed/failed depending on the outcome
+// resolveTask will resolve the task as completed/failed depending on the outcome
 // of executing the task and finalizing the task plugins.
-func (t *TaskRun) ResolveTask() error {
+func (t *TaskRun) resolveTask() error {
 	resolve := reportCompleted
 	if !t.success {
 		resolve = reportFailed
 	}
 
-	err := resolve(t.QueueClient, t, t.log)
+	err := resolve(t.queueClient, t, t.log)
 	if err != nil {
 		return errors.New(err.Error())
 	}
 	return nil
 }
 
-// DisposeStage is responsible for cleaning up resources allocated for the task execution.
+// disposeStage is responsible for cleaning up resources allocated for the task execution.
 // This will involve closing all necessary files and disposing of contexts, plugins, and sandboxes.
-func (t *TaskRun) DisposeStage() {
+func (t *TaskRun) disposeStage() {
 	err := t.controller.Dispose()
 	if err != nil {
 		t.log.WithField("error", err.Error()).Warn("Could not dispose of task context")

--- a/worker/task.go
+++ b/worker/task.go
@@ -44,11 +44,11 @@ func NewTaskRun(claim *taskClaim, path string, engine engines.Engine, pluginMana
 	}
 
 	tr := &TaskRun{
-		TaskID:      claim.TaskID,
-		RunID:       claim.RunID,
-		taskClaim:   claim.TaskClaim,
-		definition:  claim.Definition,
-		queueClient: claim.QueueClient,
+		TaskID:      claim.taskID,
+		RunID:       claim.runID,
+		taskClaim:   claim.taskClaim,
+		definition:  claim.definition,
+		queueClient: claim.queueClient,
 		log:         log,
 		context:     ctxt,
 		controller:  ctxtctl,

--- a/worker/task.go
+++ b/worker/task.go
@@ -16,17 +16,16 @@ import (
 // TaskRun represents the task lifecycle once claimed.  TaskRun contains information
 // about the task as well as controllers for executing and resolving the task.
 type TaskRun struct {
-	TaskID          string                       `json:"taskId"`
-	RunID           uint                         `json:"runId"`
-	SignedDeleteURL string                       `json:"-"`
-	TaskClaim       queue.TaskClaimResponse      `json:"-"`
-	TaskReclaim     queue.TaskReclaimResponse    `json:"-"`
-	Definition      queue.TaskDefinitionResponse `json:"-"`
-	QueueClient     queueClient
-	plugin          plugins.TaskPlugin
-	log             *logrus.Entry
-	payload         interface{}
-	pluginPayload   interface{}
+	TaskID        string
+	RunID         uint
+	TaskClaim     queue.TaskClaimResponse
+	TaskReclaim   queue.TaskReclaimResponse
+	Definition    queue.TaskDefinitionResponse
+	QueueClient   queueClient
+	plugin        plugins.TaskPlugin
+	log           *logrus.Entry
+	payload       interface{}
+	pluginPayload interface{}
 	sync.RWMutex
 	context        *runtime.TaskContext
 	controller     *runtime.TaskContextController
@@ -36,6 +35,17 @@ type TaskRun struct {
 	engine         engines.Engine
 	success        bool
 	shutdown       bool
+}
+
+func NewTaskRun(claim *taskClaim, log *logrus.Entry) *TaskRun {
+	return &TaskRun{
+		TaskID:      claim.TaskID,
+		RunID:       claim.RunID,
+		TaskClaim:   claim.TaskClaim,
+		Definition:  claim.Definition,
+		QueueClient: claim.QueueClient,
+		log:         log,
+	}
 }
 
 // Abort will set the status of the task to aborted and abort the task execution

--- a/worker/task_test.go
+++ b/worker/task_test.go
@@ -106,10 +106,10 @@ func TestParsePayload(t *testing.T) {
 	}()
 
 	for _, tc := range testCases {
-		tr.Definition = queue.TaskDefinitionResponse{
+		tr.definition = queue.TaskDefinitionResponse{
 			Payload: []byte(tc.definition),
 		}
-		err = tr.ParsePayload(pluginManager, engine)
+		err = tr.parsePayload(pluginManager, engine)
 		assert.Equal(t, tc.shouldFail, err != nil, "Parsing invalid task payload should have returned an error")
 	}
 }
@@ -121,7 +121,7 @@ func TestCreateTaskPlugins(t *testing.T) {
 	tr := &TaskRun{
 		TaskID: "abc",
 		RunID:  1,
-		Definition: queue.TaskDefinitionResponse{
+		definition: queue.TaskDefinitionResponse{
 			Payload: []byte(`{"start": {"delay": 10,"function": "write-log","argument": "Hello World"}}`),
 		},
 		log: logger.WithField("taskId", "abc"),
@@ -130,7 +130,7 @@ func TestCreateTaskPlugins(t *testing.T) {
 	tp := environment.TemporaryStorage.NewFilePath()
 	tr.context, tr.controller, err = runtime.NewTaskContext(tp)
 
-	err = tr.ParsePayload(pluginManager, engine)
+	err = tr.parsePayload(pluginManager, engine)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestCreateTaskPlugins(t *testing.T) {
 		taskPlugin: &taskPlugin{},
 	}
 
-	err = tr.CreateTaskPlugins(pm)
+	err = tr.createTaskPlugins(pm)
 	assert.Nil(t, err, "Error should not have been returned when creating task plugins")
 
 	pm = mockedPluginManager{
@@ -147,7 +147,7 @@ func TestCreateTaskPlugins(t *testing.T) {
 		taskPluginError: engines.NewMalformedPayloadError("bad payload"),
 	}
 
-	err = tr.CreateTaskPlugins(pm)
+	err = tr.createTaskPlugins(pm)
 	assert.NotNil(t, err, "Error should have been returned when creating task plugins")
 	assert.Equal(t, "engines.MalformedPayloadError", reflect.TypeOf(err).String())
 }
@@ -159,7 +159,7 @@ func TestPrepare(t *testing.T) {
 	tr := &TaskRun{
 		TaskID: "abc",
 		RunID:  1,
-		Definition: queue.TaskDefinitionResponse{
+		definition: queue.TaskDefinitionResponse{
 			Payload: []byte(`{"start": {"delay": 10,"function": "write-log","argument": "Hello World"}}`),
 		},
 		log:    logger.WithField("taskId", "abc"),
@@ -170,12 +170,12 @@ func TestPrepare(t *testing.T) {
 	tp := environment.TemporaryStorage.NewFilePath()
 	tr.context, tr.controller, err = runtime.NewTaskContext(tp)
 
-	err = tr.ParsePayload(pluginManager, engine)
+	err = tr.parsePayload(pluginManager, engine)
 	assert.Nil(t, err)
 
-	err = tr.CreateTaskPlugins(pluginManager)
+	err = tr.createTaskPlugins(pluginManager)
 	assert.Nil(t, err)
 
-	err = tr.PrepareStage()
+	err = tr.prepareStage()
 	assert.Nil(t, err)
 }

--- a/worker/taskmanager.go
+++ b/worker/taskmanager.go
@@ -145,12 +145,13 @@ func (m *Manager) CancelTask(taskID string, runID int) {
 	return
 }
 
-func (m *Manager) run(task *TaskRun) {
+func (m *Manager) run(claim *taskClaim) {
 	log := m.log.WithFields(logrus.Fields{
-		"taskID": task.TaskID,
-		"runID":  task.RunID,
+		"taskID": claim.TaskID,
+		"runID":  claim.RunID,
 	})
-	task.log = log
+
+	task := NewTaskRun(claim, log)
 
 	err := m.registerTask(task)
 

--- a/worker/taskmanager.go
+++ b/worker/taskmanager.go
@@ -147,8 +147,8 @@ func (m *Manager) CancelTask(taskID string, runID int) {
 
 func (m *Manager) run(claim *taskClaim) {
 	log := m.log.WithFields(logrus.Fields{
-		"taskID": claim.TaskID,
-		"runID":  claim.RunID,
+		"taskID": claim.taskID,
+		"runID":  claim.runID,
 	})
 
 	task, err := NewTaskRun(claim, m.environment.TemporaryStorage.NewFilePath(), m.engine, m.pluginManager, log)

--- a/worker/taskmanager_test.go
+++ b/worker/taskmanager_test.go
@@ -212,6 +212,7 @@ func TestWorkerShutdown(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 	assert.Equal(t, len(tm.RunningTasks()), 2)
+	close(tm.done)
 	tm.Stop()
 
 	wg.Wait()

--- a/worker/taskmanager_test.go
+++ b/worker/taskmanager_test.go
@@ -58,10 +58,10 @@ func TestRunTask(t *testing.T) {
 	).Return(&queue.TaskStatusResponse{}, &tcclient.CallSummary{}, nil)
 
 	claim := &taskClaim{
-		QueueClient: mockedQueue,
-		TaskID:      "abc",
-		RunID:       1,
-		Definition: queue.TaskDefinitionResponse{
+		queueClient: mockedQueue,
+		taskID:      "abc",
+		runID:       1,
+		definition: queue.TaskDefinitionResponse{
 			Payload: []byte(`{"start": {"delay": 10,"function": "write-log","argument": "Hello World"}}`),
 		},
 	}
@@ -109,12 +109,12 @@ func TestCancelTask(t *testing.T) {
 	}, &tcclient.CallSummary{}, nil)
 
 	claim := &taskClaim{
-		TaskID: "abc",
-		RunID:  1,
-		Definition: queue.TaskDefinitionResponse{
+		taskID: "abc",
+		runID:  1,
+		definition: queue.TaskDefinitionResponse{
 			Payload: []byte(`{"start": {"delay": 5000,"function": "write-log","argument": "Hello World"}}`),
 		},
-		QueueClient: mockedQueue,
+		queueClient: mockedQueue,
 	}
 	done := make(chan struct{})
 	go func() {
@@ -180,20 +180,20 @@ func TestWorkerShutdown(t *testing.T) {
 	}, &tcclient.CallSummary{}, nil)
 
 	claims := []*taskClaim{&taskClaim{
-		TaskID: "abc",
-		RunID:  1,
-		Definition: queue.TaskDefinitionResponse{
+		taskID: "abc",
+		runID:  1,
+		definition: queue.TaskDefinitionResponse{
 			Payload: []byte(`{"start": {"delay": 5000,"function": "write-log","argument": "Hello World"}}`),
 		},
-		QueueClient: mockedQueue,
+		queueClient: mockedQueue,
 	},
 		&taskClaim{
-			TaskID: "def",
-			RunID:  0,
-			Definition: queue.TaskDefinitionResponse{
+			taskID: "def",
+			runID:  0,
+			definition: queue.TaskDefinitionResponse{
 				Payload: []byte(`{"start": {"delay": 5000,"function": "write-log","argument": "Hello World"}}`),
 			},
-			QueueClient: mockedQueue,
+			queueClient: mockedQueue,
 		}}
 
 	var wg sync.WaitGroup

--- a/worker/taskstatusupdate.go
+++ b/worker/taskstatusupdate.go
@@ -108,7 +108,7 @@ func reclaimTask(client queueClient, task *TaskRun, log *logrus.Entry) *updateEr
 		return &updateError{err: err.Error()}
 	}
 
-	task.TaskReclaim = *tcrsp
+	task.taskReclaim = *tcrsp
 	log.Info("Reclaimed task successfully")
 	return nil
 }

--- a/worker/taskstatusupdate.go
+++ b/worker/taskstatusupdate.go
@@ -19,11 +19,11 @@ func (e updateError) Error() string {
 }
 
 type taskClaim struct {
-	TaskID      string
-	RunID       uint
-	TaskClaim   tcqueue.TaskClaimResponse
-	Definition  tcqueue.TaskDefinitionResponse
-	QueueClient queueClient
+	taskID      string
+	runID       uint
+	taskClaim   tcqueue.TaskClaimResponse
+	definition  tcqueue.TaskDefinitionResponse
+	queueClient queueClient
 }
 
 func reportException(client queueClient, task *TaskRun, reason runtime.ExceptionReason, log *logrus.Entry) *updateError {
@@ -85,17 +85,18 @@ func claimTask(client queueClient, taskID string, runID uint, workerID string, w
 	}
 
 	return &taskClaim{
-		TaskID: taskID,
-		RunID:  runID,
-		QueueClient: tcqueue.New(
+		taskID: taskID,
+		runID:  runID,
+		// TODO (garndt): replace with client retrieved from the task context.
+		queueClient: tcqueue.New(
 			&tcclient.Credentials{
 				ClientId:    tcrsp.Credentials.ClientID,
 				AccessToken: tcrsp.Credentials.AccessToken,
 				Certificate: tcrsp.Credentials.Certificate,
 			},
 		),
-		TaskClaim:  *tcrsp,
-		Definition: tcrsp.Task,
+		taskClaim:  *tcrsp,
+		definition: tcrsp.Task,
 	}, nil
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -50,6 +50,6 @@ func (w *Worker) Start() {
 
 // stop is a convenience method for stopping the worker loop.  Usually the worker will not be
 // stopped this way, but rather will listen for a shutdown event.
-func (w *Worker) stop() {
+func (w *Worker) Stop() {
 	close(w.done)
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -34,7 +34,7 @@ func New(config *config.Config, engine engines.Engine, environment *runtime.Envi
 // Start will begin the worker cycle of claiming and executing tasks.  The worker
 // will also being to respond to host level events such as shutdown notifications and
 // resource depletion events.
-func (w *Worker) Start() error {
+func (w *Worker) Start() {
 	w.logger.Info("worker starting up")
 
 	go w.tm.Start()
@@ -45,7 +45,7 @@ func (w *Worker) Start() error {
 	}
 
 	w.tm.Stop()
-	return nil
+	return
 }
 
 // stop is a convenience method for stopping the worker loop.  Usually the worker will not be

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -19,7 +19,7 @@ type mockedQueueService struct {
 }
 
 func (m *mockedQueueService) Start() <-chan *taskClaim {
-	defer m.worker.stop()
+	defer m.worker.Stop()
 	defer close(m.worker.tm.done)
 	m.started = true
 	return make(chan *taskClaim)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -18,11 +18,11 @@ type mockedQueueService struct {
 	worker  *Worker
 }
 
-func (m *mockedQueueService) Start() <-chan *TaskRun {
+func (m *mockedQueueService) Start() <-chan *taskClaim {
 	defer m.worker.stop()
 	defer close(m.worker.tm.done)
 	m.started = true
-	return make(chan *TaskRun)
+	return make(chan *taskClaim)
 }
 
 func (m *mockedQueueService) Stop() {


### PR DESCRIPTION
Some high level goals are to:

[X] Return a channel which task claims will be written to
[X] Separate out task claims, task messages, and task runs into their own types to make it clearer
[X] Add method for creating a new task run from a task claim