### PR TITLE
Introduce a config setting to limit the number of tasks to be claimed

### DIFF
--- a/commands/work/work.go
+++ b/commands/work/work.go
@@ -49,7 +49,7 @@ func (cmd) Execute(args map[string]interface{}) bool {
 	select {
 	case <-c:
 		signal.Stop(c)
-		w.Stop()
+		w.ImmediateStop()
 		<-done
 	case <-done:
 	}

--- a/worker/config.go
+++ b/worker/config.go
@@ -35,6 +35,7 @@ type configType struct {
 	MaxLifeCycle     int                    `json:"maxLifeCycle"`
 	MinimumDiskSpace int64                  `json:"minimumDiskSpace"`
 	MinimumMemory    int64                  `json:"minimumMemory"`
+	MaxTasksToRun    int                    `json:"maxTasksToRun"`
 }
 
 type credentials struct {
@@ -219,8 +220,8 @@ func ConfigSchema() schematypes.Object {
 			"statelessDNSDomain": schematypes.String{},
 			"maxLifeCycle": schematypes.Integer{
 				MetaData: schematypes.MetaData{
-					Title:       "Max life cycle of worker",
-					Description: "Used to limit validity of hostname",
+					Title:       "Maximum lifetime of the worker in seconds",
+					Description: "Used to limit the time period for which the DNS server will return an IP for the given worker hostname",
 				},
 				Minimum: 5 * 60,
 				Maximum: 31 * 24 * 60 * 60,
@@ -228,7 +229,7 @@ func ConfigSchema() schematypes.Object {
 			"minimumDiskSpace": schematypes.Integer{
 				MetaData: schematypes.MetaData{
 					Title: "Minimum Disk Space",
-					Description: `The minimum amount of disk space to have available
+					Description: `The minimum amount of disk space in bytes to have available
 						before starting on the next task. Garbage collector will do a
 						best-effort attempt at releasing resources to satisfy this limit`,
 				},
@@ -238,12 +239,22 @@ func ConfigSchema() schematypes.Object {
 			"minimumMemory": schematypes.Integer{
 				MetaData: schematypes.MetaData{
 					Title: "Minimum Memory",
-					Description: `The minimum amount of memory to have available
+					Description: `The minimum amount of memory in bytes to have available
 						before starting on the next task. Garbage collector will do a
 						best-effort attempt at releasing resources to satisfy this limit`,
 				},
 				Minimum: 0,
 				Maximum: math.MaxInt64,
+			},
+			"maxTasksToRun": schematypes.Integer{
+				MetaData: schematypes.MetaData{
+					Title: "Number of tasks the worker should run before exiting",
+					Description: `If set to 0, the worker does not limit the number of tasks
+						it will claim and execute. For positive values > 0, the worker will
+						exit if it completes the given number of tasks.`,
+				},
+				Minimum: 0,
+				Maximum: math.MaxInt32,
 			},
 		},
 		Required: []string{

--- a/worker/taskmanager.go
+++ b/worker/taskmanager.go
@@ -63,6 +63,7 @@ func newTaskManager(
 		workerType:       config.WorkerType,
 		log:              log.WithField("component", "Queue Service"),
 		expirationOffset: config.ReclaimOffset,
+		maxTasksToRun:    config.MaxTasksToRun,
 	}
 
 	m := &Manager{

--- a/worker/taskmanager.go
+++ b/worker/taskmanager.go
@@ -105,8 +105,8 @@ func (m *Manager) Start() {
 	return
 }
 
-// Stop should be called when the worker should aggressively terminate all
-// running tasks and then gracefully terminate.
+// ImmediateStop should be called when the worker should aggressively terminate
+// all running tasks and then gracefully terminate.
 func (m *Manager) ImmediateStop() {
 	m.queue.Stop()
 	<-m.doneClaimingTasks

--- a/worker/taskmanager_test.go
+++ b/worker/taskmanager_test.go
@@ -374,6 +374,7 @@ func TestWorkerShutdown(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	assert.Equal(t, len(tm.RunningTasks()), 2)
 	close(tm.doneClaimingTasks)
+	close(tm.doneExecutingTasks)
 	tm.ImmediateStop()
 
 	wg.Wait()

--- a/worker/taskmanager_test.go
+++ b/worker/taskmanager_test.go
@@ -365,16 +365,16 @@ func TestWorkerShutdown(t *testing.T) {
 	go func() {
 		for _, c := range claims {
 			go func(claim *taskClaim) {
+				defer wg.Done()
 				tm.run(claim)
-				wg.Done()
 			}(c)
 		}
 	}()
 
 	time.Sleep(500 * time.Millisecond)
 	assert.Equal(t, len(tm.RunningTasks()), 2)
-	close(tm.done)
-	tm.Stop()
+	close(tm.doneClaimingTasks)
+	tm.ImmediateStop()
 
 	wg.Wait()
 	assert.Equal(t, 0, len(tm.RunningTasks()))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -140,13 +140,8 @@ func (w *Worker) Start() {
 
 	go w.tm.Start()
 
-	// if task manager stops executing tasks, stop the worker
-	go func() {
-		<-w.tm.doneExecutingTasks
-		w.ImmediateStop()
-	}()
-
 	select {
+	case <-w.tm.doneExecutingTasks:
 	case <-w.sm.WaitForShutdown():
 	case <-w.done:
 	}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -14,7 +14,7 @@ type mockedQueueService struct {
 }
 
 func (m *mockedQueueService) Start() <-chan *taskClaim {
-	defer m.worker.GracefulStop()
+	defer close(m.worker.tm.doneExecutingTasks)
 	defer close(m.worker.tm.doneClaimingTasks)
 	m.started = true
 	return make(chan *taskClaim)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -14,8 +14,8 @@ type mockedQueueService struct {
 }
 
 func (m *mockedQueueService) Start() <-chan *taskClaim {
-	defer m.worker.Stop()
-	defer close(m.worker.tm.done)
+	defer m.worker.GracefulStop()
+	defer close(m.worker.tm.doneClaimingTasks)
 	m.started = true
 	return make(chan *taskClaim)
 }


### PR DESCRIPTION
This makes integration testing easier (so tests can run worker to just pick up as many tasks as they have generated) and also makes it easier to customise worker behaviour from outside the worker (e.g. to execute arbitrary steps between each task).