### PR TITLE
Make sure Env is not nil but an empty map, if no env supplied in task payload

### DIFF
--- a/plugins/env/env.go
+++ b/plugins/env/env.go
@@ -48,11 +48,11 @@ var payloadSchema = schematypes.Object{
 	},
 }
 
-func (plugin) PayloadSchema() schematypes.Object {
+func (*plugin) PayloadSchema() schematypes.Object {
 	return payloadSchema
 }
 
-func (pl plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
+func (pl *plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
 	p := payloadType{
 		Env: map[string]string{},
 	}
@@ -67,7 +67,7 @@ func (pl plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskP
 		p.Env[k] = v
 	}
 
-	return taskPlugin{
+	return &taskPlugin{
 		TaskPluginBase: plugins.TaskPluginBase{},
 		variables:      p.Env,
 	}, nil
@@ -78,7 +78,7 @@ type taskPlugin struct {
 	variables map[string]string
 }
 
-func (p taskPlugin) BuildSandbox(sandboxBuilder engines.SandboxBuilder) error {
+func (p *taskPlugin) BuildSandbox(sandboxBuilder engines.SandboxBuilder) error {
 	for k, v := range p.variables {
 		err := sandboxBuilder.SetEnvironmentVariable(k, v)
 
@@ -105,22 +105,22 @@ type pluginProvider struct {
 	plugins.PluginProviderBase
 }
 
-func (pluginProvider) NewPlugin(options plugins.PluginOptions) (plugins.Plugin, error) {
+func (*pluginProvider) NewPlugin(options plugins.PluginOptions) (plugins.Plugin, error) {
 	var c config
 	if err := schematypes.MustMap(configSchema, options.Config, &c); err != nil {
 		return nil, engines.ErrContractViolation
 	}
 
-	return plugin{
+	return &plugin{
 		PluginBase: plugins.PluginBase{},
 		extraVars:  c.Extra,
 	}, nil
 }
 
-func (pluginProvider) ConfigSchema() schematypes.Schema {
+func (*pluginProvider) ConfigSchema() schematypes.Schema {
 	return configSchema
 }
 
 func init() {
-	plugins.Register("env", pluginProvider{})
+	plugins.Register("env", &pluginProvider{})
 }

--- a/plugins/env/env.go
+++ b/plugins/env/env.go
@@ -53,7 +53,9 @@ func (plugin) PayloadSchema() schematypes.Object {
 }
 
 func (pl plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
-	var p payloadType
+	p := payloadType{
+		Env: map[string]string{},
+	}
 	err := payloadSchema.Map(options.Payload, &p)
 	if err == schematypes.ErrTypeMismatch {
 		panic("internal error -- type mismatch")

--- a/plugins/env/env.go
+++ b/plugins/env/env.go
@@ -53,10 +53,12 @@ func (*plugin) PayloadSchema() schematypes.Object {
 }
 
 func (pl *plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
-	p := payloadType{
+	p := &payloadType{
+		// Must explicitly create an empty map, so if payload does not include
+		// env vars, we'll still have a valid map to read from/write to.
 		Env: map[string]string{},
 	}
-	err := payloadSchema.Map(options.Payload, &p)
+	err := payloadSchema.Map(options.Payload, p)
 	if err == schematypes.ErrTypeMismatch {
 		panic("internal error -- type mismatch")
 	} else if err != nil {


### PR DESCRIPTION
@jonasfj seem reasonable? Basically, if no env is in task payload, you'd end up having a nil map, which you then can't later modify. Maybe `Map` should take care of this, this was just a quick fix.