### PR TITLE
Tests should log using t.Log rather than fmt.Print, and should fail rather than panic

### DIFF
--- a/commands/qemu-guest-tools/actions_test.go
+++ b/commands/qemu-guest-tools/actions_test.go
@@ -3,7 +3,6 @@ package qemuguesttools
 import (
 	"bytes"
 	"crypto/rand"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http/httptest"
@@ -21,19 +20,15 @@ import (
 	"github.com/taskcluster/taskcluster-worker/runtime"
 )
 
-func fmtPanic(a ...interface{}) {
-	panic(fmt.Sprintln(a...))
-}
-
-func nilOrPanic(err error, a ...interface{}) {
+func nilOrFatal(t *testing.T, err error, a ...interface{}) {
 	if err != nil {
-		fmtPanic(append(a, err)...)
+		t.Fatal(append(a, err)...)
 	}
 }
 
-func assert(condition bool, a ...interface{}) {
+func assert(t *testing.T, condition bool, a ...interface{}) {
 	if !condition {
-		fmtPanic(a...)
+		t.Fatal(a...)
 	}
 }
 
@@ -82,68 +77,68 @@ func TestGuestToolsProcessingActions(t *testing.T) {
 
 	testFile := filepath.Join(f.Path(), "hello.txt")
 	err = ioutil.WriteFile(testFile, []byte("hello-world"), 0777)
-	nilOrPanic(err, "Failed to create testFile: ", testFile)
+	nilOrFatal(t, err, "Failed to create testFile: ", testFile)
 
 	debug(" - request file: %s", testFile)
 	r, err := meta.GetArtifact(testFile)
-	nilOrPanic(err, "meta.GetArtifact failed, error: ", err)
+	nilOrFatal(t, err, "meta.GetArtifact failed, error: ", err)
 
 	debug(" - reading testFile")
 	data, err := ioutil.ReadAll(r)
-	nilOrPanic(err, "Failed to read testFile")
+	nilOrFatal(t, err, "Failed to read testFile")
 	debug(" - read: '%s'", string(data))
-	assert(string(data) == "hello-world", "Wrong payload: ", string(data))
+	assert(t, string(data) == "hello-world", "Wrong payload: ", string(data))
 
 	////////////////////
 	debug("### Test meta.GetArtifact (missing file)")
 	r, err = meta.GetArtifact(filepath.Join(f.Path(), "missing-file.txt"))
-	assert(r == nil, "Expected error wihtout a reader")
-	assert(err == engines.ErrResourceNotFound, "Expected ErrResourceNotFound")
+	assert(t, r == nil, "Expected error wihtout a reader")
+	assert(t, err == engines.ErrResourceNotFound, "Expected ErrResourceNotFound")
 
 	////////////////////
 	debug("### Test meta.ListFolder")
 	testFolder := filepath.Join(f.Path(), "test-folder")
 	err = os.Mkdir(testFolder, 0777)
-	nilOrPanic(err, "Failed to create test-folder/")
+	nilOrFatal(t, err, "Failed to create test-folder/")
 
 	testFile2 := filepath.Join(testFolder, "hello2.txt")
 	err = ioutil.WriteFile(testFile2, []byte("hello-world-2"), 0777)
-	nilOrPanic(err, "Failed to create testFile2: ", testFile2)
+	nilOrFatal(t, err, "Failed to create testFile2: ", testFile2)
 
 	debug(" - meta.ListFolder")
 	files, err := meta.ListFolder(f.Path())
-	nilOrPanic(err, "ListFolder failed, err: ", err)
+	nilOrFatal(t, err, "ListFolder failed, err: ", err)
 
-	assert(len(files) == 2, "Expected 2 files")
-	assert(files[0] == testFile || files[1] == testFile, "Expected testFile")
-	assert(files[0] == testFile2 || files[1] == testFile2, "Expected testFile2")
+	assert(t, len(files) == 2, "Expected 2 files")
+	assert(t, files[0] == testFile || files[1] == testFile, "Expected testFile")
+	assert(t, files[0] == testFile2 || files[1] == testFile2, "Expected testFile2")
 
 	////////////////////
 	debug("### Test meta.ListFolder (missing folder)")
 	files, err = meta.ListFolder(filepath.Join(f.Path(), "no-such-folder"))
-	assert(files == nil, "Expected files == nil, we hopefully have an error")
-	assert(err == engines.ErrResourceNotFound, "Expected ErrResourceNotFound")
+	assert(t, files == nil, "Expected files == nil, we hopefully have an error")
+	assert(t, err == engines.ErrResourceNotFound, "Expected ErrResourceNotFound")
 
 	////////////////////
 	debug("### Test meta.ListFolder (empty folder)")
 	emptyFolder := filepath.Join(f.Path(), "empty-folder")
 	err = os.Mkdir(emptyFolder, 0777)
-	nilOrPanic(err, "Failed to create empty-folder/")
+	nilOrFatal(t, err, "Failed to create empty-folder/")
 
 	files, err = meta.ListFolder(emptyFolder)
-	assert(len(files) == 0, "Expected zero files")
-	assert(err == nil, "Didn't expect any error")
+	assert(t, len(files) == 0, "Expected zero files")
+	assert(t, err == nil, "Didn't expect any error")
 
 	////////////////////
-	testShellHello(meta)
-	testShellCat(meta)
-	testShellCatStdErr(meta)
+	testShellHello(t, meta)
+	testShellCat(t, meta)
+	testShellCatStdErr(t, meta)
 }
 
-func testShellHello(meta *metaservice.MetaService) {
+func testShellHello(t *testing.T, meta *metaservice.MetaService) {
 	debug("### Test meta.Shell (using 'echo hello')")
 	shell, err := meta.ExecShell(nil, false)
-	nilOrPanic(err, "Failed to call meta.ExecShell()")
+	nilOrFatal(t, err, "Failed to call meta.ExecShell()")
 
 	readHello := sync.WaitGroup{}
 	readHello.Add(1)
@@ -165,7 +160,7 @@ func testShellHello(meta *metaservice.MetaService) {
 				break
 			}
 			if werr != nil {
-				assert(werr == io.EOF, "Expected EOF!")
+				assert(t, werr == io.EOF, "Expected EOF!")
 				break
 			}
 		}
@@ -174,14 +169,14 @@ func testShellHello(meta *metaservice.MetaService) {
 	}()
 
 	success, err := shell.Wait()
-	nilOrPanic(err, "Got an error from shell.Wait, error: ", err)
-	assert(success, "Expected success from shell, we closed with end of stdin")
+	nilOrFatal(t, err, "Got an error from shell.Wait, error: ", err)
+	assert(t, success, "Expected success from shell, we closed with end of stdin")
 }
 
-func testShellCat(meta *metaservice.MetaService) {
+func testShellCat(t *testing.T, meta *metaservice.MetaService) {
 	debug("### Test meta.Shell (using 'exec cat -')")
 	shell, err := meta.ExecShell(nil, false)
-	nilOrPanic(err, "Failed to call meta.ExecShell()")
+	nilOrFatal(t, err, "Failed to call meta.ExecShell()")
 
 	input := make([]byte, 42*1024*1024+7)
 	rand.Read(input)
@@ -206,23 +201,23 @@ func testShellCat(meta *metaservice.MetaService) {
 	outputDone.Add(1)
 	go func() {
 		data, rerr := ioutil.ReadAll(shell.StdoutPipe())
-		nilOrPanic(rerr, "Got error from stdout pipe, error: ", rerr)
+		nilOrFatal(t, rerr, "Got error from stdout pipe, error: ", rerr)
 		output = data
 		outputDone.Done()
 	}()
 
 	success, err := shell.Wait()
-	nilOrPanic(err, "Got an error from shell.Wait, error: ", err)
-	assert(success, "Expected success from shell, we closed with end of stdin")
+	nilOrFatal(t, err, "Got an error from shell.Wait, error: ", err)
+	assert(t, success, "Expected success from shell, we closed with end of stdin")
 	outputDone.Wait()
-	assert(bytes.Equal(output, input), "Expected data to match input, ",
+	assert(t, bytes.Equal(output, input), "Expected data to match input, ",
 		"len(input) = ", len(input), " len(output) = ", len(output))
 }
 
-func testShellCatStdErr(meta *metaservice.MetaService) {
+func testShellCatStdErr(t *testing.T, meta *metaservice.MetaService) {
 	debug("### Test meta.Shell (using 'exec cat - 1>&2')")
 	shell, err := meta.ExecShell(nil, false)
-	nilOrPanic(err, "Failed to call meta.ExecShell()")
+	nilOrFatal(t, err, "Failed to call meta.ExecShell()")
 
 	input := make([]byte, 4*1024*1024+37)
 	rand.Read(input)
@@ -247,15 +242,15 @@ func testShellCatStdErr(meta *metaservice.MetaService) {
 	outputDone.Add(1)
 	go func() {
 		data, rerr := ioutil.ReadAll(shell.StderrPipe())
-		nilOrPanic(rerr, "Got error from stderr pipe, error: ", rerr)
+		nilOrFatal(t, rerr, "Got error from stderr pipe, error: ", rerr)
 		output = data
 		outputDone.Done()
 	}()
 
 	success, err := shell.Wait()
-	nilOrPanic(err, "Got an error from shell.Wait, error: ", err)
-	assert(success, "Expected success from shell, we closed with end of stdin")
+	nilOrFatal(t, err, "Got an error from shell.Wait, error: ", err)
+	assert(t, success, "Expected success from shell, we closed with end of stdin")
 	outputDone.Wait()
-	assert(bytes.Equal(output, input), "Expected data to match input, ",
+	assert(t, bytes.Equal(output, input), "Expected data to match input, ",
 		"len(input) = ", len(input), " len(output) = ", len(output))
 }

--- a/engines/osxnative/user_test.go
+++ b/engines/osxnative/user_test.go
@@ -3,7 +3,6 @@
 package osxnative
 
 import (
-	"fmt"
 	"os"
 	osuser "os/user"
 	"strings"
@@ -36,7 +35,8 @@ func TestUser(t *testing.T) {
 	for _, group := range groups[1:] {
 		var members string
 		members, err = u.d.read("/Groups/"+group, "GroupMembership")
-		fmt.Println(members)
+		assert.NoError(t, err)
+		t.Log(members)
 		assert.True(t, strings.Contains(members, u.name))
 	}
 

--- a/engines/qemu/image/util_test.go
+++ b/engines/qemu/image/util_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -13,19 +12,15 @@ import (
 	"github.com/taskcluster/slugid-go/slugid"
 )
 
-func fmtPanic(a ...interface{}) {
-	panic(fmt.Sprintln(a...))
-}
-
-func nilOrPanic(err error, a ...interface{}) {
+func nilOrFatal(t *testing.T, err error, a ...interface{}) {
 	if err != nil {
-		fmtPanic(append(a, err)...)
+		t.Fatal(append(a, err)...)
 	}
 }
 
-func assert(condition bool, a ...interface{}) {
+func assert(t *testing.T, condition bool, a ...interface{}) {
 	if !condition {
-		fmtPanic(a...)
+		t.Fatal(a...)
 	}
 }
 
@@ -43,12 +38,12 @@ func TestDownloadImageOK(t *testing.T) {
 
 	// Download test url to the target file
 	err := DownloadImage(s.URL)(targetFile)
-	nilOrPanic(err, "Failed to download from testserver")
+	nilOrFatal(t, err, "Failed to download from testserver")
 
 	result, err := ioutil.ReadFile(targetFile)
-	nilOrPanic(err, "Failed to read targetFile, error: ", err)
+	nilOrFatal(t, err, "Failed to read targetFile, error: ", err)
 	text := string(result)
-	assert(text == "hello world", "Expected hello world, got ", text)
+	assert(t, text == "hello world", "Expected hello world, got ", text)
 }
 
 func TestDownloadImageRetry(t *testing.T) {
@@ -70,6 +65,6 @@ func TestDownloadImageRetry(t *testing.T) {
 
 	// Download test url to the target file
 	err := DownloadImage(s.URL)(targetFile)
-	assert(err != nil, "Expected an error")
-	assert(count == 7, "Expected 7 attempts, got: ", count)
+	assert(t, err != nil, "Expected an error")
+	assert(t, count == 7, "Expected 7 attempts, got: ", count)
 }

--- a/engines/qemu/metaservice/utils_test.go
+++ b/engines/qemu/metaservice/utils_test.go
@@ -1,19 +1,15 @@
 package metaservice
 
-import "fmt"
+import "testing"
 
-func fmtPanic(a ...interface{}) {
-	panic(fmt.Sprintln(a...))
-}
-
-func nilOrPanic(err error, a ...interface{}) {
+func nilOrFatal(t *testing.T, err error, a ...interface{}) {
 	if err != nil {
-		fmtPanic(append(a, err)...)
+		t.Fatal(append(a, err)...)
 	}
 }
 
-func assert(condition bool, a ...interface{}) {
+func assert(t *testing.T, condition bool, a ...interface{}) {
 	if !condition {
-		fmtPanic(a...)
+		t.Fatal(a...)
 	}
 }

--- a/engines/qemu/network/utils_test.go
+++ b/engines/qemu/network/utils_test.go
@@ -1,19 +1,15 @@
 package network
 
-import "fmt"
+import "testing"
 
-func fmtPanic(a ...interface{}) {
-	panic(fmt.Sprintln(a...))
-}
-
-func nilOrPanic(err error, a ...interface{}) {
+func nilOrFatal(t *testing.T, err error, a ...interface{}) {
 	if err != nil {
-		fmtPanic(append(a, err)...)
+		t.Fatal(append(a, err)...)
 	}
 }
 
-func assert(condition bool, a ...interface{}) {
+func assert(t *testing.T, condition bool, a ...interface{}) {
 	if !condition {
-		fmtPanic(a...)
+		t.Fatal(a...)
 	}
 }

--- a/engines/qemu/qemuengine_test.go
+++ b/engines/qemu/qemuengine_test.go
@@ -5,6 +5,7 @@ package qemuengine
 import (
 	"flag"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -24,12 +25,12 @@ func makeTestServer() *httptest.Server {
 		w.WriteHeader(http.StatusOK)
 		f, err := os.Open(testImageFile)
 		if err != nil {
-			fmtPanic("Unexpected error opening image file, err: ", err)
+			log.Panic("Unexpected error opening image file, err: ", err)
 		}
 		defer f.Close()
 		_, err = io.Copy(w, f)
 		if err != nil && err != io.EOF {
-			fmtPanic("Unexpected error copying image file, err: ", err)
+			log.Panic("Unexpected error copying image file, err: ", err)
 		}
 	})
 	return httptest.NewServer(handler)

--- a/engines/qemu/utils_test.go
+++ b/engines/qemu/utils_test.go
@@ -1,19 +1,15 @@
 package qemuengine
 
-import "fmt"
+import "testing"
 
-func fmtPanic(a ...interface{}) {
-	panic(fmt.Sprintln(a...))
-}
-
-func nilOrPanic(err error, a ...interface{}) {
+func nilOrFatal(t *testing.T, err error, a ...interface{}) {
 	if err != nil {
-		fmtPanic(append(a, err)...)
+		t.Fatal(append(a, err)...)
 	}
 }
 
-func assert(condition bool, a ...interface{}) {
+func assert(t *testing.T, condition bool, a ...interface{}) {
 	if !condition {
-		fmtPanic(a...)
+		t.Fatal(a...)
 	}
 }

--- a/runtime/gc/gc_test.go
+++ b/runtime/gc/gc_test.go
@@ -31,57 +31,57 @@ func (r *myResource) Dispose() error {
 }
 
 func TestGarbageCollector(t *testing.T) {
-	fmt.Println(" - Create GC")
+	t.Log(" - Create GC")
 	gc := &GarbageCollector{}
 	err := gc.CollectAll()
 	assert(err == nil, "Didn't expect error: ", err)
 
-	fmt.Println(" - Create r1")
+	t.Log(" - Create r1")
 	r1 := &myResource{}
 	gc.Register(r1)
 	assert(r1.disposed == false, "Not disposed")
 
-	fmt.Println(" - CollectAll() disposing r1")
+	t.Log(" - CollectAll() disposing r1")
 	gc.CollectAll()
 	assert(r1.disposed, "Expected it to be disposed")
 
-	fmt.Println(" - Create r2 and Acquire")
+	t.Log(" - Create r2 and Acquire")
 	r2 := &myResource{}
 	r2.Acquire()
 	gc.Register(r2)
 	assert(r2.disposed == false, "Not disposed")
 
-	fmt.Println(" - CollectAll() disposing nothing")
+	t.Log(" - CollectAll() disposing nothing")
 	gc.CollectAll()
 	assert(r2.disposed == false, "Not disposed")
 
-	fmt.Println(" - Release and CollectAll()")
+	t.Log(" - Release and CollectAll()")
 	r2.Release()
 	assert(r2.disposed == false, "Not disposed")
 	gc.CollectAll()
 	assert(r2.disposed, "disposed")
 
-	fmt.Println(" - Create r3 and Acquire")
+	t.Log(" - Create r3 and Acquire")
 	r3 := &myResource{}
 	r3.Acquire()
 	gc.Register(r3)
 	assert(r3.disposed == false, "Not disposed")
 
-	fmt.Println(" - CollectAll() getting nothing")
+	t.Log(" - CollectAll() getting nothing")
 	gc.CollectAll()
 	assert(r3.disposed == false, "Not disposed")
 
-	fmt.Println(" - Acquire() and CollectAll() getting nothing")
+	t.Log(" - Acquire() and CollectAll() getting nothing")
 	r3.Acquire()
 	gc.CollectAll()
 	assert(r3.disposed == false, "Not disposed")
 
-	fmt.Println(" - Release() and CollectAll() getting nothing")
+	t.Log(" - Release() and CollectAll() getting nothing")
 	r3.Release()
 	gc.CollectAll()
 	assert(r3.disposed == false, "Not disposed")
 
-	fmt.Println(" - Release and CollectAll() getting r3")
+	t.Log(" - Release and CollectAll() getting r3")
 	r3.Release()
 	assert(r3.disposed == false, "Not disposed")
 	gc.CollectAll()

--- a/runtime/ioext/blockedpipe_test.go
+++ b/runtime/ioext/blockedpipe_test.go
@@ -24,7 +24,7 @@ func TestBlockedPipe(t *testing.T) {
 		p := make([]byte, 4)
 		n, err := io.ReadFull(r, p)
 		if n != 4 || string(p[:n]) != "1234" {
-			fmt.Printf("read data: '%s', n = %d\n", string(p), n)
+			t.Logf("read data: '%s', n = %d\n", string(p), n)
 			panic("Wrong data read")
 		}
 		if err != nil {
@@ -36,7 +36,7 @@ func TestBlockedPipe(t *testing.T) {
 		p = make([]byte, 5)
 		n, err = io.ReadFull(r, p)
 		if n != 4 || string(p[:n]) != "5678" {
-			fmt.Printf("read data: '%s', n = %d\n", string(p), n)
+			t.Logf("read data: '%s', n = %d\n", string(p), n)
 			panic("Wrong data read")
 		}
 		if err != io.ErrUnexpectedEOF {
@@ -116,19 +116,19 @@ func TestBlockedPipeClosedPipe(t *testing.T) {
 	}
 
 	// Close the pipe
-	fmt.Println("- Closing")
+	t.Log("- Closing")
 	if r.Close() != nil {
 		panic("didn't think we should get an error here")
 	}
-	fmt.Println("- Closed")
+	t.Log("- Closed")
 
 	// Now we should be all done
 	<-allDone
-	fmt.Println("- allDone")
+	t.Log("- allDone")
 
 	// And we should have cleanedup, not leaking anything that would be bad
 	<-cleanedup
-	fmt.Println("- Cleanup")
+	t.Log("- Cleanup")
 }
 
 func TestBlockedReachesEOF(t *testing.T) {


### PR DESCRIPTION
This changes tests to use `t.Fatal` rather than `panic`, and also to use `t.Log` to log in tests, so that the output is only shown if either `-v` is passed in tests, or the test actually fails.