### PR TITLE
Fixes for mac engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ GO_VERSION := $(shell go version 2>/dev/null | cut -f3 -d' ')
 GO_MAJ := $(shell echo "$(GO_VERSION)" | cut -f1 -d'.')
 GO_MIN := $(shell echo "$(GO_VERSION)" | cut -f2 -d'.')
 
+uname := $(shell uname)
+is_darwin := $(filter Darwin,$(uname))
+CGO_ENABLE := $(if $(is_darwin),1,0)
+
 all: rebuild
 
 prechecks:
@@ -23,7 +27,7 @@ prechecks:
 
 build:
 	go fmt $$(go list ./... | grep -v /vendor/)
-	CGO_ENABLED=0 go build
+	CGO_ENABLED=$(CGO_ENABLE) go build
 
 generate:
 	# tools needed for go generate steps later...
@@ -53,5 +57,5 @@ tc-worker-env:
 	docker build -t taskcluster/tc-worker-env -f tc-worker-env.Dockerfile .
 
 tc-worker:
-	CGO_ENABLED=0 GOARCH=amd64 go build
+	CGO_ENABLED=$(CGO_ENABLE) GOARCH=amd64 go build
 	docker build -t taskcluster/tc-worker -f tc-worker.Dockerfile .

--- a/engines/osxnative/sandbox.go
+++ b/engines/osxnative/sandbox.go
@@ -202,16 +202,11 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 
 	if err = cmd.Run(); err != nil {
 		s.context.LogError("Command \"", s.taskPayload.Command, "\" failed to run: ", err)
-		switch err.(type) {
-		case *exec.ExitError:
-			err = nil // do not delete the user by the end of the function
-			return r, nil
-		default:
-			return nil, engines.ErrNonFatalInternalError
-		}
+		err = nil // do not delete the user by the end of the function
+	} else {
+		r.success = true
 	}
 
-	r.success = true
 	return r, nil
 }
 

--- a/engines/osxnative/sandbox_test.go
+++ b/engines/osxnative/sandbox_test.go
@@ -110,8 +110,9 @@ func TestInvalidCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	r, err := s.WaitForResult()
-	assert.Equal(t, err, engines.ErrNonFatalInternalError)
-	assert.Nil(t, r)
+	assert.NoError(t, err)
+	defer r.Dispose()
+	assert.False(t, r.Success())
 }
 
 func TestFailedCommand(t *testing.T) {


### PR DESCRIPTION
* Build CGO_ENABLE=1 on Darwin
* Fail the task when `cmd.Run()` fails.