### PR TITLE
Skip test that fails if running on Windows, until Windows is supported

### DIFF
--- a/commands/qemu-guest-tools/actions_test.go
+++ b/commands/qemu-guest-tools/actions_test.go
@@ -40,7 +40,7 @@ func assert(condition bool, a ...interface{}) {
 func TestGuestToolsProcessingActions(t *testing.T) {
 	// Doesn't currently run on Windows, let's skip until Windows is a priority
 	if goruntime.GOOS == "windows" {
-		t.Skip("Skipping on Windows - when we have native engine running on Windows, we should reenable!")
+		t.Skip("Skipping on Windows - when we start supporting Windows, we should reenable!")
 	}
 	// Create temporary storage
 	storage, err := runtime.NewTemporaryStorage(os.TempDir())

--- a/commands/qemu-guest-tools/actions_test.go
+++ b/commands/qemu-guest-tools/actions_test.go
@@ -38,6 +38,10 @@ func assert(condition bool, a ...interface{}) {
 }
 
 func TestGuestToolsProcessingActions(t *testing.T) {
+	// Doesn't currently run on Windows, let's skip until Windows is a priority
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - when we have native engine running on Windows, we should reenable!")
+	}
 	// Create temporary storage
 	storage, err := runtime.NewTemporaryStorage(os.TempDir())
 	if err != nil {


### PR DESCRIPTION
Probably would be better to fix, but at the moment I don't have the time to dive in to find out why this is failing.