### PR TITLE
Image download should not require aws credentials

### DIFF
--- a/engines/qemu/test-image/download.sh
+++ b/engines/qemu/test-image/download.sh
@@ -3,5 +3,5 @@
 # Find location of the script no matter where it's located
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-aws s3 cp "s3://public-qemu-images/test-images/tinycore-setup.tar.zst" "$DIR/tinycore-setup.tar.zst"
-aws s3 cp "s3://public-qemu-images/test-images/tinycore-worker.tar.zst" "$DIR/tinycore-worker.tar.zst"
+curl "https://s3-us-west-2.amazonaws.com/public-qemu-images/test-images/tinycore-setup.tar.zst" > "$DIR/tinycore-setup.tar.zst"
+curl "https://s3-us-west-2.amazonaws.com/public-qemu-images/test-images/tinycore-worker.tar.zst" > "$DIR/tinycore-worker.tar.zst"


### PR DESCRIPTION
Tested this while you were watching, so you get to give it an r+