### PR TITLE
Remove vet from travis setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - go get golang.org/x/tools/cmd/vet
   - go get github.com/pierrre/gotestcover
 
 install:


### PR DESCRIPTION
For some reason vet installation is failing on travis, but it is not
required anyway because go 1.5 already ships it.