### PR TITLE
Bug 1305707: gzip compress live log artifact.

### DIFF
--- a/runtime/artifact_test.go
+++ b/runtime/artifact_test.go
@@ -99,7 +99,7 @@ func TestPutArtifact200(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	err := putArtifact(ts.URL, "text/plain", ioext.NopCloser(&bytes.Reader{}))
+	err := putArtifact(ts.URL, "text/plain", ioext.NopCloser(&bytes.Reader{}), map[string]string{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -111,7 +111,7 @@ func TestPutArtifact400(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	err := putArtifact(ts.URL, "text/plain", ioext.NopCloser(&bytes.Reader{}))
+	err := putArtifact(ts.URL, "text/plain", ioext.NopCloser(&bytes.Reader{}), map[string]string{})
 	if err == nil {
 		t.Fail()
 	}
@@ -129,7 +129,7 @@ func TestPutArtifact500(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	err := putArtifact(ts.URL, "text/plain", ioext.NopCloser(&bytes.Reader{}))
+	err := putArtifact(ts.URL, "text/plain", ioext.NopCloser(&bytes.Reader{}), map[string]string{})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Treeherder log parser expects log file be gzipped compressed. This also
saves bandwidth resources.