### PR TITLE
Implement context

### DIFF
--- a/commands/qemu-guest-tools/cmd.go
+++ b/commands/qemu-guest-tools/cmd.go
@@ -18,9 +18,10 @@ import (
 
 	"github.com/taskcluster/taskcluster-worker/commands"
 	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
-var debug = runtime.Debug("guesttools")
+var debug = util.Debug("guesttools")
 
 func init() {
 	commands.Register("qemu-guest-tools", cmd{})

--- a/commands/qemu-run/run.go
+++ b/commands/qemu-run/run.go
@@ -20,9 +20,10 @@ import (
 	"github.com/taskcluster/taskcluster-worker/plugins/interactive"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
-var debug = runtime.Debug("qemurun")
+var debug = util.Debug("qemurun")
 
 type cmd struct{}
 

--- a/commands/shell/doc.go
+++ b/commands/shell/doc.go
@@ -3,6 +3,6 @@
 // in your terminal.
 package shell
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("shell")
+var debug = util.Debug("shell")

--- a/engines/enginetest/testutils.go
+++ b/engines/enginetest/testutils.go
@@ -13,9 +13,10 @@ import (
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
-var debug = runtime.Debug("enginetest")
+var debug = util.Debug("enginetest")
 
 func fmtPanic(a ...interface{}) {
 	panic(fmt.Sprintln(a...))

--- a/engines/mock/doc.go
+++ b/engines/mock/doc.go
@@ -2,6 +2,6 @@
 // but allows us to test plugins without having to run a real engine.
 package mockengine
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("mockengine")
+var debug = util.Debug("mockengine")

--- a/engines/mock/mocknet/doc.go
+++ b/engines/mock/mocknet/doc.go
@@ -8,10 +8,10 @@ package mocknet
 import (
 	"sync"
 
-	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
-var debug = runtime.Debug("mocknet")
+var debug = util.Debug("mocknet")
 
 // mNetworks guards access to networks, which is global list of mock networks.
 var (

--- a/engines/qemu/doc.go
+++ b/engines/qemu/doc.go
@@ -8,6 +8,6 @@
 // other systems.
 package qemuengine
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("qemu")
+var debug = util.Debug("qemu")

--- a/engines/qemu/image/doc.go
+++ b/engines/qemu/image/doc.go
@@ -3,6 +3,6 @@
 // the images don't reference external files as backing store.
 package image
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("image")
+var debug = util.Debug("image")

--- a/engines/qemu/metaservice/doc.go
+++ b/engines/qemu/metaservice/doc.go
@@ -6,6 +6,6 @@
 // It is also the services that the guest uses to report logs and final result.
 package metaservice
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("metaservice")
+var debug = util.Debug("metaservice")

--- a/engines/qemu/network/doc.go
+++ b/engines/qemu/network/doc.go
@@ -12,6 +12,6 @@
 // another virtual machine.
 package network
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("network")
+var debug = util.Debug("network")

--- a/engines/qemu/vm/doc.go
+++ b/engines/qemu/vm/doc.go
@@ -1,6 +1,6 @@
 // Package vm provides virtual machine abstractions for QEMU.
 package vm
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("vm")
+var debug = util.Debug("vm")

--- a/engines/script/doc.go
+++ b/engines/script/doc.go
@@ -2,6 +2,6 @@
 // and a JSON schema, such that the worker executes declarative tasks.
 package scriptengine
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("scriptengine")
+var debug = util.Debug("scriptengine")

--- a/plugins/interactive/displayclient/doc.go
+++ b/plugins/interactive/displayclient/doc.go
@@ -5,6 +5,6 @@
 // a go application. Both for writing tests and command line utilities.
 package displayclient
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("displayclient")
+var debug = util.Debug("displayclient")

--- a/plugins/interactive/doc.go
+++ b/plugins/interactive/doc.go
@@ -8,10 +8,10 @@ package interactive
 
 import (
 	"github.com/taskcluster/taskcluster-worker/plugins"
-	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
-var debug = runtime.Debug("interactive")
+var debug = util.Debug("interactive")
 
 func init() {
 	plugins.Register("interactive", provider{})

--- a/plugins/interactive/interactive.go
+++ b/plugins/interactive/interactive.go
@@ -248,7 +248,7 @@ func (p *taskPlugin) setupShell() error {
 		Name:     p.opts.ArtifactPrefix + "shell.html",
 		Mimetype: "text/html",
 		URL:      p.parent.config.ShellToolURL + "?" + query.Encode(),
-		Expires:  p.context.Deadline,
+		Expires:  p.context.TaskInfo.Deadline,
 	}, p.context)
 }
 
@@ -282,7 +282,7 @@ func (p *taskPlugin) setupDisplay() error {
 		Name:     p.opts.ArtifactPrefix + "display.html",
 		Mimetype: "text/html",
 		URL:      p.parent.config.DisplayToolURL + "?" + query.Encode(),
-		Expires:  p.context.Deadline,
+		Expires:  p.context.TaskInfo.Deadline,
 	}, p.context)
 }
 
@@ -305,7 +305,7 @@ func (p *taskPlugin) createSocketsFile() error {
 	return runtime.UploadS3Artifact(runtime.S3Artifact{
 		Name:     p.opts.ArtifactPrefix + "sockets.json",
 		Mimetype: "application/json",
-		Expires:  p.context.Deadline,
+		Expires:  p.context.TaskInfo.Deadline,
 		Stream:   ioext.NopCloser(bytes.NewReader(data)),
 	}, p.context)
 }

--- a/plugins/interactive/shellclient/doc.go
+++ b/plugins/interactive/shellclient/doc.go
@@ -3,6 +3,6 @@
 // stdin stream.
 package shellclient
 
-import "github.com/taskcluster/taskcluster-worker/runtime"
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
 
-var debug = runtime.Debug("shellclient")
+var debug = util.Debug("shellclient")

--- a/runtime/util/debug.go
+++ b/runtime/util/debug.go
@@ -1,4 +1,4 @@
-package runtime
+package util
 
 import (
 	"fmt"

--- a/runtime/util/doc.go
+++ b/runtime/util/doc.go
@@ -1,0 +1,3 @@
+// Package util contains a few simple utilites that has no internal
+// dependencies. This is to encourage reuse of code.
+package util


### PR DESCRIPTION
I think `TaskContext` should implement `context.Context`...

In future we should also not have `TaskContext` track status, it's totally unnecessary and only `worker/` package uses it. Plugins and engines should only care if a task is aborted/cancelled, and not whether it was an abort or a cancel.

They should only care that execution should stop...