### PR TITLE
Bug 1339196: Make $HOME and os/user.Lookup().HomeDir equal. r=jonasfj

### DIFF
--- a/engines/native/resultset.go
+++ b/engines/native/resultset.go
@@ -28,7 +28,7 @@ func (r *resultSet) Success() bool {
 
 func (r *resultSet) ExtractFile(path string) (ioext.ReadSeekCloser, error) {
 	// Evaluate symlinks
-	p, err := filepath.EvalSymlinks(filepath.Join(r.workingFolder.Path(), path))
+	p, err := filepath.EvalSymlinks(filepath.Join(r.user.Home(), path))
 	if err != nil {
 		if _, ok := err.(*os.PathError); ok {
 			return nil, engines.ErrResourceNotFound
@@ -41,7 +41,7 @@ func (r *resultSet) ExtractFile(path string) (ioext.ReadSeekCloser, error) {
 	// Cleanup the path
 	p = filepath.Clean(p)
 
-	prefix, err := filepath.EvalSymlinks(r.workingFolder.Path() + string(filepath.Separator))
+	prefix, err := filepath.EvalSymlinks(r.user.Home() + string(filepath.Separator))
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ func (r *resultSet) ExtractFile(path string) (ioext.ReadSeekCloser, error) {
 
 func (r *resultSet) ExtractFolder(path string, handler engines.FileHandler) error {
 	// Evaluate symlinks
-	p, err := filepath.EvalSymlinks(filepath.Join(r.workingFolder.Path(), path))
+	p, err := filepath.EvalSymlinks(filepath.Join(r.user.Home(), path))
 	if err != nil {
 		if _, ok := err.(*os.PathError); ok {
 			return engines.ErrResourceNotFound
@@ -85,7 +85,7 @@ func (r *resultSet) ExtractFolder(path string, handler engines.FileHandler) erro
 	// Cleanup the path
 	p = filepath.Clean(p)
 
-	prefix, err := filepath.EvalSymlinks(r.workingFolder.Path() + string(filepath.Separator))
+	prefix, err := filepath.EvalSymlinks(r.user.Home() + string(filepath.Separator))
 	if err != nil {
 		panic(err)
 	}
@@ -154,9 +154,11 @@ func (r *resultSet) Dispose() error {
 	}
 
 	// Remove temporary home folder
-	if rerr := r.workingFolder.Remove(); rerr != nil {
-		r.log.Error("Failed to remove temporary home directory, error: ", rerr)
-		err = rerr
+	if r.workingFolder != nil {
+		if rerr := r.workingFolder.Remove(); rerr != nil {
+			r.log.Error("Failed to remove temporary home directory, error: ", rerr)
+			err = rerr
+		}
 	}
 
 	return err

--- a/engines/native/sandbox.go
+++ b/engines/native/sandbox.go
@@ -30,37 +30,51 @@ type sandbox struct {
 	wg            atomics.WaitGroup
 }
 
-func newSandbox(b *sandboxBuilder) (*sandbox, error) {
-	// Create temporary home folder for the task
-	workingFolder, err := b.engine.environment.TemporaryStorage.NewFolder()
-	if err != nil {
-		b.log.Error("Failed to create temporary folder: ", err)
-		return nil, fmt.Errorf("Failed to temporary folder, error: %s", err)
-	}
-
-	if b.payload.Context != "" {
-		if err = fetchContext(b.payload.Context, workingFolder.Path()); err != nil {
-			b.context.LogError(err)
-			return nil, engines.NewMalformedPayloadError(
-				fmt.Sprintf("Error downloading %s: %v", b.payload.Context, err),
-			)
-		}
-	}
-
+func newSandbox(b *sandboxBuilder) (s *sandbox, err error) {
 	var user *system.User
+	var workingFolder runtime.TemporaryFolder
+
+	defer func() {
+		if err != nil {
+			if b.engine.config.CreateUser && user != nil {
+				user.Remove()
+			}
+
+			if workingFolder != nil {
+				_ = workingFolder.Remove()
+			}
+		}
+	}()
 
 	if b.engine.config.CreateUser {
+		// Create temporary home folder for the task
+		workingFolder, err = b.engine.environment.TemporaryStorage.NewFolder()
+		if err != nil {
+			err = fmt.Errorf("Failed to temporary folder, error: %s", err)
+			b.log.Error(err)
+			return
+		}
+
 		// Create temporary user account
 		user, err = system.CreateUser(workingFolder.Path(), b.engine.groups)
 		if err != nil {
-			workingFolder.Remove() // best-effort clean-up this is a fatal error
-			return nil, fmt.Errorf("Failed to create temporary system user, error: %s", err)
+			err = fmt.Errorf("Failed to create temporary system user, error: %s", err)
+			return
 		}
 	} else {
 		user, err = system.CurrentUser()
 		if err != nil {
-			workingFolder.Remove()
-			return nil, err
+			return
+		}
+	}
+
+	if b.payload.Context != "" {
+		if err = fetchContext(b.payload.Context, user); err != nil {
+			err = engines.NewMalformedPayloadError(
+				fmt.Sprintf("Error downloading %s: %v", b.payload.Context, err),
+			)
+			b.context.LogError(err)
+			return
 		}
 	}
 
@@ -69,7 +83,7 @@ func newSandbox(b *sandboxBuilder) (*sandbox, error) {
 		env[k] = v
 	}
 
-	env["HOME"] = workingFolder.Path()
+	env["HOME"] = user.Home()
 	env["USER"] = user.Name()
 	env["LOGNAME"] = user.Name()
 
@@ -78,26 +92,22 @@ func newSandbox(b *sandboxBuilder) (*sandbox, error) {
 	process, err := system.StartProcess(system.ProcessOptions{
 		Arguments:     b.payload.Command,
 		Environment:   env,
-		WorkingFolder: workingFolder.Path(),
+		WorkingFolder: user.Home(),
 		Owner:         user,
 		Stdout:        ioext.WriteNopCloser(b.context.LogDrain()),
 		// Stderr defaults to Stdout when not specified
 	})
 	if err != nil {
-		if b.engine.config.CreateUser {
-			user.Remove()
-		}
-
-		workingFolder.Remove()
-
 		// StartProcess provides human-readable error messages (see docs)
 		// We'll convert it to a MalformedPayloadError
-		return nil, engines.NewMalformedPayloadError(
+		err = engines.NewMalformedPayloadError(
 			"Unable to start specified command: ", b.payload.Command, "error: ", err,
 		)
+		b.context.LogError(err)
+		return
 	}
 
-	s := &sandbox{
+	s = &sandbox{
 		engine:        b.engine,
 		context:       b.context,
 		log:           b.log,
@@ -109,13 +119,13 @@ func newSandbox(b *sandboxBuilder) (*sandbox, error) {
 
 	go s.waitForTermination()
 
-	return s, nil
+	return
 }
 
-func fetchContext(context, destdir string) error {
+func fetchContext(context string, user *system.User) error {
 	// TODO: use future cache subsystem, when we have it
 	// TODO: use the soon to be merged fetcher subsystem
-	filename, err := util.Download(context, destdir)
+	filename, err := util.Download(context, user.Home())
 	if err != nil {
 		return fmt.Errorf("Error downloading '%s': %v", context, err)
 	}
@@ -124,6 +134,10 @@ func fetchContext(context, destdir string) error {
 	// TODO: abstract this away in system package
 	if err = os.Chmod(filename, 0700); err != nil {
 		return fmt.Errorf("Error setting file '%s' permissions: %v", filename, err)
+	}
+
+	if err = system.ChangeOwner(filename, user); err != nil {
+		return err
 	}
 
 	unpackedFile := ""
@@ -230,9 +244,10 @@ func (s *sandbox) Abort() error {
 		}
 
 		// Remove temporary home folder
-		err := s.workingFolder.Remove()
-		if err != nil {
-			s.log.Error("Failed to remove temporary home directory, error: ", err)
+		if s.workingFolder != nil {
+			if err := s.workingFolder.Remove(); err != nil {
+				s.log.Error("Failed to remove temporary home directory, error: ", err)
+			}
 		}
 
 		// Set result

--- a/engines/native/shell.go
+++ b/engines/native/shell.go
@@ -41,7 +41,7 @@ func newShell(s *sandbox, command []string, tty bool) (*shell, error) {
 	process, err := system.StartProcess(system.ProcessOptions{
 		Arguments:     command,
 		Environment:   s.env,
-		WorkingFolder: s.workingFolder.Path(),
+		WorkingFolder: s.user.Home(),
 		Owner:         s.user,
 		Stdin:         pipein,
 		Stdout:        pipeout,

--- a/engines/native/system/system_posix.go
+++ b/engines/native/system/system_posix.go
@@ -1,0 +1,31 @@
+// +build !windows,!plan9,!nacl
+
+package system
+
+import (
+	"fmt"
+	"os"
+	osuser "os/user"
+	"strconv"
+)
+
+// ChangeOwner changes the owner of filepath to the given user
+func ChangeOwner(filepath string, user *User) error {
+	u, err := osuser.Lookup(user.Name())
+	if err != nil {
+		return fmt.Errorf("Cannot lookup user %s: %v", user.Name(), err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return fmt.Errorf("Cannot convert uid(%s) to int: %v", u.Uid, err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return fmt.Errorf("Cannot convert gid(%s) to int: %v", u.Gid, err)
+	}
+	if err = os.Chown(filepath, uid, gid); err != nil {
+		return fmt.Errorf("Can't change owner of %s: %v", filepath, err)
+	}
+
+	return nil
+}

--- a/engines/native/system/system_windows.go
+++ b/engines/native/system/system_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package system
+
+// ChangeOwner changes the owner of filepath to the given user
+func ChangeOwner(filepath string, user *User) error {
+	panic("Not implemented")
+}

--- a/engines/native/system/user_darwin.go
+++ b/engines/native/system/user_darwin.go
@@ -183,6 +183,11 @@ func (u *User) Name() string {
 	return u.name
 }
 
+// Home returns the user home folder`
+func (u *User) Home() string {
+	return u.homeFolder
+}
+
 // return the next uid available
 func getMaxUID(d dscl) (int, error) {
 	uids, err := d.list("/Users", "uid")

--- a/engines/native/system/user_linux.go
+++ b/engines/native/system/user_linux.go
@@ -140,3 +140,8 @@ func (u *User) Remove() {
 func (u *User) Name() string {
 	return u.name
 }
+
+// Home returns the user home folder`
+func (u *User) Home() string {
+	return u.homeFolder
+}

--- a/engines/native/system/user_windows.go
+++ b/engines/native/system/user_windows.go
@@ -29,3 +29,8 @@ func (u *User) Remove() {
 func (u *User) Name() string {
 	return u.name
 }
+
+// Home returns the user home folder`
+func (u *User) Home() string {
+	return u.homeFolder
+}


### PR DESCRIPTION
We can get user's home directory either but looking at the $HOME
environment variable or read the OS specific user database.

As is common for scripts to look for home directory just by reading $HOME
environment variable, our first approach was to not change user database
and modify the $HOME variable to a temporary directory when spawning
the task command without creating a new user. This way, we could clobber
the task just by removing the $HOME directory.

This approach worked for most tests but xpcshell. Particularly, it checks
if $HOME matches user database, making this test to fail.

As we may not be allowed to change even the current user home directory,
we fix this by using the user's true home directory.

This implies that we only need to create a temporary directory if we
create a new user to run the task, otherwise it is not necessary. We
also need to explicitly set the correct owner of the context file.