### PR TITLE
Don't add prefix message when dumping command output.

### DIFF
--- a/engines/osxnative/sandbox.go
+++ b/engines/osxnative/sandbox.go
@@ -52,7 +52,7 @@ type stderrLogWriter struct {
 }
 
 func (w stderrLogWriter) Write(p []byte) (int, error) {
-	w.context.LogError(string(p))
+	w.context.LogRaw(string(p))
 	return len(p), nil
 }
 

--- a/runtime/taskcontext.go
+++ b/runtime/taskcontext.go
@@ -181,7 +181,7 @@ func (c *TaskContext) IsCancelled() bool {
 // These log messages will be prefixed "[taskcluster]" so it's easy to see to
 // that they are worker logs.
 func (c *TaskContext) Log(a ...interface{}) {
-	c.log("[taskcluster] ", a...)
+	c.LogRaw("[taskcluster] ", a...)
 }
 
 // LogError writes a log error message from the worker
@@ -190,12 +190,13 @@ func (c *TaskContext) Log(a ...interface{}) {
 // that they are worker logs.  These errors are also easy to grep from the logs in
 // case of failure.
 func (c *TaskContext) LogError(a ...interface{}) {
-	c.log("[taskcluster:error] ", a...)
+	c.LogRaw("[taskcluster:error] ", a...)
 }
 
-func (c *TaskContext) log(prefix string, a ...interface{}) {
+// LogRaw writes log without any prefix message or newline
+func (c *TaskContext) LogRaw(prefix string, a ...interface{}) {
 	a = append([]interface{}{prefix}, a...)
-	_, err := fmt.Fprintln(c.logStream, a...)
+	_, err := fmt.Fprint(c.logStream, a...)
 	if err != nil {
 		//TODO: Forward this to the system log, it's not a critical error
 	}


### PR DESCRIPTION
When logging out the output of a command run in a context of a task, we
should not add any prefix string, we this will make treeherder parsing
to fail.