### PR TITLE
Run tasks with their own user context.

### DIFF
--- a/engines/osxnative/dscl.go
+++ b/engines/osxnative/dscl.go
@@ -1,0 +1,64 @@
+package osxnative
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type dscl struct {
+}
+
+// run will exectue a dscl command using the provided arguments
+// returning the output of the command as a string.
+func (d dscl) run(command string, a ...string) (string, error) {
+	args := []string{".", command}
+	args = append(args, a...)
+	cmd := exec.Command("dscl", args...)
+	cmd.Env = os.Environ()
+	output, err := cmd.Output()
+	return string(output), err
+}
+
+func (d dscl) list(a ...string) ([][]string, error) {
+	output, err := d.run("list", a...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	ret := [][]string{}
+	for _, s := range strings.Split(output, "\n") {
+		fields := strings.Fields(s)
+		if len(fields) != 0 {
+			ret = append(ret, strings.Fields(s))
+		}
+	}
+
+	return ret, nil
+}
+
+func (d dscl) read(a ...string) (string, error) {
+	s, err := d.run("read", a...)
+
+	if err != nil {
+		return s, err
+	}
+
+	return strings.Fields(s)[1], nil
+}
+
+func (d dscl) create(a ...string) error {
+	_, err := d.run("create", a...)
+	return err
+}
+
+func (d dscl) append(a ...string) error {
+	_, err := d.run("append", a...)
+	return err
+}
+
+func (d dscl) delete(a ...string) error {
+	_, err := d.run("delete", a...)
+	return err
+}

--- a/engines/osxnative/dscl.go
+++ b/engines/osxnative/dscl.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (

--- a/engines/osxnative/engine.go
+++ b/engines/osxnative/engine.go
@@ -50,5 +50,6 @@ func (e engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.Sandb
 		taskPayload:        taskPayload,
 		context:            options.TaskContext,
 		envMutex:           &m,
+		engine:             &e,
 	}, nil
 }

--- a/engines/osxnative/engine.go
+++ b/engines/osxnative/engine.go
@@ -1,3 +1,4 @@
+// +build darwin
 //go:generate go-composite-schema --unexported --required engine payload-schema.yml generated_payloadschema.go
 
 // Package osxnative implements the Mac OSX engine

--- a/engines/osxnative/httpserver.go
+++ b/engines/osxnative/httpserver.go
@@ -39,7 +39,7 @@ func (s *httpServer) url() string {
 	return s.testServer.URL
 }
 
-func newHttpServer() *httpServer {
+func newHTTPServer() *httpServer {
 	m := make(map[string]string)
 	return &httpServer{
 		testServer: httptest.NewServer(handler{&m}),

--- a/engines/osxnative/httpserver.go
+++ b/engines/osxnative/httpserver.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (

--- a/engines/osxnative/resultset.go
+++ b/engines/osxnative/resultset.go
@@ -5,40 +5,30 @@ import (
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strings"
 )
 
 type resultset struct {
 	engines.ResultSetBase
-	context *runtime.TaskContext
-	success bool
+	taskUser user
+	context  *runtime.TaskContext
+	success  bool
+	engine   *engine
 }
 
 var pathMatcher *regexp.Regexp
 
-func init() {
-	home := os.Getenv("HOME")
-	if strings.HasPrefix(home, "/") {
-		// remove trailing "/"
-		home = home[:len(home)]
-	}
-
-	pathMatcher = regexp.MustCompile("^(" + home + "|/tmp)(/.*)?$")
-}
-
-func newResultSet(context *runtime.TaskContext, success bool) resultset {
-	return resultset{
-		ResultSetBase: engines.ResultSetBase{},
-		context:       context,
-		success:       success,
-	}
-}
-
 // Check if the path is valid. The only valid paths are those
 // inside user's home directory and in /tmp/
-func (r resultset) validPath(pathName string) bool {
+func (r resultset) validPath(home string, pathName string) bool {
+	pathMatcher = regexp.MustCompile("^(" + home + "|/tmp)(/.*)?$")
+
+	if !filepath.IsAbs(pathName) {
+		pathName = filepath.Join(home, pathName)
+	}
+
 	absPath, err := filepath.Abs(pathName)
 
 	if err != nil {
@@ -56,8 +46,13 @@ func (r resultset) Success() bool {
 }
 
 func (r resultset) ExtractFile(path string) (ioext.ReadSeekCloser, error) {
-	if !r.validPath(path) {
+	cwd := getWorkingDir(r.taskUser, r.context)
+	if !r.validPath(cwd, path) {
 		return nil, engines.NewMalformedPayloadError(path + " is invalid")
+	}
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cwd, path)
 	}
 
 	file, err := os.Open(path)
@@ -71,8 +66,13 @@ func (r resultset) ExtractFile(path string) (ioext.ReadSeekCloser, error) {
 }
 
 func (r resultset) ExtractFolder(path string, handler engines.FileHandler) error {
-	if !r.validPath(path) {
+	cwd := getWorkingDir(r.taskUser, r.context)
+	if !r.validPath(cwd, path) {
 		return engines.NewMalformedPayloadError(path + " is invalid")
+	}
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cwd, path)
 	}
 
 	return filepath.Walk(path, func(p string, info os.FileInfo, e error) error {
@@ -96,4 +96,19 @@ func (r resultset) ExtractFolder(path string, handler engines.FileHandler) error
 
 		return nil
 	})
+}
+
+func (r resultset) Dispose() error {
+	err := r.taskUser.delete()
+	if err != nil {
+		r.engine.log.WithField("user", r.taskUser.name).WithError(err).Error("Error removing user")
+		exitError, ok := err.(*exec.ExitError)
+		if ok {
+			r.engine.log.Error(string(exitError.Stderr))
+		}
+
+		return engines.ErrNonFatalInternalError
+	}
+
+	return nil
 }

--- a/engines/osxnative/resultset.go
+++ b/engines/osxnative/resultset.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (

--- a/engines/osxnative/sandbox.go
+++ b/engines/osxnative/sandbox.go
@@ -8,6 +8,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	osuser "os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 )
 
 // white list of environment variables that must
@@ -15,8 +20,6 @@ import (
 var environmentWhitelist = []string{
 	"PATH",
 	"HOME",
-	"USER",
-	"SHELL",
 	"TMPDIR",
 	"PWD",
 	"EDITOR",
@@ -55,18 +58,20 @@ type sandbox struct {
 	taskPayload *payload
 	env         []string
 	aborted     bool
+	engine      *engine
 }
 
-func newSandbox(context *runtime.TaskContext, taskPayload *payload, env []string) *sandbox {
+func newSandbox(context *runtime.TaskContext, taskPayload *payload, env []string, engine *engine) *sandbox {
 	return &sandbox{
 		context:     context,
 		taskPayload: taskPayload,
 		env:         env,
 		aborted:     false,
+		engine:      engine,
 	}
 }
 
-func downloadLink(link string) (string, error) {
+func downloadLink(destdir string, link string) (string, error) {
 	resp, err := http.Get(link)
 
 	if err != nil {
@@ -78,11 +83,14 @@ func downloadLink(link string) (string, error) {
 	contentDisposition := resp.Header.Get("Content-Disposition")
 	_, params, err := mime.ParseMediaType(contentDisposition)
 
-	if err != nil {
-		return "", err
+	var filename string
+	if err == nil {
+		filename = params["filename"]
+	} else {
+		filename = filepath.Base(link)
 	}
 
-	filename := params["filename"]
+	filename = filepath.Join(destdir, filename)
 	file, err := os.Create(filename)
 
 	if err != nil {
@@ -104,23 +112,7 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 		return nil, engines.ErrSandboxAborted
 	}
 
-	if s.taskPayload.Link != "" {
-		filename, err := downloadLink(s.taskPayload.Link)
-
-		if err != nil {
-			s.context.LogError(err)
-			return nil, engines.ErrNonFatalInternalError
-		}
-
-		defer os.Remove(filename)
-
-		err = os.Chmod(filename, 0777)
-
-		if err != nil {
-			s.context.LogError(err)
-			return nil, engines.ErrNonFatalInternalError
-		}
-	}
+	var err error
 
 	env := make([]string, len(s.env), len(s.env)+len(environmentWhitelist))
 	copy(env, s.env)
@@ -136,21 +128,106 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 	cmd := exec.Command(s.taskPayload.Command[0], s.taskPayload.Command[1:]...)
 	cmd.Stdout = stdoutLogWriter{s.context}
 	cmd.Stderr = stderrLogWriter{s.context}
+
+	// USER and HOME are treated seperately because their values
+	// depend on either we create the new user successfuly or not
+	processUser := os.Getenv("USER")
+	processHome := os.Getenv("HOME")
+
+	// If we fail to create a new user, the most probable cause is that
+	// we don't have enough permissions. Chances are that we are running
+	// in in a development environment, so do not fail the task to tests
+	// run successfully.
+	u := user{}
+	if err = u.create(); err != nil {
+		s.context.LogError("Could not create user: ", err, "\n")
+		exitError, ok := err.(*exec.ExitError)
+		if ok {
+			s.context.LogError(string(exitError.Stderr), "\n")
+		}
+
+		tcWorkerEnv, exists := os.LookupEnv("TASKCLUSTER_WORKER_ENV")
+
+		if exists && strings.ToLower(tcWorkerEnv) == "production" {
+			return nil, engines.ErrNonFatalInternalError
+		}
+	} else {
+		defer func() {
+			if err != nil {
+				u.delete()
+			}
+		}()
+
+		userInfo, err := osuser.Lookup(u.name)
+		if err != nil {
+			s.context.LogError("Error looking up for user \""+u.name+"\": ", err, "\n")
+		} else {
+			uid, err := strconv.ParseUint(userInfo.Uid, 10, 32)
+			if err != nil {
+				s.context.LogError("ParseUint failed to convert ", userInfo.Uid, ": ", err, "\n")
+				return nil, engines.ErrNonFatalInternalError
+			}
+
+			gid, err := strconv.ParseUint(userInfo.Gid, 10, 32)
+			if err != nil {
+				s.context.LogError("ParseUint failed to convert ", userInfo.Gid, ": ", err, "\n")
+				return nil, engines.ErrNonFatalInternalError
+			}
+
+			cmd.SysProcAttr = &syscall.SysProcAttr{
+				Credential: &syscall.Credential{
+					Uid:    uint32(uid),
+					Gid:    uint32(gid),
+					Groups: []uint32{},
+				},
+			}
+
+			cmd.Dir = userInfo.HomeDir
+			processUser = u.name
+			processHome = userInfo.HomeDir
+		}
+	}
+
+	env = append(env, "HOME="+processHome, "USER="+processUser)
 	cmd.Env = env
 
-	err := cmd.Run()
+	if s.taskPayload.Link != "" {
+		filename, err := downloadLink(getWorkingDir(u, s.context), s.taskPayload.Link)
 
-	if err != nil {
-		s.context.LogError("Command \"", s.taskPayload.Command, "\" failed to run: ", err)
+		if err != nil {
+			s.context.LogError(err)
+			return nil, engines.ErrNonFatalInternalError
+		}
+
+		defer os.Remove(filename)
+
+		if err = os.Chmod(filename, 0777); err != nil {
+			s.context.LogError(err, "\n")
+			return nil, engines.ErrNonFatalInternalError
+		}
+	}
+
+	r := resultset{
+		ResultSetBase: engines.ResultSetBase{},
+		taskUser:      u,
+		context:       s.context,
+		success:       false,
+		engine:        s.engine,
+	}
+
+	if err = cmd.Run(); err != nil {
+		s.context.LogError("Command \"", s.taskPayload.Command, "\" failed to run: ", err, "\n")
 		switch err.(type) {
 		case *exec.ExitError:
-			return newResultSet(s.context, false), nil
+			err = nil // do not delete the user by the end of the function
+			return r, nil
 		default:
 			return nil, engines.ErrNonFatalInternalError
 		}
 	}
 
-	return newResultSet(s.context, true), nil
+	r.success = true
+	return r, nil
 }
 
 func (s *sandbox) Abort() error {

--- a/engines/osxnative/sandbox.go
+++ b/engines/osxnative/sandbox.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (

--- a/engines/osxnative/sandboxbuilder.go
+++ b/engines/osxnative/sandboxbuilder.go
@@ -12,6 +12,7 @@ type sandboxbuilder struct {
 	taskPayload *payload
 	context     *runtime.TaskContext
 	envMutex    *sync.Mutex
+	engine      *engine
 }
 
 func (s sandboxbuilder) SetEnvironmentVariable(name string, value string) error {
@@ -23,7 +24,7 @@ func (s sandboxbuilder) SetEnvironmentVariable(name string, value string) error 
 		return engines.ErrNamingConflict
 	}
 
-	s.context.Log("Setting \"", name, "\" environment variable to \"", value, "\" ")
+	s.context.Log("Setting \"", name, "\" environment variable to \"", value, "\" \n")
 	s.env[name] = value
 	return nil
 }
@@ -34,5 +35,5 @@ func (s sandboxbuilder) StartSandbox() (engines.Sandbox, error) {
 		env = append(env, name+"="+value)
 	}
 
-	return newSandbox(s.context, s.taskPayload, env), nil
+	return newSandbox(s.context, s.taskPayload, env, s.engine), nil
 }

--- a/engines/osxnative/sandboxbuilder.go
+++ b/engines/osxnative/sandboxbuilder.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (

--- a/engines/osxnative/user.go
+++ b/engines/osxnative/user.go
@@ -1,0 +1,146 @@
+package osxnative
+
+import (
+	"github.com/taskcluster/slugid-go/slugid"
+	"os"
+	"path"
+	"strconv"
+)
+
+type user struct {
+	d    dscl
+	name string
+}
+
+func (u *user) create() error {
+	var err error
+	defer func() {
+		if err != nil {
+			u.delete()
+		}
+	}()
+
+	uid, err := u.getMaxUID()
+	if err != nil {
+		return err
+	}
+
+	staffGid, err := u.d.read("/Groups/staff", "PrimaryGroupID")
+	if err != nil {
+		return err
+	}
+
+	name := "worker-" + slugid.Nice()
+	userPath := path.Join("/Users", name)
+
+	err = u.d.create(userPath)
+	if err != nil {
+		return err
+	}
+
+	// We set the uid, then check if it is unique, if
+	// not, increment and try again
+	duplicated := true
+	for duplicated {
+		uid++
+		strUID := strconv.Itoa(uid)
+
+		// set user uid
+		err = u.d.create(userPath, "uid", strUID)
+		if err != nil {
+			return err
+		}
+
+		// check if uid has been used for another user
+		duplicated, err = u.isDuplicatedID("uid", uid)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = u.d.create(userPath, "PrimaryGroupID", staffGid)
+	if err != nil {
+		return err
+	}
+
+	err = u.d.create(userPath, "NFSHomeDirectory", userPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(userPath, 0700)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chown(userPath, uid, 0)
+	if err != nil {
+		return err
+	}
+
+	u.name = name
+
+	return nil
+}
+
+func (u *user) delete() error {
+	if u.name == "" {
+		return nil
+	}
+
+	userPath := path.Join("/Users", u.name)
+	err := u.d.delete(userPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(userPath)
+	u.name = ""
+	return err
+}
+
+// return the next uid available
+func (u *user) getMaxUID() (int, error) {
+	uids, err := u.d.list("/Users", "uid")
+
+	if err != nil {
+		return -1, err
+	}
+
+	maxUID := 0
+	for _, entry := range uids {
+		uid, err := strconv.Atoi(entry[1])
+
+		if err != nil {
+			return -1, err
+		}
+
+		if uid > maxUID {
+			maxUID = uid
+		}
+	}
+
+	return maxUID, nil
+}
+
+func (u *user) isDuplicatedID(name string, id int) (bool, error) {
+	entries, err := u.d.list("/Users", name)
+
+	if err != nil {
+		return true, err
+	}
+
+	n := 0
+	for _, entry := range entries {
+		entryID, err := strconv.Atoi(entry[1])
+		if err != nil {
+			return true, err
+		}
+
+		if id == entryID {
+			n++
+		}
+	}
+
+	return n > 1, nil
+}

--- a/engines/osxnative/user.go
+++ b/engines/osxnative/user.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (

--- a/engines/osxnative/user_test.go
+++ b/engines/osxnative/user_test.go
@@ -1,0 +1,40 @@
+package osxnative
+
+import (
+	assert "github.com/stretchr/testify/require"
+	"os"
+	osuser "os/user"
+	"testing"
+)
+
+func TestUser(t *testing.T) {
+	currentUser, err := osuser.Current()
+	assert.NoError(t, err)
+
+	if currentUser.Username != "root" {
+		t.Skip("This test requires root privileges, skipping.")
+	}
+
+	u := user{}
+	assert.NoError(t, u.create())
+
+	defer u.delete()
+
+	userInfo, err := osuser.Lookup(u.name)
+	assert.NoError(t, err)
+	assert.Equal(t, userInfo.Username, u.name)
+
+	// Check for the existence of the home directory
+	_, err = os.Stat(userInfo.HomeDir)
+	assert.NoError(t, err)
+
+	// we defer u.delete() to make sure it is called in case of
+	// a failure, but double calling it won't hurt (of couse if
+	// user.delete is not buggy)
+	err = u.delete()
+	assert.NoError(t, err)
+
+	_, err = os.Stat(userInfo.HomeDir)
+	assert.Error(t, err, "Home directory should not exist")
+	assert.True(t, os.IsNotExist(err))
+}

--- a/engines/osxnative/user_test.go
+++ b/engines/osxnative/user_test.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (

--- a/engines/osxnative/util.go
+++ b/engines/osxnative/util.go
@@ -1,0 +1,34 @@
+package osxnative
+
+import (
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"os"
+	osuser "os/user"
+)
+
+// Get the child process working.
+// If we could create a new user, the working is the user home
+// directory, otherwise it is the parent's working dir.
+func getWorkingDir(u user, context *runtime.TaskContext) string {
+	var cwd string
+	var err error
+
+	// In case of error we panic here because error at this point means
+	// something is terribly wrong
+	if u.name != "" {
+		userInfo, err := osuser.Lookup(u.name)
+		if err != nil {
+			context.LogError("user.Lookup failed: ", err, "\n")
+			panic(err)
+		}
+		cwd = userInfo.HomeDir
+	} else {
+		cwd, err = os.Getwd()
+		if err != nil {
+			context.LogError("Getwd failed: ", err, "\n")
+			panic(err)
+		}
+	}
+
+	return cwd
+}

--- a/engines/osxnative/util.go
+++ b/engines/osxnative/util.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package osxnative
 
 import (


### PR DESCRIPTION
To run tasks concurrently in the same environment and make sure they don't
mess up with each other, we run each of them with a different user, which
also prevents tasks from doing fancy things to get secret information.

For each new task, we create a new user on the fly, associate it to the
staff group member and create a home directory. The task is triggered
from user's home directory. After task is done, we remove the user as
well as its home directory.

In the case we fail to create a new user, we log the error but don't
fail the task. This behavior is to let the tests pass even when
running without capability to create users.