### PR TITLE
Honor artifacts relative paths.

### DIFF
--- a/engines/enginetest/artifacts.go
+++ b/engines/enginetest/artifacts.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -113,7 +114,11 @@ func (c *ArtifactTestCase) TestExtractNestedFolderPath() {
 	for _, f := range c.NestedFolderFiles {
 		found := false
 		for _, f2 := range files {
-			if f == f2 {
+			f3, err := filepath.Rel(c.NestedFolderPath, f)
+			if err != nil {
+				continue
+			}
+			if f3 == f2 {
 				found = true
 			}
 		}
@@ -124,7 +129,11 @@ func (c *ArtifactTestCase) TestExtractNestedFolderPath() {
 	for _, f := range files {
 		found := false
 		for _, f2 := range c.NestedFolderFiles {
-			if f == f2 {
+			f3, err := filepath.Rel(c.NestedFolderPath, f2)
+			if err != nil {
+				continue
+			}
+			if f == f3 {
 				found = true
 			}
 		}

--- a/engines/osxnative/engine_test.go
+++ b/engines/osxnative/engine_test.go
@@ -18,9 +18,7 @@ var envVarTestCase = enginetest.EnvVarTestCase{
 	VariableName:         "HELLO_WORLD",
 	InvalidVariableNames: []string{"bad d", "also bad", "can't have space"},
 	Payload: `{
-		"engine": {
-			"command": ["ls"]
-		}
+		"command": ["ls"]
 	}`,
 }
 
@@ -33,19 +31,13 @@ var loggingTestCase = enginetest.LoggingTestCase{
 	EngineProvider: &provider,
 	Target:         "HOME",
 	TargetPayload: `{
-	"engine": {
-			"command": ["/bin/bash", "-c", "env"]
-		}
+		"command": ["/bin/bash", "-c", "env"]
 	}`,
 	FailingPayload: `{
-	"engine": {
-			"command": ["/bin/bash", "-c", "env;exit 1"]
-		}
+		"command": ["/bin/bash", "-c", "env;exit 1"]
 	}`,
 	SilentPayload: `{
-	"engine": {
-			"command": ["/bin/echo", "test"]
-		}
+		"command": ["/bin/echo", "test"]
 	}`,
 }
 

--- a/engines/osxnative/resultset.go
+++ b/engines/osxnative/resultset.go
@@ -3,13 +3,14 @@
 package osxnative
 
 import (
-	"github.com/taskcluster/taskcluster-worker/engines"
-	"github.com/taskcluster/taskcluster-worker/runtime"
-	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+
+	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
 )
 
 type resultset struct {
@@ -85,6 +86,12 @@ func (r resultset) ExtractFolder(path string, handler engines.FileHandler) error
 
 		if !info.IsDir() {
 			file, err := os.Open(p)
+			if err != nil {
+				r.context.LogError(err)
+				return engines.ErrResourceNotFound
+			}
+
+			p, err = filepath.Rel(path, p)
 			if err != nil {
 				r.context.LogError(err)
 				return engines.ErrResourceNotFound

--- a/engines/osxnative/resultset_test.go
+++ b/engines/osxnative/resultset_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	osuser "os/user"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
@@ -105,6 +106,10 @@ func TestExtractFolder(t *testing.T) {
 	assert.Equal(t, err, engines.ErrResourceNotFound)
 
 	err = r.ExtractFolder("test-data", func(p string, stream ioext.ReadSeekCloser) error {
+		if _, err := os.Stat(filepath.Join("test-data", p)); err != nil {
+			return fmt.Errorf("%s should be a valid path relative to test-data directory: %v", p, err)
+		}
+
 		expected := path.Base(p) + "\n"
 		data, err2 := ioutil.ReadAll(stream)
 		sdata := string(data)

--- a/engines/osxnative/sandbox_test.go
+++ b/engines/osxnative/sandbox_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/runtime"
 )
 
-func newTestSandbox(taskPayload *payload, env []string) (*sandbox, error) {
+func newTestSandbox(taskPayload *payloadType, env []string) (*sandbox, error) {
 	temp, err := runtime.NewTemporaryStorage(os.TempDir())
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func newTestSandbox(taskPayload *payload, env []string) (*sandbox, error) {
 }
 
 func TestWaitResult(t *testing.T) {
-	testPayload := payload{
+	testPayload := payloadType{
 		Command: []string{"/bin/echo", "-n", "test"},
 	}
 
@@ -49,7 +49,7 @@ func TestWaitResult(t *testing.T) {
 }
 
 func TestInvalidCommand(t *testing.T) {
-	testPayload := payload{
+	testPayload := payloadType{
 		Command: []string{"Idontexist"},
 	}
 
@@ -62,7 +62,7 @@ func TestInvalidCommand(t *testing.T) {
 }
 
 func TestFailedCommand(t *testing.T) {
-	testPayload := payload{
+	testPayload := payloadType{
 		Command: []string{"/bin/ls", "/invalidpath"},
 	}
 
@@ -77,7 +77,7 @@ func TestFailedCommand(t *testing.T) {
 }
 
 func TestAbort(t *testing.T) {
-	testPayload := payload{
+	testPayload := payloadType{
 		Command: []string{"/bin/echo", "-n", "test"},
 	}
 
@@ -114,7 +114,7 @@ func TestExecDownloadedScript(t *testing.T) {
 	serv.addHandle("/test.sh", "#!/bin/sh\necho -n test\n")
 	defer serv.close()
 
-	testPayload := payload{
+	testPayload := payloadType{
 		Link:    serv.url() + "/test.sh",
 		Command: []string{"./test.sh"},
 	}

--- a/plugins/artifacts/artifacts.go
+++ b/plugins/artifacts/artifacts.go
@@ -3,6 +3,7 @@ package artifacts
 
 import (
 	"mime"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -66,7 +67,7 @@ func (tp *taskPlugin) Stopped(result engines.ResultSet) (bool, error) {
 		}
 		switch artifact.Type {
 		case "directory":
-			err := result.ExtractFolder(artifact.Path, tp.createUploadHandler(artifact.Name, artifact.Path, artifact.Expires))
+			err := result.ExtractFolder(artifact.Path, tp.createUploadHandler(artifact.Name, artifact.Expires))
 			if err != nil {
 				if tp.errorHandled(artifact.Name, artifact.Expires, err) {
 					nonFatalErrs = append(nonFatalErrs, engines.NewMalformedPayloadError(err.Error()))
@@ -119,9 +120,9 @@ func (tp taskPlugin) errorHandled(name string, expires time.Time, err error) boo
 	return false
 }
 
-func (tp taskPlugin) createUploadHandler(name, prefix string, expires time.Time) func(string, ioext.ReadSeekCloser) error {
-	return func(path string, stream ioext.ReadSeekCloser) error {
-		return tp.attemptUpload(stream, path, filepath.Join(name, filepath.Base(path)), expires)
+func (tp taskPlugin) createUploadHandler(name string, expires time.Time) func(string, ioext.ReadSeekCloser) error {
+	return func(artifactPath string, stream ioext.ReadSeekCloser) error {
+		return tp.attemptUpload(stream, artifactPath, path.Join(name, artifactPath), expires)
 	}
 }
 


### PR DESCRIPTION
From PR #101, the path passed to the file handler must be relative to
the artifact path.

If did the math correctly, this breaks qemu engine.