### PR TITLE
Added configuration options for max memory per vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ coverage.out
 /.bash_history
 /engines/qemu/test-image/tinycore-setup.tar.zst
 /engines/qemu/test-image/tinycore-worker.tar.zst
-/mock-config.yml
+/config/mock-config.yml
+/config/qemu-config.yml

--- a/commands/qemu-build/buildimage.go
+++ b/commands/qemu-build/buildimage.go
@@ -84,7 +84,11 @@ func buildImage(
 
 	// Create virtual machine
 	log.Info("Creating virtual machine")
-	vm := vm.NewVirtualMachine(img, net, socketFolder, boot, cdrom, log.WithField("component", "vm"))
+	vm, err := vm.NewVirtualMachine(img.Machine().Options(), img, net, socketFolder, boot, cdrom, log.WithField("component", "vm"))
+	if err != nil {
+		log.Error("Failed to recreated virtual-machine, error: ", err)
+		return err
+	}
 
 	// Start the virtual machine
 	log.Info("Starting virtual machine")

--- a/commands/qemu-run/run.go
+++ b/commands/qemu-run/run.go
@@ -94,7 +94,13 @@ func (cmd) Execute(arguments map[string]interface{}) bool {
 
 	// Create virtual machine
 	log.Info("Creating virtual machine")
-	vm := vm.NewVirtualMachine(image, net, tempFolder, "", "", logger.WithField("component", "vm"))
+	vm, err := vm.NewVirtualMachine(
+		image.Machine().Options(), image, net, tempFolder,
+		"", "", logger.WithField("component", "vm"),
+	)
+	if err != nil {
+		log.Fatal("Failed to create virtual-machine, error: ", err)
+	}
 
 	// Create meta-data service
 	log.Info("Creating meta-data service")

--- a/config/qemu-config-example.yml
+++ b/config/qemu-config-example.yml
@@ -1,0 +1,33 @@
+capacity:         1
+credentials:
+  # Create a client with the scope:
+  # assume:project:taskcluster:worker-test-scopes
+  clientId:       '...'
+  accessToken:    '...'
+provisionerId:    test-dummy-provisioner
+workerType:       dummy-worker-mock-33 # choose number to avoid conflicts
+workerGroup:      test-dummy-workers
+workerId:         dummy-worker-33
+engine:           qemu
+engines:
+  qemu:
+    maxConcurrency: 2
+    imageFolder:    /tmp/images/
+    socketFolder:   /tmp/
+    machineOptions:
+      maxMemory:    4096
+logLevel:         debug
+plugins:
+  interactive:    {}
+  disabled:       []
+pollingInterval:  1
+queueBaseUrl:     https://queue.taskcluster.net/v1
+reclaimOffset:    120
+temporaryFolder:  /tmp/tc-worker-tmp
+serverIp:           127.0.0.1
+serverPort:         60000
+statelessDNSSecret: fake-secret
+statelessDNSDomain: example.com
+maxLifeCycle:       10 * 60 # 10 min
+minimumDiskSpace:   10000000
+minimumMemory:      1000000

--- a/engines/qemu/qemuengine_test.go
+++ b/engines/qemu/qemuengine_test.go
@@ -58,7 +58,10 @@ var provider = &enginetest.EngineProvider{
 	Config: `{
 		"maxConcurrency":   5,
 		"imageFolder":      "/tmp/images/",
-		"socketFolder":     "/tmp/"
+		"socketFolder":     "/tmp/",
+		"machineOptions": {
+			"maxMemory": 512
+		}
   }`,
 }
 

--- a/engines/qemu/vm/options.go
+++ b/engines/qemu/vm/options.go
@@ -13,17 +13,17 @@ var MachineOptionsSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "Machine Options",
 		Description: `Limitations and default values for the virtual machine
-                  configuration. Tasks with machine images that doesn't satisfy
-                  these limitations will be resolved 'malformed-payload'.`,
+    configuration. Tasks with machine images that doesn't satisfy
+    these limitations will be resolved 'malformed-payload'.`,
 	},
 	Properties: schematypes.Properties{
 		"maxMemory": schematypes.Integer{
 			MetaData: schematypes.MetaData{
 				Title: "Max Memory",
 				Description: `Maximum allowed virtual machine memory in MiB. This is
-										 	also the default memory if the machine image doesn't
-											specify memory requirements. If the machine specifies a
-											memory higher than this, the task will fail to run.`,
+				also the default memory if the machine image doesn't
+				specify memory requirements. If the machine specifies a
+				memory higher than this, the task will fail to run.`,
 			},
 			Minimum: 0,
 			Maximum: 1024 * 1024, // 1 TiB

--- a/engines/qemu/vm/options.go
+++ b/engines/qemu/vm/options.go
@@ -1,0 +1,35 @@
+package vm
+
+import schematypes "github.com/taskcluster/go-schematypes"
+
+// MachineOptions specifies the limits on the virtual machine limits, default
+// values and options.
+type MachineOptions struct {
+	MaxMemory int `json:"maxMemory"`
+}
+
+// MachineOptionsSchema is the schema for MachineOptions.
+var MachineOptionsSchema = schematypes.Object{
+	MetaData: schematypes.MetaData{
+		Title: "Machine Options",
+		Description: `Limitations and default values for the virtual machine
+                  configuration. Tasks with machine images that doesn't satisfy
+                  these limitations will be resolved 'malformed-payload'.`,
+	},
+	Properties: schematypes.Properties{
+		"maxMemory": schematypes.Integer{
+			MetaData: schematypes.MetaData{
+				Title: "Max Memory",
+				Description: `Maximum allowed virtual machine memory in MiB. This is
+										 	also the default memory if the machine image doesn't
+											specify memory requirements. If the machine specifies a
+											memory higher than this, the task will fail to run.`,
+			},
+			Minimum: 0,
+			Maximum: 1024 * 1024, // 1 TiB
+		},
+	},
+	Required: []string{
+		"maxMemory",
+	},
+}

--- a/engines/qemu/vm/vm.go
+++ b/engines/qemu/vm/vm.go
@@ -46,7 +46,7 @@ type VirtualMachine struct {
 // NewVirtualMachine constructs a new virtual machine using the given
 // machineOptions, image, network and cdroms.
 //
-// Returns engines.MalformedPayloadError, if machineOptions and image definition
+// Returns engines.MalformedPayloadError if machineOptions and image definition
 // are conflicting. If this returns an error, caller is responsible for
 // releasing all resources, otherwise, they will be held by the VirtualMachine
 // object.

--- a/engines/qemu/vm/vm.go
+++ b/engines/qemu/vm/vm.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -42,11 +43,25 @@ type VirtualMachine struct {
 	domain       *qemu.Domain
 }
 
-// NewVirtualMachine constructs a new virtual machine.
+// NewVirtualMachine constructs a new virtual machine using the given
+// machineOptions, image, network and cdroms.
+//
+// Returns engines.MalformedPayloadError, if machineOptions and image definition
+// are conflicting. If this returns an error, caller is responsible for
+// releasing all resources, otherwise, they will be held by the VirtualMachine
+// object.
 func NewVirtualMachine(
+	machineOptions MachineOptions,
 	image Image, network Network, socketFolder, cdrom1, cdrom2 string,
 	log *logrus.Entry,
-) *VirtualMachine {
+) (*VirtualMachine, error) {
+	// Get machine definition and set defaults
+	machine := image.Machine()
+	err := machine.SetDefaults(machineOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create a sub-folder in the socketFolder
 	socketFolder = filepath.Join(socketFolder, slugid.Nice())
 
@@ -81,16 +96,16 @@ func NewVirtualMachine(
 			"accel": "kvm",
 			// TODO: Configure additional options")
 		}),
-		"-m", "512", // TODO: Make memory configurable
+		"-m", strconv.Itoa(machine.Memory),
 		"-realtime", "mlock=off", // TODO: Enable for things like talos
 		// TODO: fit to system HT, see: https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
 		// TODO: Configure CPU instruction sets: http://forum.ipfire.org/viewtopic.php?t=12642
 		"-smp", "cpus=2,sockets=2,cores=1,threads=1",
-		"-uuid", vm.image.Machine().UUID,
+		"-uuid", machine.UUID,
 		"-no-user-config", "-nodefaults",
 		"-rtc", "base=utc", // TODO: Allow clock=vm for loadvm with windows
 		"-boot", "menu=off,strict=on",
-		"-k", vm.image.Machine().Keyboard.Layout,
+		"-k", machine.Keyboard.Layout,
 		"-device", arg("vmware-svga", opts{
 			// TODO: Investigate if we can use vmware
 			// VGA ought to be the safe choice here
@@ -110,10 +125,10 @@ func NewVirtualMachine(
 			"addr": "0x4", // Always put balloon on PCI 0x4
 		}),
 		"-netdev", vm.network.NetDev("netdev-0"),
-		"-device", arg(vm.image.Machine().Network.Device, opts{
+		"-device", arg(machine.Network.Device, opts{
 			"netdev": "netdev-0",
 			"id":     "nic0",
-			"mac":    vm.image.Machine().Network.MAC,
+			"mac":    machine.Network.MAC,
 			"bus":    "pci.0",
 			"addr":   "0x5", // Always put network on PCI 0x5
 		}),
@@ -155,10 +170,10 @@ func NewVirtualMachine(
 	}
 
 	// Add optional sound device
-	if vm.image.Machine().Sound != nil {
-		if vm.image.Machine().Sound.Controller == "pci" {
+	if machine.Sound != nil {
+		if machine.Sound.Controller == "pci" {
 			options = append(options, []string{
-				"-device", arg(vm.image.Machine().Sound.Device, opts{
+				"-device", arg(machine.Sound.Device, opts{
 					"id":   "sound-0",
 					"bus":  "pci.0",
 					"addr": "0x6", // Always put sound on PCI 0x6
@@ -166,12 +181,12 @@ func NewVirtualMachine(
 			}...)
 		} else {
 			options = append(options, []string{
-				"-device", arg(vm.image.Machine().Sound.Controller, opts{
+				"-device", arg(machine.Sound.Controller, opts{
 					"id":   "sound-0",
 					"bus":  "pci.0",
 					"addr": "0x6", // Always put sound on PCI 0x6
 				}),
-				"-device", arg(vm.image.Machine().Sound.Device, opts{
+				"-device", arg(machine.Sound.Device, opts{
 					"id":  "sound-0-codec-0",
 					"bus": "sound-0.0",
 					"cad": "0",
@@ -231,7 +246,7 @@ func NewVirtualMachine(
 	// Create QEMU process
 	vm.qemu = exec.Command("qemu-system-x86_64", options...)
 
-	return vm
+	return vm, nil
 }
 
 // SetHTTPHandler sets the HTTP handler for the meta-data service.


### PR DESCRIPTION
This added an engine option to QEMU engine so we can configure max allowed memory per VM.

If  a machine is specified to require more memory than is allowed, it'll result in an malformed-payload error.