### PR TITLE
Return early after task reclaiming failed. r=garndt

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -103,6 +103,7 @@ func (t *TaskRun) reclaim(until time.Time, done <-chan struct{}) {
 		if err != nil {
 			t.log.WithError(err).Error("Error reclaiming task")
 			t.Abort()
+			return
 		}
 
 		queueClient := queue.New(&tcclient.Credentials{


### PR DESCRIPTION
If reclaim failed, claim object will be nil, and any tempt to use it
will panic. Therefore, we return when task reclaim fails.