### PR TITLE
Include payload in validation error message. r=jonasfj

### DIFF
--- a/runtime/compositeschema.go
+++ b/runtime/compositeschema.go
@@ -124,6 +124,7 @@ func (s *schemaEntry) Parse(data map[string]json.RawMessage) (interface{}, error
 			// Err implements the ResultError interface
 			message += err.Description() + "\n"
 		}
+		message += string(value) + "\n"
 		return nil, errors.New(message)
 	}
 


### PR DESCRIPTION
Dumping payload to logs when validation fails helps to diagnose what's
wrong with payload layout.