### PR TITLE
Removed CallSummary references...

### DIFF
--- a/plugins/artifacts/artifacts_test.go
+++ b/plugins/artifacts/artifacts_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 	"github.com/taskcluster/taskcluster-worker/plugins/plugintest"
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
 )
@@ -37,7 +36,7 @@ func (a artifactTestCase) Test() {
 			taskID,
 			"0",
 			path,
-		).Return(&resp, &tcclient.CallSummary{}, nil)
+		).Return(&resp, nil)
 	}
 
 	a.Case.QueueMock = mockedQueue

--- a/runtime/artifact.go
+++ b/runtime/artifact.go
@@ -124,7 +124,7 @@ func CreateRedirectArtifact(artifact RedirectArtifact, context *TaskContext) err
 
 func createArtifact(context *TaskContext, name string, req []byte) ([]byte, error) {
 	par := queue.PostArtifactRequest(req)
-	parsp, _, err := context.Queue().CreateArtifact(
+	parsp, err := context.Queue().CreateArtifact(
 		context.TaskID,
 		strconv.Itoa(context.RunID),
 		name,

--- a/runtime/artifact_test.go
+++ b/runtime/artifact_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
 	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
 )
@@ -31,7 +30,7 @@ func setupArtifactTest(name string, artifactResp queue.PostArtifactRequest) (*Ta
 		taskID,
 		"0",
 		name,
-	).Return(&resp, &tcclient.CallSummary{}, nil)
+	).Return(&resp, nil)
 	controller.SetQueueClient(mockedQueue)
 	return context, mockedQueue
 }

--- a/runtime/client/queue.go
+++ b/runtime/client/queue.go
@@ -3,21 +3,20 @@ package client
 import (
 	"github.com/stretchr/testify/mock"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 // Queue is an interface to the Queue client provided by the
 // taskcluster-client-go package.  Passing around an interface allows the
 // queue client to be mocked
 type Queue interface {
-	ReportCompleted(string, string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
-	ReportException(string, string, *queue.TaskExceptionRequest) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
-	ReportFailed(string, string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
-	ClaimTask(string, string, *queue.TaskClaimRequest) (*queue.TaskClaimResponse, *tcclient.CallSummary, error)
-	ReclaimTask(string, string) (*queue.TaskReclaimResponse, *tcclient.CallSummary, error)
-	PollTaskUrls(string, string) (*queue.PollTaskUrlsResponse, *tcclient.CallSummary, error)
-	CancelTask(string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error)
-	CreateArtifact(string, string, string, *queue.PostArtifactRequest) (*queue.PostArtifactResponse, *tcclient.CallSummary, error)
+	ReportCompleted(string, string) (*queue.TaskStatusResponse, error)
+	ReportException(string, string, *queue.TaskExceptionRequest) (*queue.TaskStatusResponse, error)
+	ReportFailed(string, string) (*queue.TaskStatusResponse, error)
+	ClaimTask(string, string, *queue.TaskClaimRequest) (*queue.TaskClaimResponse, error)
+	ReclaimTask(string, string) (*queue.TaskReclaimResponse, error)
+	PollTaskUrls(string, string) (*queue.PollTaskUrlsResponse, error)
+	CancelTask(string) (*queue.TaskStatusResponse, error)
+	CreateArtifact(string, string, string, *queue.PostArtifactRequest) (*queue.PostArtifactResponse, error)
 }
 
 // MockQueue is a mocked TaskCluster queue client.  Calls to methods exposed by the queue
@@ -30,38 +29,38 @@ type MockQueue struct {
 	mock.Mock
 }
 
-func (m *MockQueue) ReportCompleted(taskID, runID string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) ReportCompleted(taskID, runID string) (*queue.TaskStatusResponse, error) {
 	args := m.Called(taskID, runID)
-	return args.Get(0).(*queue.TaskStatusResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.TaskStatusResponse), args.Error(1)
 }
 
-func (m *MockQueue) ReclaimTask(taskID, runID string) (*queue.TaskReclaimResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) ReclaimTask(taskID, runID string) (*queue.TaskReclaimResponse, error) {
 	args := m.Called(taskID, runID)
-	return args.Get(0).(*queue.TaskReclaimResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.TaskReclaimResponse), args.Error(1)
 }
 
-func (m *MockQueue) PollTaskUrls(provisionerID, workerType string) (*queue.PollTaskUrlsResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) PollTaskUrls(provisionerID, workerType string) (*queue.PollTaskUrlsResponse, error) {
 	args := m.Called(provisionerID, workerType)
-	return args.Get(0).(*queue.PollTaskUrlsResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.PollTaskUrlsResponse), args.Error(1)
 }
-func (m *MockQueue) CancelTask(taskID string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) CancelTask(taskID string) (*queue.TaskStatusResponse, error) {
 	args := m.Called(taskID)
-	return args.Get(0).(*queue.TaskStatusResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.TaskStatusResponse), args.Error(1)
 }
-func (m *MockQueue) ClaimTask(taskID, runID string, payload *queue.TaskClaimRequest) (*queue.TaskClaimResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) ClaimTask(taskID, runID string, payload *queue.TaskClaimRequest) (*queue.TaskClaimResponse, error) {
 	args := m.Called(taskID, runID, payload)
-	return args.Get(0).(*queue.TaskClaimResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.TaskClaimResponse), args.Error(1)
 }
-func (m *MockQueue) ReportFailed(taskID, runID string) (*queue.TaskStatusResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) ReportFailed(taskID, runID string) (*queue.TaskStatusResponse, error) {
 	args := m.Called(taskID, runID)
-	return args.Get(0).(*queue.TaskStatusResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.TaskStatusResponse), args.Error(1)
 }
-func (m *MockQueue) ReportException(taskID, runID string, payload *queue.TaskExceptionRequest) (*queue.TaskStatusResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) ReportException(taskID, runID string, payload *queue.TaskExceptionRequest) (*queue.TaskStatusResponse, error) {
 	args := m.Called(taskID, runID, payload)
-	return args.Get(0).(*queue.TaskStatusResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.TaskStatusResponse), args.Error(1)
 }
 
-func (m *MockQueue) CreateArtifact(taskID, runID, name string, payload *queue.PostArtifactRequest) (*queue.PostArtifactResponse, *tcclient.CallSummary, error) {
+func (m *MockQueue) CreateArtifact(taskID, runID, name string, payload *queue.PostArtifactRequest) (*queue.PostArtifactResponse, error) {
 	args := m.Called(taskID, runID, name)
-	return args.Get(0).(*queue.PostArtifactResponse), args.Get(1).(*tcclient.CallSummary), args.Error(2)
+	return args.Get(0).(*queue.PostArtifactResponse), args.Error(1)
 }

--- a/worker/task.go
+++ b/worker/task.go
@@ -60,7 +60,7 @@ func NewTaskRun(
 	ctxt, ctxtctl, err := runtime.NewTaskContext(tp, info)
 
 	queueClient := queue.New(&tcclient.Credentials{
-		ClientId:    claim.taskClaim.Credentials.ClientID,
+		ClientID:    claim.taskClaim.Credentials.ClientID,
 		AccessToken: claim.taskClaim.Credentials.AccessToken,
 		Certificate: claim.taskClaim.Credentials.Certificate,
 	})
@@ -106,7 +106,7 @@ func (t *TaskRun) reclaim(until time.Time, done <-chan struct{}) {
 		}
 
 		queueClient := queue.New(&tcclient.Credentials{
-			ClientId:    claim.Credentials.ClientID,
+			ClientID:    claim.Credentials.ClientID,
 			AccessToken: claim.Credentials.AccessToken,
 			Certificate: claim.Credentials.Certificate,
 		})

--- a/worker/task_test.go
+++ b/worker/task_test.go
@@ -198,7 +198,7 @@ func TestRunTask(t *testing.T) {
 		"ReportCompleted",
 		"abc",
 		"1",
-	).Return(&queue.TaskStatusResponse{}, &tcclient.CallSummary{}, nil)
+	).Return(&queue.TaskStatusResponse{}, nil)
 
 	tr.controller.SetQueueClient(mockedQueue)
 
@@ -221,7 +221,7 @@ func TestRunMalformedEnginePayloadTask(t *testing.T) {
 		"abc",
 		"1",
 		&queue.TaskExceptionRequest{Reason: "malformed-payload"},
-	).Return(&queue.TaskStatusResponse{}, &tcclient.CallSummary{}, nil)
+	).Return(&queue.TaskStatusResponse{}, nil)
 
 	tr.controller.SetQueueClient(mockedQueue)
 

--- a/worker/taskmanager.go
+++ b/worker/taskmanager.go
@@ -40,7 +40,7 @@ type Manager struct {
 func newTaskManager(config *config.Config, engine engines.Engine, environment *runtime.Environment, log *logrus.Entry) (*Manager, error) {
 	queue := tcqueue.New(
 		&tcclient.Credentials{
-			ClientId:    config.Credentials.ClientID,
+			ClientID:    config.Credentials.ClientID,
 			AccessToken: config.Credentials.AccessToken,
 			Certificate: config.Credentials.Certificate,
 		},

--- a/worker/taskstatusupdate.go
+++ b/worker/taskstatusupdate.go
@@ -1,9 +1,11 @@
 package worker
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/taskcluster/httpbackoff"
 	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
@@ -27,7 +29,7 @@ type taskClaim struct {
 
 func reportException(client client.Queue, task *TaskRun, reason runtime.ExceptionReason, log *logrus.Entry) *updateError {
 	payload := queue.TaskExceptionRequest{Reason: string(reason)}
-	_, _, err := client.ReportException(task.TaskID, strconv.FormatInt(int64(task.RunID), 10), &payload)
+	_, err := client.ReportException(task.TaskID, strconv.FormatInt(int64(task.RunID), 10), &payload)
 	if err != nil {
 		log.WithField("error", err).Warn("Not able to report exception for task")
 		return &updateError{err: err.Error()}
@@ -36,7 +38,7 @@ func reportException(client client.Queue, task *TaskRun, reason runtime.Exceptio
 }
 
 func reportFailed(client client.Queue, task *TaskRun, log *logrus.Entry) *updateError {
-	_, _, err := client.ReportFailed(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
+	_, err := client.ReportFailed(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
 	if err != nil {
 		log.WithField("error", err).Warn("Not able to report failed completion for task.")
 		return &updateError{err: err.Error()}
@@ -45,7 +47,7 @@ func reportFailed(client client.Queue, task *TaskRun, log *logrus.Entry) *update
 }
 
 func reportCompleted(client client.Queue, task *TaskRun, log *logrus.Entry) *updateError {
-	_, _, err := client.ReportCompleted(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
+	_, err := client.ReportCompleted(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
 	if err != nil {
 		log.WithField("error", err).Warn("Not able to report successful completion for task.")
 		return &updateError{err: err.Error()}
@@ -53,34 +55,43 @@ func reportCompleted(client client.Queue, task *TaskRun, log *logrus.Entry) *upd
 	return nil
 }
 
-func claimTask(client client.Queue, taskID string, runID int, workerID string, workerGroup string, log *logrus.Entry) (*taskClaim, *updateError) {
+func claimTask(client client.Queue, taskID string, runID int, workerID string, workerGroup string, log *logrus.Entry) (*taskClaim, error) {
 	log.Info("Claiming task")
 	payload := queue.TaskClaimRequest{
 		WorkerGroup: workerGroup,
 		WorkerID:    workerID,
 	}
 
-	tcrsp, callSummary, err := client.ClaimTask(taskID, strconv.FormatInt(int64(runID), 10), &payload)
+	tcrsp, err := client.ClaimTask(taskID, strconv.FormatInt(int64(runID), 10), &payload)
 	// check if an error occurred...
 	if err != nil {
-		e := &updateError{
-			err:        err.Error(),
-			statusCode: callSummary.HttpResponse.StatusCode,
-		}
-		var errorMessage string
-		switch {
-		case callSummary.HttpResponse.StatusCode == 401 || callSummary.HttpResponse.StatusCode == 403:
-			errorMessage = "Not authorized to claim task."
-		case callSummary.HttpResponse.StatusCode >= 500:
-			errorMessage = "Server error when attempting to claim task."
+		switch err := err.(type) {
+		case httpbackoff.BadHttpResponseCode:
+			e := &updateError{
+				err:        err.Error(),
+				statusCode: err.HttpResponseCode,
+			}
+			var errorMessage string
+			switch {
+			case err.HttpResponseCode == 401 || err.HttpResponseCode == 403:
+				errorMessage = fmt.Sprintf("Not authorized to claim task %s (status code %v).", taskID, err.HttpResponseCode)
+			case err.HttpResponseCode >= 500:
+				errorMessage = fmt.Sprintf("Server error (status code %v) when attempting to claim task %v.", err.HttpResponseCode, taskID)
+			case err.HttpResponseCode != 200:
+				errorMessage = fmt.Sprintf("Received http status code %v when claiming task %v.", err.HttpResponseCode, taskID)
+			}
+			log.WithFields(logrus.Fields{
+				"error":      err,
+				"statusCode": err.HttpResponseCode,
+			}).Error(errorMessage)
+			return nil, e
+
 		default:
-			errorMessage = "Received an error with a status code other than 401/403/500."
+			log.WithFields(logrus.Fields{
+				"error": err,
+			}).Error(fmt.Sprintf("Unexpected error occurred when claiming task %s", taskID))
+			return nil, err
 		}
-		log.WithFields(logrus.Fields{
-			"error":      err,
-			"statusCode": callSummary.HttpResponse.StatusCode,
-		}).Error(errorMessage)
-		return nil, e
 	}
 
 	return &taskClaim{
@@ -93,7 +104,7 @@ func claimTask(client client.Queue, taskID string, runID int, workerID string, w
 
 func reclaimTask(client client.Queue, taskID string, runID int, log *logrus.Entry) (*queue.TaskReclaimResponse, *updateError) {
 	log.Info("Reclaiming task")
-	tcrsp, _, err := client.ReclaimTask(taskID, strconv.FormatInt(int64(runID), 10))
+	tcrsp, err := client.ReclaimTask(taskID, strconv.FormatInt(int64(runID), 10))
 
 	// check if an error occurred...
 	if err != nil {


### PR DESCRIPTION
@walac @jonasfj @gregarndt 

Jonas asked me to remove CallSummary from generated methods of `taskcluster-client-go`. This PR is to adapt to the upstream changes.

You'll need to run `go get -u -t ./...` to pick up the upstream changes, after this PR gets merged.