### PR TITLE
Fix gometalinter

### DIFF
--- a/commands/qemu-build/buildimage.go
+++ b/commands/qemu-build/buildimage.go
@@ -103,7 +103,7 @@ func buildImage(
 	select {
 	case <-interrupted:
 		vm.Kill()
-		err = errors.New("SIGINT recieved, aborting virtual machine")
+		err = errors.New("SIGINT received, aborting virtual machine")
 	case <-vm.Done:
 		err = vm.Error
 	}

--- a/commands/qemu-guest-tools/cmd.go
+++ b/commands/qemu-guest-tools/cmd.go
@@ -1,6 +1,7 @@
 // Package qemuguesttools implements the command that runs inside a QEMU VM.
-// These guest tools are reponsible for fetching and executing the task command,
-// as well as posting the log from the task command to the meta-data service.
+// These guest tools are responsible for fetching and executing the task
+// command, as well as posting the log from the task command to the meta-data
+// service.
 //
 // The guest tools are also responsible for polling the meta-data service for
 // actions to do like list-folder, get-artifact or execute a new shell.
@@ -37,7 +38,7 @@ run inside the virtual machines used with QEMU engine.
 
 The "run" (default) command will fetch a command to execute from the meta-data
 service, upload the log and result as success/failed. The command will also
-continously poll the meta-data service for actions, such as put-artifact,
+continuously poll the meta-data service for actions, such as put-artifact,
 list-folder or start an interactive shell.
 
 The "post-log" command will upload <log-file> to the meta-data service. If - is

--- a/engines/errors.go
+++ b/engines/errors.go
@@ -41,7 +41,7 @@ var ErrHandlerInterrupt = errors.New("Handler returned an error and interrupted 
 var ErrSandboxTerminated = errors.New("The Sandbox has terminated")
 
 // ErrSandboxAborted is used to indicate that a Sandbox has been aborted.
-var ErrSandboxAborted = errors.New("Exection of sandbox was aborted")
+var ErrSandboxAborted = errors.New("Execution of sandbox was aborted")
 
 // ErrShellTerminated is used to indicate that a shell has already terminated
 var ErrShellTerminated = errors.New("The shell has already terminated")

--- a/engines/osxnative/resultset_test.go
+++ b/engines/osxnative/resultset_test.go
@@ -106,11 +106,11 @@ func TestExtractFolder(t *testing.T) {
 
 	err = r.ExtractFolder("test-data", func(p string, stream ioext.ReadSeekCloser) error {
 		expected := path.Base(p) + "\n"
-		data, err := ioutil.ReadAll(stream)
+		data, err2 := ioutil.ReadAll(stream)
 		sdata := string(data)
 
-		if err != nil {
-			return err
+		if err2 != nil {
+			return err2
 		}
 
 		if sdata != expected {

--- a/engines/osxnative/sandbox.go
+++ b/engines/osxnative/sandbox.go
@@ -162,19 +162,19 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 			}
 		}()
 
-		userInfo, err := osuser.Lookup(u.name)
-		if err != nil {
+		userInfo, err2 := osuser.Lookup(u.name)
+		if err2 != nil {
 			s.context.LogError("Error looking up for user \""+u.name+"\": ", err, "\n")
 		} else {
-			uid, err := strconv.ParseUint(userInfo.Uid, 10, 32)
-			if err != nil {
-				s.context.LogError("ParseUint failed to convert ", userInfo.Uid, ": ", err, "\n")
+			uid, err2 := strconv.ParseUint(userInfo.Uid, 10, 32)
+			if err2 != nil {
+				s.context.LogError("ParseUint failed to convert ", userInfo.Uid, ": ", err2, "\n")
 				return nil, engines.ErrNonFatalInternalError
 			}
 
-			gid, err := strconv.ParseUint(userInfo.Gid, 10, 32)
-			if err != nil {
-				s.context.LogError("ParseUint failed to convert ", userInfo.Gid, ": ", err, "\n")
+			gid, err2 := strconv.ParseUint(userInfo.Gid, 10, 32)
+			if err2 != nil {
+				s.context.LogError("ParseUint failed to convert ", userInfo.Gid, ": ", err2, "\n")
 				return nil, engines.ErrNonFatalInternalError
 			}
 
@@ -196,17 +196,17 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 	cmd.Env = env
 
 	if s.taskPayload.Link != "" {
-		filename, err := downloadLink(getWorkingDir(u, s.context), s.taskPayload.Link)
+		filename, err2 := downloadLink(getWorkingDir(u, s.context), s.taskPayload.Link)
 
-		if err != nil {
-			s.context.LogError(err)
+		if err2 != nil {
+			s.context.LogError(err2)
 			return nil, engines.ErrNonFatalInternalError
 		}
 
 		defer os.Remove(filename)
 
-		if err = os.Chmod(filename, 0777); err != nil {
-			s.context.LogError(err, "\n")
+		if err2 = os.Chmod(filename, 0777); err2 != nil {
+			s.context.LogError(err2, "\n")
 			return nil, engines.ErrNonFatalInternalError
 		}
 	}

--- a/engines/osxnative/sandbox.go
+++ b/engines/osxnative/sandbox.go
@@ -133,8 +133,8 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 	cmd.Stdout = stdoutLogWriter{s.context}
 	cmd.Stderr = stderrLogWriter{s.context}
 
-	// USER and HOME are treated seperately because their values
-	// depend on either we create the new user successfuly or not
+	// USER and HOME are treated separately because their values
+	// depend on either we create the new user successfully or not
 	processUser := os.Getenv("USER")
 	processHome := os.Getenv("HOME")
 

--- a/engines/osxnative/sandbox.go
+++ b/engines/osxnative/sandbox.go
@@ -162,19 +162,22 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 			}
 		}()
 
-		userInfo, err2 := osuser.Lookup(u.name)
-		if err2 != nil {
+		var userInfo *osuser.User
+		userInfo, err = osuser.Lookup(u.name)
+		if err != nil {
 			s.context.LogError("Error looking up for user \""+u.name+"\": ", err, "\n")
 		} else {
-			uid, err2 := strconv.ParseUint(userInfo.Uid, 10, 32)
-			if err2 != nil {
-				s.context.LogError("ParseUint failed to convert ", userInfo.Uid, ": ", err2, "\n")
+			var uid uint64
+			uid, err = strconv.ParseUint(userInfo.Uid, 10, 32)
+			if err != nil {
+				s.context.LogError("ParseUint failed to convert ", userInfo.Uid, ": ", err, "\n")
 				return nil, engines.ErrNonFatalInternalError
 			}
 
-			gid, err2 := strconv.ParseUint(userInfo.Gid, 10, 32)
-			if err2 != nil {
-				s.context.LogError("ParseUint failed to convert ", userInfo.Gid, ": ", err2, "\n")
+			var gid uint64
+			gid, err = strconv.ParseUint(userInfo.Gid, 10, 32)
+			if err != nil {
+				s.context.LogError("ParseUint failed to convert ", userInfo.Gid, ": ", err, "\n")
 				return nil, engines.ErrNonFatalInternalError
 			}
 
@@ -196,17 +199,18 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 	cmd.Env = env
 
 	if s.taskPayload.Link != "" {
-		filename, err2 := downloadLink(getWorkingDir(u, s.context), s.taskPayload.Link)
+		var filename string
+		filename, err = downloadLink(getWorkingDir(u, s.context), s.taskPayload.Link)
 
-		if err2 != nil {
-			s.context.LogError(err2)
+		if err != nil {
+			s.context.LogError(err)
 			return nil, engines.ErrNonFatalInternalError
 		}
 
 		defer os.Remove(filename)
 
-		if err2 = os.Chmod(filename, 0777); err2 != nil {
-			s.context.LogError(err2, "\n")
+		if err = os.Chmod(filename, 0777); err != nil {
+			s.context.LogError(err, "\n")
 			return nil, engines.ErrNonFatalInternalError
 		}
 	}

--- a/engines/osxnative/util.go
+++ b/engines/osxnative/util.go
@@ -3,9 +3,10 @@
 package osxnative
 
 import (
-	"github.com/taskcluster/taskcluster-worker/runtime"
 	"os"
 	osuser "os/user"
+
+	"github.com/taskcluster/taskcluster-worker/runtime"
 )
 
 // Get the child process working.
@@ -18,10 +19,10 @@ func getWorkingDir(u user, context *runtime.TaskContext) string {
 	// In case of error we panic here because error at this point means
 	// something is terribly wrong
 	if u.name != "" {
-		userInfo, err := osuser.Lookup(u.name)
-		if err != nil {
-			context.LogError("user.Lookup failed: ", err, "\n")
-			panic(err)
+		userInfo, err2 := osuser.Lookup(u.name)
+		if err2 != nil {
+			context.LogError("user.Lookup failed: ", err2, "\n")
+			panic(err2)
 		}
 		cwd = userInfo.HomeDir
 	} else {

--- a/engines/qemu/network/iptables.go
+++ b/engines/qemu/network/iptables.go
@@ -81,7 +81,7 @@ func ipTableRules(tapDevice string, ipPrefix string, delete bool) [][]string {
 		{"-d", "192.168.0.0/16", "-j", "REJECT", "--reject-with", "icmp-net-unreachable"},
 		// Allow out-going from tctap1 with correct source subnet
 		{"-o", "eth0", "-s", subnet, "-j", "ACCEPT"},
-		// Allow tctap1 -> tctap1 withing allowed subnet
+		// Allow tctap1 -> tctap1 within allowed subnet
 		{"-o", "tctap1", "-s", subnet, "-j", "ACCEPT"},
 		// Reject all other input for forwarding from tap-device
 		{"-j", "REJECT", "--reject-with", "icmp-net-prohibited"},
@@ -96,7 +96,7 @@ func ipTableRules(tapDevice string, ipPrefix string, delete bool) [][]string {
 		{"-s", "192.168.0.0/16", "-j", "DROP"},
 		// Allow incoming from tctap1 with correct destination (if already established)
 		{"-i", "eth0", "-d", subnet, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
-		// Allow tctap1 -> tctap1 withing allowed subnet
+		// Allow tctap1 -> tctap1 within allowed subnet
 		{"-i", "tctap1", "-s", subnet, "-j", "ACCEPT"},
 		// Reject all other output from forwarding to tap-device
 		{"-j", "DROP"},

--- a/engines/qemu/network/pool.go
+++ b/engines/qemu/network/pool.go
@@ -377,7 +377,7 @@ func destroyNetwork(n *entry) error {
 		{"ip", "tuntap", "del", "dev", n.tapDevice, "mode", "tap"},
 	}, true)
 	if err != nil {
-		debug("Failed to destory tap device: %s, error: %s", n.tapDevice, err)
+		debug("Failed to destoy tap device: %s, error: %s", n.tapDevice, err)
 		return fmt.Errorf("Failed to remove tap device: %s, error: %s", n.tapDevice, err)
 	}
 

--- a/engines/qemu/vm/machine.go
+++ b/engines/qemu/vm/machine.go
@@ -175,7 +175,7 @@ func LoadMachine(machineFile string) (*Machine, error) {
 			"Invalid JSON in 'machine.json', error: ", err)
 	}
 
-	// Validate the defintion
+	// Validate the definition
 	if err := m.Validate(); err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (m *Machine) Clone() *Machine {
 // valid and legal.
 func (m *Machine) Validate() error {
 	hasError := false
-	errs := "Invalid machine defintion in 'machine.json'"
+	errs := "Invalid machine definition in 'machine.json'"
 	msg := func(a ...interface{}) {
 		errs += "\n" + fmt.Sprint(a...)
 		hasError = true

--- a/engines/sandbox.go
+++ b/engines/sandbox.go
@@ -45,7 +45,7 @@ type Sandbox interface {
 	//
 	// When this method returns, all resources held by the Sandbox instance must
 	// have been released or transferred to the ResultSet instance returned. If an
-	// internal error occured, resources may be freed and WaitForResult() may
+	// internal error occurred, resources may be freed and WaitForResult() may
 	// return ErrNonFatalInternalError if the error didn't leak resources and we
 	// don't expect the error to be persistent.
 	//

--- a/plugins/doc.go
+++ b/plugins/doc.go
@@ -11,10 +11,10 @@
 //
 // A plugin does not get any plugin specific task.payload space, instead the
 // options required by a plugin must be part of the task.payload. Hence, all
-// plugins must be available on all platforms. To faciliate this, plugins should
-// not use platform specific APIs, instead they should rely on interface offered
-// by the engine objects to do so, fail gracefully if an engine method is
-// not supported in a given configuration and returns ErrFeatureNotSupported.
+// plugins must be available on all platforms. To facilitate this, plugins
+// should not use platform specific APIs, instead they should rely on interface
+// offered by the engine objects to do so, fail gracefully if an engine method
+// is not supported in a given configuration and returns ErrFeatureNotSupported.
 //
 // When a plugin encounters an unsupported feature that it needs, it may either
 // return a MalformedPayloadError, or simply ignore the error and workaround it.

--- a/plugins/interactive/shellclient/shellclient.go
+++ b/plugins/interactive/shellclient/shellclient.go
@@ -250,7 +250,7 @@ func (s *ShellClient) readMessages() {
 			}
 		}
 
-		// If bytes from stdin are acknowleged, then we unblock additional bytes
+		// If bytes from stdin are acknowledged, then we unblock additional bytes
 		if mType == interactive.MessageTypeAck && len(mData) == 5 {
 			if mData[0] == interactive.StreamStdin {
 				n := binary.BigEndian.Uint32(mData[1:])

--- a/plugins/interactive/shellhandler.go
+++ b/plugins/interactive/shellhandler.go
@@ -293,7 +293,7 @@ func (s *ShellHandler) readMessages() {
 			}
 		}
 
-		// If bytes from stdout/stderr are acknowleged, then we unblock
+		// If bytes from stdout/stderr are acknowledged, then we unblock
 		// additional bytes
 		if mType == MessageTypeAck && len(mData) == 5 {
 			mStream := mData[0]

--- a/runtime/ioext/blockedpipe.go
+++ b/runtime/ioext/blockedpipe.go
@@ -114,7 +114,7 @@ func (r *PipeReader) CloseWithError(err error) error {
 
 // Unblock allows n bytes to traverse through the pipe. Typically, this pipe is
 // used when implementing congestion control and r.Unblock(n) is then called
-// when the remote side have acknowleged n bytes. This way the network isn't
+// when the remote side have acknowledged n bytes. This way the network isn't
 // congested with lots of outstanding bytes.
 //
 // As a special case n = -1 permanently unblocks the pipe.

--- a/worker/queueservice_test.go
+++ b/worker/queueservice_test.go
@@ -121,7 +121,7 @@ func TestShouldNotRefreshMessageQueueURLs(t *testing.T) {
 		log:              logger.WithField("component", "Queue Service"),
 	}
 
-	// Because the expiration is not close, adn the service already has queues,
+	// Because the expiration is not close, and the service already has queues,
 	// there should be no reason to refresh.  Because the service was not created
 	// with a taskcluster queue client, if it attempts to refresh, there will be
 	// a panic
@@ -305,7 +305,7 @@ func TestPollTaskURLInvalidMessageTextEncoding(t *testing.T) {
 
 func TestSuccessfullyDeleteFromAzureQueue(t *testing.T) {
 	// The method for deleting from the azure queue just makes sure that when
-	// calling a given URL that a 200 status reponse is received.
+	// calling a given URL that a 200 status response is received.
 	var handler = func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
 	}


### PR DESCRIPTION
After this we should run `gometalinter --vendor --disable-all --enable=misspell --tests  ./...` on travis...

I'm not sure how add gometalinter, as it has a lot of dependencies, it might not be appropriate to vendor it...