### PR TITLE
Script artifact folder

### DIFF
--- a/engines/script/sandboxbuilder.go
+++ b/engines/script/sandboxbuilder.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/runtime"
@@ -23,6 +25,10 @@ func (b *sandboxBuilder) StartSandbox() (engines.Sandbox, error) {
 	folder, err := b.engine.environment.TemporaryStorage.NewFolder()
 	if err != nil {
 		return nil, fmt.Errorf("Error creating temporary folder: %s", err)
+	}
+	err = os.Mkdir(filepath.Join(folder.Path(), artifactFolder), 0777)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create artifact folder, error: %s", err)
 	}
 	data, err := json.Marshal(b.payload)
 	if err != nil {

--- a/examples/script-config.yml
+++ b/examples/script-config.yml
@@ -21,7 +21,8 @@ config:
       #  - Read JSON payload from stdin,
       #  - Read TASK_ID and RUN_ID environment variables (if it wants them),
       #  - Print log to stdout
-      #  - Write artifacts to working directory (a temporary folder is given)
+      #  - Use working directory for temporary files (it'll be cleaned between tasks)
+      #  - Write artifacts ./artifacts/ (relative to current working directory) 
       #  - Exit zero to indicate successful task completetion
       command:      ['python', {$abs: 'examples/script.py'}]
       schema:       # schema for task.payload passed to command over stdin

--- a/examples/script.py
+++ b/examples/script.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
-import sys, json
+import sys, json, os
 
+# Read the payload
 payload = json.loads(sys.stdin.read())
-
 print "Payload given:"
 print payload
+
+# Create an artifact
+os.mkdir('artifacts/public/')
+with open('artifacts/public/test-artifact.txt', 'w') as f:
+  f.write('buildUrl given was: ' + payload.get('buildUrl'))
+
+# Note: current working directory will be cleaned between tasks


### PR DESCRIPTION
One temporary folder per script task.. Files left in `artifacts/` of that folder will be uploaded as artifacts.