### PR TITLE
Enforces correct artifact name. r=jonasfj

### DIFF
--- a/plugins/artifacts/artifacts.go
+++ b/plugins/artifacts/artifacts.go
@@ -6,7 +6,6 @@ package artifacts
 import (
 	"mime"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
@@ -119,7 +118,7 @@ func (tp taskPlugin) errorHandled(name string, expires tcclient.Time, err error)
 
 func (tp taskPlugin) createUploadHandler(name, prefix string, expires tcclient.Time) func(string, ioext.ReadSeekCloser) error {
 	return func(path string, stream ioext.ReadSeekCloser) error {
-		return tp.attemptUpload(stream, path, strings.Replace(path, prefix, name, 1), expires)
+		return tp.attemptUpload(stream, path, filepath.Join(name, filepath.Base(path)), expires)
 	}
 }
 


### PR DESCRIPTION
osxnative engine creates an on-the-fly user to run its tasks. When the
artifact path is relative, the full path for the artifact is relative
to this temporary user home directory. As the artifact full path may not
have an intersection with artifact name, a string replacement may yield
a invalid artifact name.

This patch uses a concatenation of the artifact directory with artifact
file to generate the full artifact name.