### PR TITLE
Swap out ReadCloser for ReadSeekCloser to support retries in artifact uploads

### DIFF
--- a/engines/enginetest/artifacts.go
+++ b/engines/enginetest/artifacts.go
@@ -3,7 +3,6 @@ package enginetest
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"strings"
 	"sync"
@@ -70,7 +69,7 @@ func (c *ArtifactTestCase) TestExtractFolderNotFound() {
 	assert(r.buildRunSandbox(), "Task failed to run, payload: ", c.Payload)
 
 	err := r.resultSet.ExtractFolder(c.FolderNotFoundPath, func(
-		path string, reader io.ReadCloser,
+		path string, reader engines.ReadSeekCloser,
 	) error {
 		return errors.New("File was found, didn't expect that!!!")
 	})
@@ -89,7 +88,7 @@ func (c *ArtifactTestCase) TestExtractNestedFolderPath() {
 	m := sync.Mutex{}
 	files := []string{}
 	err := r.resultSet.ExtractFolder(c.NestedFolderPath, func(
-		path string, reader io.ReadCloser,
+		path string, reader engines.ReadSeekCloser,
 	) error {
 		m.Lock()
 		files = append(files, path)
@@ -137,7 +136,7 @@ func (c *ArtifactTestCase) TestExtractFolderHandlerInterrupt() {
 	assert(r.buildRunSandbox(), "Task failed to run, payload: ", c.Payload)
 
 	err := r.resultSet.ExtractFolder(c.NestedFolderPath, func(
-		path string, reader io.ReadCloser,
+		path string, reader engines.ReadSeekCloser,
 	) error {
 		return errors.New("Error that should interrupt ExtractFolder")
 	})

--- a/engines/resultset.go
+++ b/engines/resultset.go
@@ -1,6 +1,16 @@
 package engines
 
-import "io"
+import (
+	"io"
+)
+
+// A ReadSeekCloser wraps some basic io operations such that we can do
+// retries in artifact upload logic
+type ReadSeekCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
 
 // FileHandler is given as callback when iterating through a list of files.
 //
@@ -8,7 +18,7 @@ import "io"
 // parameter. This function maybe called sequentially or concurrently, but if
 // it returns an the ResultSet should stop calling it and pass the error through
 // as return value from ResultSet.ExtractFolder.
-type FileHandler func(path string, stream io.ReadCloser) error
+type FileHandler func(path string, stream ReadSeekCloser) error
 
 // The ResultSet interface represents the results of a sandbox that has finished
 // execution, but is hanging around while results are being extracted.
@@ -36,7 +46,7 @@ type ResultSet interface {
 	//
 	// Non-fatal erorrs: ErrFeatureNotSupported, ErrResourceNotFound,
 	// MalformedPayloadError
-	ExtractFile(path string) (io.ReadCloser, error)
+	ExtractFile(path string) (ReadSeekCloser, error)
 
 	// Extract a folder from the sandbox.
 	//
@@ -72,7 +82,7 @@ type ResultSet interface {
 
 	// ArchiveSandbox streams out the entire sandbox (or as much as possible)
 	// as a tar-stream. Ideally this also includes cache folders.
-	ArchiveSandbox() (io.ReadCloser, error)
+	ArchiveSandbox() (ReadSeekCloser, error)
 
 	// Dispose shall release all resources.
 	//
@@ -95,7 +105,7 @@ type ResultSetBase struct{}
 
 // ExtractFile returns ErrFeatureNotSupported indicating that the feature isn't
 // supported.
-func (ResultSetBase) ExtractFile(string) (io.ReadCloser, error) {
+func (ResultSetBase) ExtractFile(string) (ReadSeekCloser, error) {
 	return nil, ErrFeatureNotSupported
 }
 
@@ -107,7 +117,7 @@ func (ResultSetBase) ExtractFolder(string, FileHandler) error {
 
 // ArchiveSandbox returns ErrFeatureNotSupported indicating that the feature
 // isn't supported.
-func (ResultSetBase) ArchiveSandbox() (io.ReadCloser, error) {
+func (ResultSetBase) ArchiveSandbox() (ReadSeekCloser, error) {
 	return nil, ErrFeatureNotSupported
 }
 

--- a/engines/resultset.go
+++ b/engines/resultset.go
@@ -4,8 +4,8 @@ import (
 	"io"
 )
 
-// A ReadSeekCloser wraps some basic io operations such that we can do
-// retries in artifact upload logic
+// ReadSeekCloser implements io.Reader, io.Seeker, and io.Closer. It is trivially implemented by os.File.
+// The interface is used to expose file objects from ResultSet while abstracting with file-system specifics.
 type ReadSeekCloser interface {
 	io.Reader
 	io.Seeker


### PR DESCRIPTION
This will make implementing certain engines (like the docker engine) more difficult, and likely require tmp files to be created for artifacts, but will make the implementation of artifact uploading much simpler. This PR exists for discussion about whether or not this would be preferable. @jonasfj and @gregarndt are both interested parties.