### PR TITLE
Add configuration for creation to macosx engine.

### DIFF
--- a/engines/osxnative/dscl.go
+++ b/engines/osxnative/dscl.go
@@ -47,7 +47,7 @@ func (d dscl) read(a ...string) (string, error) {
 		return s, err
 	}
 
-	return strings.Fields(s)[1], nil
+	return strings.Join(strings.Fields(s)[1:], " "), nil
 }
 
 func (d dscl) create(a ...string) error {

--- a/engines/osxnative/engine_test.go
+++ b/engines/osxnative/engine_test.go
@@ -10,7 +10,9 @@ import (
 
 var provider = enginetest.EngineProvider{
 	Engine: "macosx",
-	Config: "{}",
+	Config: `{
+		"createUser": false
+	}`,
 }
 
 var envVarTestCase = enginetest.EnvVarTestCase{

--- a/engines/osxnative/resultset_test.go
+++ b/engines/osxnative/resultset_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	osuser "os/user"
 	"path"
 	"path/filepath"
 	"testing"
@@ -34,9 +33,13 @@ func makeResultSet(t *testing.T) resultset {
 		t.Fatal(err)
 	}
 
+	config := configType{
+		CreateUser: false,
+	}
+
 	e := engine{
-		EngineBase: engines.EngineBase{},
-		log:        logrus.New().WithField("component", "test"),
+		config: &config,
+		log:    logrus.New().WithField("component", "test"),
 	}
 
 	return resultset{
@@ -66,13 +69,10 @@ func TestValidPath(t *testing.T) {
 		{"/", false},
 	}
 
-	userInfo, err := osuser.Current()
-	assert.NoError(t, err)
-
 	r := makeResultSet(t)
 
 	for _, tc := range testCases {
-		if r.validPath(userInfo.HomeDir, tc.pathName) != tc.expectedResult {
+		if r.validPath(home, tc.pathName) != tc.expectedResult {
 			t.Errorf("validPath(%s) != %t", tc.pathName, tc.expectedResult)
 		}
 	}

--- a/engines/osxnative/sandbox_test.go
+++ b/engines/osxnative/sandbox_test.go
@@ -72,8 +72,13 @@ func newTestSandbox(taskPayload *payloadType, env []string) (*sandbox, error) {
 		return nil, err
 	}
 
+	config := configType{
+		CreateUser: false,
+	}
+
 	e := engine{
 		EngineBase: engines.EngineBase{},
+		config:     &config,
 		log:        logrus.New().WithField("component", "test"),
 	}
 

--- a/examples/macosx-config.yml
+++ b/examples/macosx-config.yml
@@ -1,26 +1,34 @@
-capacity:         1
-credentials:
-  # Create a client with the scope:
-  # assume:project:taskcluster:worker-test-scopes
-  clientId:       'abcdefghijklmnopqrstuvwxyz'
-  accessToken:    'abcdefghijklmnopqrstuvwxyz'
-provisionerId:    tc-worker-provisioner
-workerType:       gecko-test-macosx64
-workerGroup:      macosx-tc-worker
-workerId:         tc-worker-01 
-engine:           macosx
-engines:
-  mock: {}
-  macosx: {}
-logLevel:         debug
-plugins:
-  disabled:       ['success']
-pollingInterval:  1
-queueBaseUrl:     https://queue.taskcluster.net/v1
-reclaimOffset:    120
-temporaryFolder:  /tmp/tc-worker-tmp
-serverIp:           127.0.0.1
-serverPort:         60000
-statelessDNSSecret: fake-secret
-statelessDNSDomain: example.com
-maxLifeCycle:       600
+# Configuration file for tc-worker.Dockerfile
+transforms:
+  - env
+config:
+  capacity:         1
+  credentials:
+    # Create a client with the scope:
+    # assume:project:taskcluster:worker-test-scopes
+    # secrets:get:project/taskcluster/taskcluster-worker/stateless-dns
+    clientId:       {$env: TASKCLUSTER_CLIENT_ID}
+    accessToken:    {$env: TASKCLUSTER_ACCESS_TOKEN}
+  provisionerId:    gecko-t-tc-worker
+  workerType:       gecko-test-macosx64
+  workerGroup:      macosx-tc-worker
+  workerId:         tc-worker-01
+  engine:           macosx
+  engines:
+    macosx:
+      createUser: true
+      userGroups: ['staff']
+  logLevel:         info
+  plugins:
+    disabled:       ['success', 'interactive']
+  pollingInterval:  10
+  queueBaseUrl:     https://queue.taskcluster.net/v1
+  reclaimOffset:    120
+  temporaryFolder:  /tmp/tc-worker-tmp
+  serverIp:           127.0.0.1
+  serverPort:         60000
+  statelessDNSSecret: fake-secret
+  statelessDNSDomain: example.com
+  maxLifeCycle:       600
+  minimumDiskSpace:   10000000  # 10 GB
+  minimumMemory:      1000000   # 1 GB


### PR DESCRIPTION
In order to create some kind of isolation among tasks, macosx engine has the ability to create an on-fly user to run tasks. This commit adds configurations to the engine to tell if a new user should be created or not to run a task, as well as the user group.
