### PR TITLE
Create queue client in task context

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,17 @@ type (
 			ExpirationOffset int `json:"expirationOffset"`
 		} `json:"queueService"`
 
+		// Properties related to the TaskCluster Platform
+		Taskcluster struct {
+
+			// Properties defining interaction with the TaskCluster queue
+			Queue struct {
+
+				// Base URL for TaskCluster queue
+				URL string `json:"url"`
+			} `json:"queue"`
+		} `json:"taskcluster"`
+
 		// A logical group for this worker to belong to, such as an AWS region.
 		WorkerGroup string `json:"workerGroup"`
 
@@ -118,6 +129,25 @@ var ConfigSchema = func() runtime.CompositeSchema {
 		        "expirationOffset"
 		      ],
 		      "title": "QueueService",
+		      "type": "object"
+		    },
+		    "taskcluster": {
+		      "description": "Properties related to the TaskCluster Platform",
+		      "properties": {
+		        "queue": {
+		          "description": "Properties defining interaction with the TaskCluster queue",
+		          "properties": {
+		            "url": {
+		              "description": "Base URL for TaskCluster queue",
+		              "title": "BaseUrl",
+		              "type": "string"
+		            }
+		          },
+		          "title": "TaskclusterQueueProperties",
+		          "type": "object"
+		        }
+		      },
+		      "title": "TaskclusterProperties",
 		      "type": "object"
 		    },
 		    "workerGroup": {

--- a/config/global-config.yml
+++ b/config/global-config.yml
@@ -9,6 +9,20 @@ properties:
     title: "PollingInterval"
     description: "The amount of time to wait between task polling iterations"
     type: "integer"
+  taskcluster:
+    title: TaskclusterProperties
+    description: Properties related to the TaskCluster Platform
+    type: object
+    properties:
+      queue:
+        title: TaskclusterQueueProperties
+        description: Properties defining interaction with the TaskCluster queue
+        type: object
+        properties:
+          url:
+            title: BaseUrl
+            description: Base URL for TaskCluster queue
+            type: string
   credentials:
     title:          Credentials
     description: |-

--- a/engines/enginetest/testutils.go
+++ b/engines/enginetest/testutils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/engines/extpoints"
 	"github.com/taskcluster/taskcluster-worker/runtime"
@@ -78,7 +79,7 @@ func (p *EngineProvider) ensureEngine() {
 }
 
 func (p *EngineProvider) newTestTaskContext() (*runtime.TaskContext, *runtime.TaskContextController) {
-	ctx, control, err := runtime.NewTaskContext(p.environment.TemporaryStorage.NewFilePath())
+	ctx, control, err := runtime.NewTaskContext(p.environment.TemporaryStorage.NewFilePath(), &queue.TaskClaimResponse{})
 	nilOrPanic(err, "Failed to create new TaskContext")
 	return ctx, control
 }

--- a/engines/enginetest/testutils.go
+++ b/engines/enginetest/testutils.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/engines/extpoints"
 	"github.com/taskcluster/taskcluster-worker/runtime"
@@ -79,7 +78,7 @@ func (p *EngineProvider) ensureEngine() {
 }
 
 func (p *EngineProvider) newTestTaskContext() (*runtime.TaskContext, *runtime.TaskContextController) {
-	ctx, control, err := runtime.NewTaskContext(p.environment.TemporaryStorage.NewFilePath(), &queue.TaskClaimResponse{})
+	ctx, control, err := runtime.NewTaskContext(p.environment.TemporaryStorage.NewFilePath(), runtime.TaskInfo{})
 	nilOrPanic(err, "Failed to create new TaskContext")
 	return ctx, control
 }

--- a/plugins/plugintest/plugintest.go
+++ b/plugins/plugintest/plugintest.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	rt "runtime"
 
+	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/engines/extpoints"
 	// Ensure we load the mock engine
@@ -69,7 +70,7 @@ func (c Case) Test() {
 		Log:         runtimeEnvironment.Log.WithField("engine", "mock"),
 		// TODO: Add engine config
 	})
-	context, controller, err := runtime.NewTaskContext(runtimeEnvironment.TemporaryStorage.NewFilePath())
+	context, controller, err := runtime.NewTaskContext(runtimeEnvironment.TemporaryStorage.NewFilePath(), &queue.TaskClaimResponse{})
 	sandboxBuilder, err := engine.NewSandboxBuilder(engines.SandboxOptions{
 		TaskContext: context,
 		Payload:     parseEnginePayload(engine, c.Payload),

--- a/plugins/plugintest/plugintest.go
+++ b/plugins/plugintest/plugintest.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	rt "runtime"
 
-	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/engines/extpoints"
 	// Ensure we load the mock engine
@@ -70,7 +69,7 @@ func (c Case) Test() {
 		Log:         runtimeEnvironment.Log.WithField("engine", "mock"),
 		// TODO: Add engine config
 	})
-	context, controller, err := runtime.NewTaskContext(runtimeEnvironment.TemporaryStorage.NewFilePath(), &queue.TaskClaimResponse{})
+	context, controller, err := runtime.NewTaskContext(runtimeEnvironment.TemporaryStorage.NewFilePath(), runtime.TaskInfo{})
 	sandboxBuilder, err := engine.NewSandboxBuilder(engines.SandboxOptions{
 		TaskContext: context,
 		Payload:     parseEnginePayload(engine, c.Payload),

--- a/runtime/client/queue.go
+++ b/runtime/client/queue.go
@@ -1,4 +1,4 @@
-package runtime
+package client
 
 import (
 	"github.com/stretchr/testify/mock"
@@ -6,10 +6,10 @@ import (
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
-// QueueClient is an interface to the Queue client provided by the
+// Queue is an interface to the Queue client provided by the
 // taskcluster-client-go package.  Passing around an interface allows the
 // queue client to be mocked
-type QueueClient interface {
+type Queue interface {
 	ReportCompleted(string, string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
 	ReportException(string, string, *queue.TaskExceptionRequest) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
 	ReportFailed(string, string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)

--- a/runtime/queue.go
+++ b/runtime/queue.go
@@ -1,4 +1,4 @@
-package worker
+package runtime
 
 import (
 	"github.com/stretchr/testify/mock"
@@ -6,6 +6,25 @@ import (
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
+// QueueClient is an interface to the Queue client provided by the
+// taskcluster-client-go package.  Passing around an interface allows the
+// queue client to be mocked
+type QueueClient interface {
+	ReportCompleted(string, string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
+	ReportException(string, string, *queue.TaskExceptionRequest) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
+	ReportFailed(string, string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
+	ClaimTask(string, string, *queue.TaskClaimRequest) (*queue.TaskClaimResponse, *tcclient.CallSummary, error)
+	ReclaimTask(string, string) (*queue.TaskReclaimResponse, *tcclient.CallSummary, error)
+	PollTaskUrls(string, string) (*queue.PollTaskUrlsResponse, *tcclient.CallSummary, error)
+	CancelTask(string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
+}
+
+// MockQueue is a mocked TaskCluster queue client.  Calls to methods exposed by the queue
+// client will be recorded for assertion later and will respond with the data
+// that was specified during creation of the mocked object.
+//
+// For more information about each of these client methods, consult the
+// taskcluster-clieng-go/queue package
 type MockQueue struct {
 	mock.Mock
 }

--- a/runtime/taskcontext.go
+++ b/runtime/taskcontext.go
@@ -101,22 +101,22 @@ func (c *TaskContextController) Dispose() error {
 	return c.logStream.Remove()
 }
 
-// GetQueueClient will return a client for the TaskCluster Queue.  This client
-// is useful for plugins that require interactions with the queue, such as creating
-// artifacts.
-func (c *TaskContext) GetQueueClient() QueueClient {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.queue
-}
-
-// CreateQueueClient will create a client for the TaskCluster Queue.  This client
+// SetQueueClient will set a client for the TaskCluster Queue.  This client
 // can then be used by others that have access to the task context and require
 // interaction with the queue.
-func (c *TaskContext) SetQueueClient(client QueueClient) {
+func (c *TaskContextController) SetQueueClient(client QueueClient) {
 	c.mu.Lock()
 	c.queue = client
 	c.mu.Unlock()
+}
+
+// Queue will return a client for the TaskCluster Queue.  This client
+// is useful for plugins that require interactions with the queue, such as creating
+// artifacts.
+func (c *TaskContext) Queue() QueueClient {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.queue
 }
 
 // Abort sets the status to aborted

--- a/runtime/taskcontext_test.go
+++ b/runtime/taskcontext_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/taskcluster/slugid-go/slugid"
+	"github.com/taskcluster/taskcluster-client-go/queue"
 )
 
 func nilOrPanic(err error, a ...interface{}) {
@@ -21,7 +22,7 @@ func nilOrPanic(err error, a ...interface{}) {
 func TestTaskContextLogging(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(os.TempDir(), slugid.V4())
-	context, control, err := NewTaskContext(path)
+	context, control, err := NewTaskContext(path, &queue.TaskClaimResponse{})
 	nilOrPanic(err, "Failed to create context")
 
 	context.Log("Hello World")
@@ -44,7 +45,7 @@ func TestTaskContextLogging(t *testing.T) {
 func TestTaskContextConcurrentLogging(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(os.TempDir(), slugid.V4())
-	context, control, err := NewTaskContext(path)
+	context, control, err := NewTaskContext(path, &queue.TaskClaimResponse{})
 	nilOrPanic(err, "Failed to create context")
 
 	wg := sync.WaitGroup{}

--- a/runtime/taskcontext_test.go
+++ b/runtime/taskcontext_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/taskcluster/slugid-go/slugid"
-	"github.com/taskcluster/taskcluster-client-go/queue"
 )
 
 func nilOrPanic(err error, a ...interface{}) {
@@ -22,7 +21,7 @@ func nilOrPanic(err error, a ...interface{}) {
 func TestTaskContextLogging(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(os.TempDir(), slugid.V4())
-	context, control, err := NewTaskContext(path, &queue.TaskClaimResponse{})
+	context, control, err := NewTaskContext(path, TaskInfo{})
 	nilOrPanic(err, "Failed to create context")
 
 	context.Log("Hello World")
@@ -45,7 +44,7 @@ func TestTaskContextLogging(t *testing.T) {
 func TestTaskContextConcurrentLogging(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(os.TempDir(), slugid.V4())
-	context, control, err := NewTaskContext(path, &queue.TaskClaimResponse{})
+	context, control, err := NewTaskContext(path, TaskInfo{})
 	nilOrPanic(err, "Failed to create context")
 
 	wg := sync.WaitGroup{}

--- a/worker/queueservice.go
+++ b/worker/queueservice.go
@@ -16,8 +16,8 @@ import (
 
 	logrus "github.com/Sirupsen/logrus"
 	"github.com/taskcluster/httpbackoff"
-	tcqueue "github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
 )
 
@@ -51,21 +51,6 @@ type (
 		signedDeleteURL string
 	}
 
-	// TaskclusterQueue is an interface to the Queue client provided by the
-	// taskcluster-client-go package.  Passing around an interface allows the
-	// queue client to be mocked
-	// TODO (garndt): move out of the worker package to something more
-	// appropriate like the task context or runtime.
-	queueClient interface {
-		ReportCompleted(string, string) (*tcqueue.TaskStatusResponse, *tcclient.CallSummary, error)
-		ReportException(string, string, *tcqueue.TaskExceptionRequest) (*tcqueue.TaskStatusResponse, *tcclient.CallSummary, error)
-		ReportFailed(string, string) (*tcqueue.TaskStatusResponse, *tcclient.CallSummary, error)
-		ClaimTask(string, string, *tcqueue.TaskClaimRequest) (*tcqueue.TaskClaimResponse, *tcclient.CallSummary, error)
-		ReclaimTask(string, string) (*tcqueue.TaskReclaimResponse, *tcclient.CallSummary, error)
-		PollTaskUrls(string, string) (*tcqueue.PollTaskUrlsResponse, *tcclient.CallSummary, error)
-		CancelTask(string) (*tcqueue.TaskStatusResponse, *tcclient.CallSummary, error)
-	}
-
 	// QueueService is an interface describing the methods responsible for claiming
 	// work from Azure queues.
 	QueueService interface {
@@ -82,7 +67,7 @@ type (
 		queues           []messageQueue
 		expires          tcclient.Time
 		expirationOffset int
-		client           queueClient
+		client           runtime.QueueClient
 		provisionerID    string
 		workerType       string
 		workerID         string

--- a/worker/queueservice.go
+++ b/worker/queueservice.go
@@ -17,8 +17,8 @@ import (
 	logrus "github.com/Sirupsen/logrus"
 	"github.com/taskcluster/httpbackoff"
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
-	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
 )
 
 type (
@@ -67,7 +67,7 @@ type (
 		queues           []messageQueue
 		expires          tcclient.Time
 		expirationOffset int
-		client           runtime.QueueClient
+		client           client.Queue
 		provisionerID    string
 		workerType       string
 		workerID         string

--- a/worker/queueservice_test.go
+++ b/worker/queueservice_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
 	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
 )
 
 const ProvisionerID = "dummy-provisioner"
@@ -24,7 +25,7 @@ var WorkerID = fmt.Sprintf("dummy-worker-%s", slugid.Nice())
 
 func TestRetrievePollTaskUrls(t *testing.T) {
 	logger, _ := runtime.CreateLogger("")
-	mockedQueue := &runtime.MockQueue{}
+	mockedQueue := &client.MockQueue{}
 	service := queueService{
 		client:           mockedQueue,
 		provisionerID:    ProvisionerID,
@@ -67,7 +68,7 @@ func TestRetrievePollTaskUrls(t *testing.T) {
 
 func TestRetrievePollTaskUrlsErrorCaught(t *testing.T) {
 	logger, _ := runtime.CreateLogger("")
-	mockedQueue := &runtime.MockQueue{}
+	mockedQueue := &client.MockQueue{}
 	service := queueService{
 		client:           mockedQueue,
 		provisionerID:    ProvisionerID,
@@ -564,7 +565,7 @@ func TestClaimTask(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(handler))
 	defer s.Close()
 
-	mockedQueue := &runtime.MockQueue{}
+	mockedQueue := &client.MockQueue{}
 	mockedQueue.On(
 		"ClaimTask",
 		"abc",
@@ -631,7 +632,7 @@ func TestClaimTaskError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(handler))
 	defer s.Close()
 
-	mockedQueue := &runtime.MockQueue{}
+	mockedQueue := &client.MockQueue{}
 	mockedQueue.On(
 		"ClaimTask",
 		"abc",
@@ -675,7 +676,7 @@ func TestClaimTasks(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(handler))
 	defer s.Close()
 
-	mockedQueue := &runtime.MockQueue{}
+	mockedQueue := &client.MockQueue{}
 	mockedQueue.On(
 		"ClaimTask",
 		"abc",

--- a/worker/queueservice_test.go
+++ b/worker/queueservice_test.go
@@ -24,7 +24,7 @@ var WorkerID = fmt.Sprintf("dummy-worker-%s", slugid.Nice())
 
 func TestRetrievePollTaskUrls(t *testing.T) {
 	logger, _ := runtime.CreateLogger("")
-	mockedQueue := &MockQueue{}
+	mockedQueue := &runtime.MockQueue{}
 	service := queueService{
 		client:           mockedQueue,
 		provisionerID:    ProvisionerID,
@@ -67,7 +67,7 @@ func TestRetrievePollTaskUrls(t *testing.T) {
 
 func TestRetrievePollTaskUrlsErrorCaught(t *testing.T) {
 	logger, _ := runtime.CreateLogger("")
-	mockedQueue := &MockQueue{}
+	mockedQueue := &runtime.MockQueue{}
 	service := queueService{
 		client:           mockedQueue,
 		provisionerID:    ProvisionerID,
@@ -564,7 +564,7 @@ func TestClaimTask(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(handler))
 	defer s.Close()
 
-	mockedQueue := &MockQueue{}
+	mockedQueue := &runtime.MockQueue{}
 	mockedQueue.On(
 		"ClaimTask",
 		"abc",
@@ -631,7 +631,7 @@ func TestClaimTaskError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(handler))
 	defer s.Close()
 
-	mockedQueue := &MockQueue{}
+	mockedQueue := &runtime.MockQueue{}
 	mockedQueue.On(
 		"ClaimTask",
 		"abc",
@@ -675,7 +675,7 @@ func TestClaimTasks(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(handler))
 	defer s.Close()
 
-	mockedQueue := &MockQueue{}
+	mockedQueue := &runtime.MockQueue{}
 	mockedQueue.On(
 		"ClaimTask",
 		"abc",

--- a/worker/task.go
+++ b/worker/task.go
@@ -47,7 +47,11 @@ func NewTaskRun(
 ) (*TaskRun, error) {
 
 	tp := environment.TemporaryStorage.NewFilePath()
-	ctxt, ctxtctl, err := runtime.NewTaskContext(tp, claim.taskClaim)
+	info := runtime.TaskInfo{
+		TaskID: claim.taskClaim.Status.TaskID,
+		RunID:  claim.taskClaim.RunID,
+	}
+	ctxt, ctxtctl, err := runtime.NewTaskContext(tp, info)
 
 	queueClient := queue.New(&tcclient.Credentials{
 		ClientId:    claim.taskClaim.Credentials.ClientID,

--- a/worker/task.go
+++ b/worker/task.go
@@ -57,7 +57,7 @@ func NewTaskRun(
 
 	queueClient.BaseURL = config.Taskcluster.Queue.URL
 
-	ctxt.SetQueueClient(queueClient)
+	ctxtctl.SetQueueClient(queueClient)
 
 	if err != nil {
 		return nil, err
@@ -323,7 +323,7 @@ func (t *TaskRun) exceptionStage(taskError error) {
 		return
 	}
 
-	e := reportException(t.context.GetQueueClient(), t, reason, t.log)
+	e := reportException(t.context.Queue(), t, reason, t.log)
 	if e != nil {
 		t.log.WithField("error", e.Error()).Warn("Could not resolve task as exception.")
 	}
@@ -339,7 +339,7 @@ func (t *TaskRun) resolveTask() error {
 		resolve = reportFailed
 	}
 
-	err := resolve(t.context.GetQueueClient(), t, t.log)
+	err := resolve(t.context.Queue(), t, t.log)
 	if err != nil {
 		return errors.New(err.Error())
 	}

--- a/worker/task_test.go
+++ b/worker/task_test.go
@@ -186,7 +186,7 @@ func TestRunTask(t *testing.T) {
 		"1",
 	).Return(&queue.TaskStatusResponse{}, &tcclient.CallSummary{}, nil)
 
-	tr.context.SetQueueClient(mockedQueue)
+	tr.controller.SetQueueClient(mockedQueue)
 
 	tr.Run()
 	mockedQueue.AssertCalled(t, "ReportCompleted", "abc", "1")
@@ -209,7 +209,7 @@ func TestRunMalformedEnginePayloadTask(t *testing.T) {
 		&queue.TaskExceptionRequest{Reason: "malformed-payload"},
 	).Return(&queue.TaskStatusResponse{}, &tcclient.CallSummary{}, nil)
 
-	tr.context.SetQueueClient(mockedQueue)
+	tr.controller.SetQueueClient(mockedQueue)
 
 	tr.Run()
 	mockedQueue.AssertCalled(t, "ReportException", "abc", "1", &queue.TaskExceptionRequest{Reason: "malformed-payload"})

--- a/worker/task_test.go
+++ b/worker/task_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	pluginExtpoints "github.com/taskcluster/taskcluster-worker/plugins/extpoints"
 	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
 )
 
 var logger, _ = runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
@@ -127,7 +128,11 @@ func TestParsePayload(t *testing.T) {
 	}
 
 	tp := environment.TemporaryStorage.NewFilePath()
-	tr.context, tr.controller, err = runtime.NewTaskContext(tp, claim.taskClaim)
+	info := runtime.TaskInfo{
+		TaskID: claim.taskClaim.Status.TaskID,
+		RunID:  claim.taskClaim.RunID,
+	}
+	tr.context, tr.controller, err = runtime.NewTaskContext(tp, info)
 	defer func() {
 		tr.controller.CloseLog()
 		tr.controller.Dispose()
@@ -179,7 +184,7 @@ func TestRunTask(t *testing.T) {
 	tr, err := NewTaskRun(&config.Config{}, claim, environment, engine, pluginManager, logger.WithField("test", "TestRunTask"))
 	assert.Nil(t, err)
 
-	mockedQueue := &runtime.MockQueue{}
+	mockedQueue := &client.MockQueue{}
 	mockedQueue.On(
 		"ReportCompleted",
 		"abc",
@@ -201,7 +206,7 @@ func TestRunMalformedEnginePayloadTask(t *testing.T) {
 	tr, err := NewTaskRun(&config.Config{}, claim, environment, engine, pluginManager, logger.WithField("test", "TestRunTask"))
 	assert.Nil(t, err)
 
-	mockedQueue := &runtime.MockQueue{}
+	mockedQueue := &client.MockQueue{}
 	mockedQueue.On(
 		"ReportException",
 		"abc",

--- a/worker/taskstatusupdate.go
+++ b/worker/taskstatusupdate.go
@@ -4,8 +4,7 @@ import (
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
-	tcqueue "github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 )
 
@@ -19,15 +18,14 @@ func (e updateError) Error() string {
 }
 
 type taskClaim struct {
-	taskID      string
-	runID       uint
-	taskClaim   tcqueue.TaskClaimResponse
-	definition  tcqueue.TaskDefinitionResponse
-	queueClient queueClient
+	taskID     string
+	runID      uint
+	taskClaim  *queue.TaskClaimResponse
+	definition *queue.TaskDefinitionResponse
 }
 
-func reportException(client queueClient, task *TaskRun, reason runtime.ExceptionReason, log *logrus.Entry) *updateError {
-	payload := tcqueue.TaskExceptionRequest{Reason: string(reason)}
+func reportException(client runtime.QueueClient, task *TaskRun, reason runtime.ExceptionReason, log *logrus.Entry) *updateError {
+	payload := queue.TaskExceptionRequest{Reason: string(reason)}
 	_, _, err := client.ReportException(task.TaskID, strconv.FormatInt(int64(task.RunID), 10), &payload)
 	if err != nil {
 		log.WithField("error", err).Warn("Not able to report exception for task")
@@ -36,7 +34,7 @@ func reportException(client queueClient, task *TaskRun, reason runtime.Exception
 	return nil
 }
 
-func reportFailed(client queueClient, task *TaskRun, log *logrus.Entry) *updateError {
+func reportFailed(client runtime.QueueClient, task *TaskRun, log *logrus.Entry) *updateError {
 	_, _, err := client.ReportFailed(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
 	if err != nil {
 		log.WithField("error", err).Warn("Not able to report failed completion for task.")
@@ -45,7 +43,7 @@ func reportFailed(client queueClient, task *TaskRun, log *logrus.Entry) *updateE
 	return nil
 }
 
-func reportCompleted(client queueClient, task *TaskRun, log *logrus.Entry) *updateError {
+func reportCompleted(client runtime.QueueClient, task *TaskRun, log *logrus.Entry) *updateError {
 	_, _, err := client.ReportCompleted(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
 	if err != nil {
 		log.WithField("error", err).Warn("Not able to report successful completion for task.")
@@ -54,9 +52,9 @@ func reportCompleted(client queueClient, task *TaskRun, log *logrus.Entry) *upda
 	return nil
 }
 
-func claimTask(client queueClient, taskID string, runID uint, workerID string, workerGroup string, log *logrus.Entry) (*taskClaim, *updateError) {
+func claimTask(client runtime.QueueClient, taskID string, runID uint, workerID string, workerGroup string, log *logrus.Entry) (*taskClaim, *updateError) {
 	log.Info("Claiming task")
-	payload := tcqueue.TaskClaimRequest{
+	payload := queue.TaskClaimRequest{
 		WorkerGroup: workerGroup,
 		WorkerID:    workerID,
 	}
@@ -85,31 +83,22 @@ func claimTask(client queueClient, taskID string, runID uint, workerID string, w
 	}
 
 	return &taskClaim{
-		taskID: taskID,
-		runID:  runID,
-		// TODO (garndt): replace with client retrieved from the task context.
-		queueClient: tcqueue.New(
-			&tcclient.Credentials{
-				ClientId:    tcrsp.Credentials.ClientID,
-				AccessToken: tcrsp.Credentials.AccessToken,
-				Certificate: tcrsp.Credentials.Certificate,
-			},
-		),
-		taskClaim:  *tcrsp,
-		definition: tcrsp.Task,
+		taskID:     taskID,
+		runID:      runID,
+		taskClaim:  tcrsp,
+		definition: &tcrsp.Task,
 	}, nil
 }
 
-func reclaimTask(client queueClient, task *TaskRun, log *logrus.Entry) *updateError {
+func reclaimTask(client runtime.QueueClient, task *TaskRun, log *logrus.Entry) (*queue.TaskReclaimResponse, *updateError) {
 	log.Info("Reclaiming task")
 	tcrsp, _, err := client.ReclaimTask(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
 
 	// check if an error occurred...
 	if err != nil {
-		return &updateError{err: err.Error()}
+		return nil, &updateError{err: err.Error()}
 	}
 
-	task.taskReclaim = *tcrsp
 	log.Info("Reclaimed task successfully")
-	return nil
+	return tcrsp, nil
 }


### PR DESCRIPTION
This PR allows:
1. Task Context to have a queue client
2. Queue client can be updated safely by a claimer/reclaimer
3. Anything with the task context reference can get the queue client with the claims credentials
4. Base URL for the Queue can be defined in the config.  Right now this is mostly just for mocking out the queue endpoint for tests, but could be used when the queue does not live in the canonical place any longer.