### PR TITLE
Dump task logs to log entry.

### DIFF
--- a/runtime/taskcontext.go
+++ b/runtime/taskcontext.go
@@ -7,6 +7,7 @@ import (
 
 	"sync"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
 	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
@@ -63,6 +64,7 @@ type TaskInfo struct {
 // properties, and abortion notifications.
 type TaskContext struct {
 	TaskInfo
+	LogEntry   *logrus.Entry
 	webHookSet *webhookserver.WebHookSet
 	logStream  *stream.Stream
 	mu         sync.RWMutex
@@ -173,6 +175,10 @@ func (c *TaskContext) log(prefix string, a ...interface{}) {
 	_, err := fmt.Fprintln(c.logStream, a...)
 	if err != nil {
 		//TODO: Forward this to the system log, it's not a critical error
+	}
+
+	if c.LogEntry != nil {
+		c.LogEntry.Debug(a...)
 	}
 }
 

--- a/worker/task.go
+++ b/worker/task.go
@@ -55,6 +55,7 @@ func NewTaskRun(
 		Expires:  claim.taskClaim.Task.Expires,
 	}
 	ctxt, ctxtctl, err := runtime.NewTaskContext(tp, info)
+	ctxt.LogEntry = log
 
 	queueClient := queue.New(&tcclient.Credentials{
 		ClientId:    claim.taskClaim.Credentials.ClientID,


### PR DESCRIPTION
Task context writes log messages to a temporary file, this makes
difficulty to look at the logs when running the tasks locally.

TaskContext now write logs to logrus debug output besides temporary
files.