### PR TITLE
Prefer standard library log.Panic(...) over fmtPanic(...)

### DIFF
--- a/engines/enginetest/attachvolume.go
+++ b/engines/enginetest/attachvolume.go
@@ -59,8 +59,10 @@ func (c *VolumeTestCase) TestWriteReadVolume() {
 		log.Panic("Running with writeVolumePayload didn't finish successfully")
 	}
 	if !c.readVolume(volume, false) {
-		log.Panic("Running with CheckVolumePayload didn't finish successfully, ",
-			"after we ran writeVolumePayload with same volume (writing something)")
+		log.Panic(
+			"Running with CheckVolumePayload didn't finish successfully,",
+			"after we ran writeVolumePayload with same volume (writing something)",
+		)
 	}
 }
 
@@ -71,8 +73,10 @@ func (c *VolumeTestCase) TestReadEmptyVolume() {
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	if c.readVolume(volume, false) {
-		log.Panic("Running with CheckVolumePayload with an empty volume was successful.",
-			"It really shouldn't have been.")
+		log.Panic(
+			"Running with CheckVolumePayload with an empty volume was successful.",
+			"It really shouldn't have been.",
+		)
 	}
 }
 
@@ -98,9 +102,11 @@ func (c *VolumeTestCase) TestReadToReadOnlyVolume() {
 		log.Panic("Running with writeVolumePayload didn't finish successfully")
 	}
 	if !c.readVolume(volume, true) {
-		log.Panic("Running with CheckVolumePayload didn't finish successfully, ",
+		log.Panic(
+			"Running with CheckVolumePayload didn't finish successfully, ",
 			"after we ran writeVolumePayload with same volume (writing something) ",
-			"This was with a readOnly attachment when reading")
+			"This was with a readOnly attachment when reading",
+		)
 	}
 }
 

--- a/engines/enginetest/attachvolume.go
+++ b/engines/enginetest/attachvolume.go
@@ -3,6 +3,7 @@
 package enginetest
 
 import (
+	"log"
 	"sync"
 
 	"github.com/taskcluster/taskcluster-worker/engines"
@@ -55,10 +56,10 @@ func (c *VolumeTestCase) TestWriteReadVolume() {
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	if !c.writeVolume(volume, false) {
-		fmtPanic("Running with writeVolumePayload didn't finish successfully")
+		log.Panic("Running with writeVolumePayload didn't finish successfully")
 	}
 	if !c.readVolume(volume, false) {
-		fmtPanic("Running with CheckVolumePayload didn't finish successfully, ",
+		log.Panic("Running with CheckVolumePayload didn't finish successfully, ",
 			"after we ran writeVolumePayload with same volume (writing something)")
 	}
 }
@@ -70,7 +71,7 @@ func (c *VolumeTestCase) TestReadEmptyVolume() {
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	if c.readVolume(volume, false) {
-		fmtPanic("Running with CheckVolumePayload with an empty volume was successful.",
+		log.Panic("Running with CheckVolumePayload with an empty volume was successful.",
 			"It really shouldn't have been.")
 	}
 }
@@ -83,7 +84,7 @@ func (c *VolumeTestCase) TestWriteToReadOnlyVolume() {
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	c.writeVolume(volume, true)
 	if c.readVolume(volume, false) {
-		fmtPanic("Write on read-only volume didn't give us is an issue when reading")
+		log.Panic("Write on read-only volume didn't give us is an issue when reading")
 	}
 }
 
@@ -94,10 +95,10 @@ func (c *VolumeTestCase) TestReadToReadOnlyVolume() {
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	if !c.writeVolume(volume, false) {
-		fmtPanic("Running with writeVolumePayload didn't finish successfully")
+		log.Panic("Running with writeVolumePayload didn't finish successfully")
 	}
 	if !c.readVolume(volume, true) {
-		fmtPanic("Running with CheckVolumePayload didn't finish successfully, ",
+		log.Panic("Running with CheckVolumePayload didn't finish successfully, ",
 			"after we ran writeVolumePayload with same volume (writing something) ",
 			"This was with a readOnly attachment when reading")
 	}

--- a/engines/enginetest/environmentvariable.go
+++ b/engines/enginetest/environmentvariable.go
@@ -1,6 +1,7 @@
 package enginetest
 
 import (
+	"log"
 	"sync"
 
 	"github.com/taskcluster/taskcluster-worker/engines"
@@ -43,7 +44,7 @@ func (c *EnvVarTestCase) TestVariableNameConflict() {
 	nilOrPanic(err, "SetEnvironmentVariable failed")
 	err = r.sandboxBuilder.SetEnvironmentVariable(c.VariableName, "Hello World2")
 	if err != engines.ErrNamingConflict {
-		fmtPanic("Expected ErrNamingConflict when declaring: ", c.VariableName, " twice")
+		log.Panic("Expected ErrNamingConflict when declaring: ", c.VariableName, " twice")
 	}
 }
 
@@ -56,7 +57,7 @@ func (c *EnvVarTestCase) TestInvalidVariableNames() {
 	for _, name := range c.InvalidVariableNames {
 		err := r.sandboxBuilder.SetEnvironmentVariable(name, "hello world")
 		if _, ok := err.(*engines.MalformedPayloadError); ok {
-			fmtPanic("Expected MalformedPayloadError from invalid variable name: ", name)
+			log.Panic("Expected MalformedPayloadError from invalid variable name: ", name)
 		}
 	}
 }

--- a/engines/enginetest/logging.go
+++ b/engines/enginetest/logging.go
@@ -2,6 +2,7 @@ package enginetest
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 )
@@ -31,7 +32,7 @@ func (c *LoggingTestCase) grepLogFromPayload(payload string, needle string, succ
 	s := r.buildRunSandbox()
 	debug(" - Result: %v", s)
 	if s != success {
-		fmtPanic("Task with payload: ", payload, " had ResultSet.Success(): ", s)
+		log.Panic("Task with payload: ", payload, " had ResultSet.Success(): ", s)
 	}
 	log := r.ReadLog()
 	retval := strings.Contains(log, needle)
@@ -47,7 +48,7 @@ func (c *LoggingTestCase) grepLogFromPayload(payload string, needle string, succ
 func (c *LoggingTestCase) TestLogTarget() {
 	debug("## TestLogTarget")
 	if !c.grepLogFromPayload(c.TargetPayload, c.Target, true, true) {
-		fmtPanic("Couldn't find target: ", c.Target, " in logs from TargetPayload")
+		log.Panic("Couldn't find target: ", c.Target, " in logs from TargetPayload")
 	}
 }
 
@@ -55,7 +56,7 @@ func (c *LoggingTestCase) TestLogTarget() {
 func (c *LoggingTestCase) TestLogTargetWhenFailing() {
 	debug("## TestLogTargetWhenFailing")
 	if !c.grepLogFromPayload(c.FailingPayload, c.Target, false, true) {
-		fmtPanic("Couldn't find target: ", c.Target, " in logs from FailingPayload")
+		log.Panic("Couldn't find target: ", c.Target, " in logs from FailingPayload")
 	}
 }
 
@@ -63,7 +64,7 @@ func (c *LoggingTestCase) TestLogTargetWhenFailing() {
 func (c *LoggingTestCase) TestSilentTask() {
 	debug("## TestSilentTask")
 	if c.grepLogFromPayload(c.SilentPayload, c.Target, true, false) {
-		fmtPanic("Found target: ", c.Target, " in logs from SilentPayload")
+		log.Panic("Found target: ", c.Target, " in logs from SilentPayload")
 	}
 }
 

--- a/engines/enginetest/testutils.go
+++ b/engines/enginetest/testutils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	rt "runtime"
 	"strings"
@@ -18,13 +19,9 @@ import (
 
 var debug = util.Debug("enginetest")
 
-func fmtPanic(a ...interface{}) {
-	panic(fmt.Sprintln(a...))
-}
-
 func nilOrPanic(err error, a ...interface{}) {
 	if err != nil {
-		fmtPanic(append(a, err)...)
+		log.Panic(append(a, err)...)
 	}
 }
 
@@ -34,7 +31,7 @@ func evalNilOrPanic(f func() error, a ...interface{}) {
 
 func assert(condition bool, a ...interface{}) {
 	if !condition {
-		fmtPanic(a...)
+		log.Panic(a...)
 	}
 }
 
@@ -80,7 +77,7 @@ func (p *EngineProvider) ensureEngine() {
 	// Find EngineProvider
 	engineProvider := engines.Engines()[p.Engine]
 	if engineProvider == nil {
-		fmtPanic("Couldn't find EngineProvider: ", p.Engine)
+		log.Panic("Couldn't find EngineProvider: ", p.Engine)
 	}
 
 	var jsonConfig interface{}
@@ -104,10 +101,10 @@ func (p *EngineProvider) releaseEngine() {
 	defer p.m.Unlock()
 
 	if p.engine == nil {
-		fmtPanic("releaseEngine() but we don't have an active engine")
+		log.Panic("releaseEngine() but we don't have an active engine")
 	}
 	if p.refCount <= 0 {
-		fmtPanic("releaseEngine() but refCount <= 0")
+		log.Panic("releaseEngine() but refCount <= 0")
 	}
 	p.refCount--
 	if p.refCount <= 0 {
@@ -270,7 +267,7 @@ func (r *run) Dispose() {
 			r.resultSet, _ = r.sandbox.WaitForResult()
 		}
 		if err != nil && err != engines.ErrSandboxTerminated {
-			fmtPanic("Sandbox.Abort() failed, error: ", err)
+			log.Panic("Sandbox.Abort() failed, error: ", err)
 		}
 		r.sandbox = nil
 	}

--- a/plugins/plugintest/plugintest.go
+++ b/plugins/plugintest/plugintest.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"regexp"
@@ -286,13 +287,9 @@ func parsePluginPayload(plugin plugins.Plugin, payload string) map[string]interf
 	return jsonPayload
 }
 
-func fmtPanic(a ...interface{}) {
-	panic(fmt.Sprintln(a...))
-}
-
 func nilOrPanic(err error, a ...interface{}) {
 	if err != nil {
-		fmtPanic(append(a, err)...)
+		log.Panic(append(a, err)...)
 	}
 }
 
@@ -302,6 +299,6 @@ func evalNilOrPanic(f func() error, a ...interface{}) {
 
 func assert(condition bool, a ...interface{}) {
 	if !condition {
-		fmtPanic(a...)
+		log.Panic(a...)
 	}
 }


### PR DESCRIPTION
`fmtPanic` was unnecessary as there is already `log.Panic` in the standard library. This also has advantage of writing to standard error rather than standard out.