### PR TITLE
Monitor wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage.out
 /mock-config.yml
 /qemu-config.yml
 /vendor/*/
+/config.env

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Adding Dependencies
 ---------------------
 
 ```
-go get <package>
-govendor add +ext <package>
+govendor get <package>
+govendor add +vendor <package>
 git add vendor/vendor.json
 git commit -m 'My new package.'
 ```

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Adding Dependencies
 ---------------------
 
 ```
-govendor get <package>
-govendor add +vendor <package>
+go get <package>
+govendor add +external
 git add vendor/vendor.json
 git commit -m 'My new package.'
 ```

--- a/engines/enginetest/testutils.go
+++ b/engines/enginetest/testutils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+	"github.com/taskcluster/taskcluster-worker/runtime/mocks"
 	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
@@ -148,6 +149,7 @@ func newTestEnvironment() *runtime.Environment {
 		GarbageCollector: &gc.GarbageCollector{},
 		TemporaryStorage: folder,
 		Log:              logger,
+		Monitor:          mocks.NewMockMonitor(true),
 	}
 }
 

--- a/engines/mock/mockengine.go
+++ b/engines/mock/mockengine.go
@@ -23,6 +23,9 @@ func init() {
 }
 
 func (e engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine, error) {
+	if options.Environment.Monitor == nil {
+		panic("EngineOptions.Environment.Monitor is nil, this is a contract violation")
+	}
 	return engine{Log: options.Log}, nil
 }
 

--- a/engines/qemu/engine.go
+++ b/engines/qemu/engine.go
@@ -82,7 +82,7 @@ func (p engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine
 		c.ImageFolder,
 		options.Environment.GarbageCollector,
 		options.Log.WithField("subsystem", "image-manager"),
-		options.Environment.Sentry,
+		options.Environment.Monitor.WithPrefix("image-manager"),
 	)
 	if err != nil {
 		return nil, err

--- a/engines/qemu/image/extract.go
+++ b/engines/qemu/image/extract.go
@@ -59,12 +59,12 @@ func extractImage(imageFile, imageFolder string) (*vm.Machine, error) {
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			return nil, engines.NewMalformedPayloadError(
-				"Failed to extract image archieve, error: ", string(ee.Stderr),
+				"Failed to extract image archive, error: ", string(ee.Stderr),
 			)
 		}
 		// If this wasn't GNU tar exiting non-zero then it must be some internal
 		// error. Perhaps tar is missing from the PATH.
-		return nil, fmt.Errorf("Failed to extract image archieve, error: %s", err)
+		return nil, fmt.Errorf("Failed to extract image archive, error: %s", err)
 	}
 
 	// Check files exist, are plain files and not larger than maxImageSize

--- a/engines/qemu/image/manager.go
+++ b/engines/qemu/image/manager.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/getsentry/raven-go"
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster-worker/engines/qemu/vm"
+	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/gc"
 )
 
@@ -20,7 +20,7 @@ type Manager struct {
 	imageFolder string
 	gc          gc.ResourceTracker
 	log         *logrus.Entry
-	sentry      *raven.Client
+	monitor     runtime.Monitor
 }
 
 // Downloader is a function capable of downloading an image to an imageFile.
@@ -48,7 +48,7 @@ type Instance struct {
 
 // NewManager creates a new image manager using the imageFolder for storing
 // images and instances of images.
-func NewManager(imageFolder string, gc gc.ResourceTracker, log *logrus.Entry, sentry *raven.Client) (*Manager, error) {
+func NewManager(imageFolder string, gc gc.ResourceTracker, log *logrus.Entry, monitor runtime.Monitor) (*Manager, error) {
 	// Ensure the image folder is created
 	err := os.MkdirAll(imageFolder, 0777)
 	if err != nil {
@@ -59,7 +59,7 @@ func NewManager(imageFolder string, gc gc.ResourceTracker, log *logrus.Entry, se
 		imageFolder: imageFolder,
 		gc:          gc,
 		log:         log,
-		sentry:      sentry,
+		monitor:     monitor,
 	}, nil
 }
 
@@ -134,8 +134,7 @@ cleanup:
 	// Delete the image file
 	e := os.RemoveAll(imageFile)
 	if e != nil {
-		eventID := img.manager.sentry.CaptureError(e, nil) // TODO: Severity level warning
-		img.manager.log.Warning("Failed to delete image file, err: ", e, " sentry eventId: ", eventID)
+		img.manager.monitor.ReportWarning(e, "Failed to delete image file")
 	}
 
 	// If there was an err, set ima.err and remove it from cache
@@ -149,8 +148,7 @@ cleanup:
 		// Delete the image folder
 		e := os.RemoveAll(img.folder)
 		if e != nil {
-			eventID := img.manager.sentry.CaptureError(e, nil) // TODO: Severity level warning
-			img.manager.log.Warning("Failed to delete image folder, err: ", e, " sentry eventId: ", eventID)
+			img.manager.monitor.ReportWarning(e, "Failed to delete image folder")
 		}
 	} else {
 		img.manager.gc.Register(img)
@@ -234,8 +232,7 @@ func (i *Instance) Release() {
 
 	// Delete the layer.qcow2 copy
 	if err := os.Remove(i.diskFile); err != nil {
-		eventID := i.image.manager.sentry.CaptureError(err, nil)
-		i.image.manager.log.Error("Failed to layer.qcow2 copy, err: ", err, " sentry eventId: ", eventID)
+		i.image.manager.monitor.ReportError(err, "Failed to delete layer.qcow2 copy")
 	}
 
 	// Release the image

--- a/engines/qemu/image/mutableimage.go
+++ b/engines/qemu/image/mutableimage.go
@@ -53,7 +53,7 @@ func NewMutableImage(folder string, size int, machine *vm.Machine) (*MutableImag
 }
 
 // NewMutableImageFromFile creates a mutable image from an existing compressed
-// image tar archieve.
+// image tar archive.
 func NewMutableImageFromFile(imageFile, imageFolder string) (*MutableImage, error) {
 	// Extract image normally
 	machine, err := extractImage(imageFile, imageFolder)

--- a/plugins/plugintest/plugintest.go
+++ b/plugins/plugintest/plugintest.go
@@ -20,6 +20,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
 	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+	"github.com/taskcluster/taskcluster-worker/runtime/mocks"
 	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
 )
 
@@ -252,6 +253,7 @@ func newTestEnvironment() *runtime.Environment {
 		GarbageCollector: &gc.GarbageCollector{},
 		TemporaryStorage: folder,
 		Log:              logger,
+		Monitor:          mocks.NewMockMonitor(true),
 	}
 }
 

--- a/runtime/client/auth.go
+++ b/runtime/client/auth.go
@@ -1,0 +1,10 @@
+package client
+
+import "github.com/taskcluster/taskcluster-client-go/auth"
+
+// Auth interface covers parts of the auth.Auth client that we use. This allows
+// us to mock the implementation during tests.
+type Auth interface {
+	SentryDSN(project string) (*auth.SentryDSNResponse, error)
+	StatsumToken(project string) (*auth.StatsumTokenResponse, error)
+}

--- a/runtime/client/auth.go
+++ b/runtime/client/auth.go
@@ -1,10 +1,30 @@
 package client
 
-import "github.com/taskcluster/taskcluster-client-go/auth"
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/taskcluster/taskcluster-client-go/auth"
+)
 
 // Auth interface covers parts of the auth.Auth client that we use. This allows
 // us to mock the implementation during tests.
 type Auth interface {
 	SentryDSN(project string) (*auth.SentryDSNResponse, error)
 	StatsumToken(project string) (*auth.StatsumTokenResponse, error)
+}
+
+// MockAuth is a mock implementation of Auth for testing.
+type MockAuth struct {
+	mock.Mock
+}
+
+// SentryDSN is a mock implementation of SentryDSN that calls into m.Mock
+func (m *MockAuth) SentryDSN(project string) (*auth.SentryDSNResponse, error) {
+	args := m.Called(project)
+	return args.Get(0).(*auth.SentryDSNResponse), args.Error(1)
+}
+
+// StatsumToken is a mock implementation of StatsumToken that calls into Mock
+func (m *MockAuth) StatsumToken(project string) (*auth.StatsumTokenResponse, error) {
+	args := m.Called(project)
+	return args.Get(0).(*auth.StatsumTokenResponse), args.Error(1)
 }

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"github.com/Sirupsen/logrus"
-	"github.com/getsentry/raven-go"
 	"github.com/taskcluster/taskcluster-worker/runtime/gc"
 	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
 )
@@ -13,8 +12,8 @@ type Environment struct {
 	//TODO: Add some sort of interface to the system logger
 	//TODO: Add some interface to submit statistics for influxdb/signalfx
 	//TODO: Add some interface to attach a http.Handler to public facing server
-	TemporaryStorage TemporaryStorage
-	Log              *logrus.Logger
-	Sentry           *raven.Client
-	WebHookServer    webhookserver.WebHookServer
+	TemporaryStorage
+	Log *logrus.Logger
+	webhookserver.WebHookServer
+	Monitor
 }

--- a/runtime/mocks/doc.go
+++ b/runtime/mocks/doc.go
@@ -1,0 +1,3 @@
+// Package mocks contains mock implementations of various interfaces useful for
+// writing unit-tests.
+package mocks

--- a/runtime/mocks/mockmonitor.go
+++ b/runtime/mocks/mockmonitor.go
@@ -1,0 +1,226 @@
+package mocks
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pborman/uuid"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
+
+var mockMonitorLog = util.Debug("monitor")
+
+type metricCache struct {
+	m        sync.Mutex
+	measures map[string]bool
+	counters map[string]bool
+}
+
+// MockMonitor implements runtime.Monitor for use in unit tests.
+type MockMonitor struct {
+	tags         map[string]string
+	prefix       string
+	metadata     string
+	panicOnError bool
+	cache        *metricCache
+}
+
+// NewMockMonitor returns a Monitor that prints all messages using util.Debug()
+// meaning that you must set environment variable DEBUG='monitor' to see the
+// messages.
+//
+// If panicOnError is set this will panic if Error() or reportError() is called.
+// This is often useful for testing components that takes a Monitor as argument.
+func NewMockMonitor(panicOnError bool) *MockMonitor {
+	return &MockMonitor{
+		panicOnError: panicOnError,
+		cache: &metricCache{
+			measures: make(map[string]bool),
+			counters: make(map[string]bool),
+		},
+	}
+}
+
+// Measure records values for given name
+func (m *MockMonitor) Measure(name string, value ...float64) {
+	m.cache.m.Lock()
+	defer m.cache.m.Unlock()
+
+	m.cache.measures[m.prefix+name] = true
+}
+
+// Count incrments counter by name with given value
+func (m *MockMonitor) Count(name string, value float64) {
+	m.cache.m.Lock()
+	defer m.cache.m.Unlock()
+
+	m.cache.counters[m.prefix+name] = true
+}
+
+// Time measures and records the execution time of fn
+func (m *MockMonitor) Time(name string, fn func()) {
+	start := time.Now()
+	fn()
+	m.Measure(name, time.Since(start).Seconds()*1000)
+}
+
+// HasMeasure returns true if a measure with given name has been reported
+func (m *MockMonitor) HasMeasure(name string) bool {
+	m.cache.m.Lock()
+	defer m.cache.m.Unlock()
+
+	return m.cache.measures[m.prefix+name]
+}
+
+// HasCounter returns true if a counter with given name has been reported
+func (m *MockMonitor) HasCounter(name string) bool {
+	m.cache.m.Lock()
+	defer m.cache.m.Unlock()
+
+	return m.cache.counters[m.prefix+name]
+}
+
+// ReportError records an error, and panics if panicOnError was set
+func (m *MockMonitor) ReportError(err error, message ...interface{}) string {
+	incidentID := uuid.NewRandom().String()
+	text := fmt.Sprint(append([]interface{}{"error: ", err}, message))
+	m.WithTag("incidentId", incidentID).(*MockMonitor).output("ERROR-REPORT", text)
+	if m.panicOnError {
+		panic(fmt.Sprintf("ReportError: %s", text))
+	}
+	return incidentID
+}
+
+// ReportWarning logs a warning
+func (m *MockMonitor) ReportWarning(err error, message ...interface{}) string {
+	incidentID := uuid.NewRandom().String()
+	text := fmt.Sprint(append([]interface{}{"error: ", err}, message))
+	m.WithTag("incidentId", incidentID).(*MockMonitor).output("WARNING-REPORT", text)
+	return incidentID
+}
+
+func (m *MockMonitor) output(kind string, a ...interface{}) {
+	mockMonitorLog("%s -- %s: %s", kind, m.metadata, fmt.Sprint(a...))
+}
+
+// Debug writes a debug message
+func (m *MockMonitor) Debug(a ...interface{}) { m.output("DEBUG", a...) }
+
+// Debugln writes a debug message
+func (m *MockMonitor) Debugln(a ...interface{}) { m.Debug(fmt.Sprintln(a...)) }
+
+// Debugf writes debug message labelled as Debug
+func (m *MockMonitor) Debugf(f string, a ...interface{}) { m.Debug(fmt.Sprintf(f, a...)) }
+
+// Print writes debug message labelled as Print
+func (m *MockMonitor) Print(a ...interface{}) { m.output("INFO", a...) }
+
+// Println writes debug message labelled as Print
+func (m *MockMonitor) Println(a ...interface{}) { m.Print(fmt.Sprintln(a...)) }
+
+// Printf writes debug message labelled as Print
+func (m *MockMonitor) Printf(f string, a ...interface{}) { m.Print(fmt.Sprintf(f, a...)) }
+
+// Info writes debug message labelled as Info
+func (m *MockMonitor) Info(a ...interface{}) { m.output("INFO", a...) }
+
+// Infoln writes debug message labelled as Info
+func (m *MockMonitor) Infoln(a ...interface{}) { m.Info(fmt.Sprintln(a...)) }
+
+// Infof writes debug message labelled as Info
+func (m *MockMonitor) Infof(f string, a ...interface{}) { m.Info(fmt.Sprintf(f, a...)) }
+
+// Warn writes debug message labelled as Warn
+func (m *MockMonitor) Warn(a ...interface{}) { m.output("WARN", a...) }
+
+// Warnln writes debug message labelled as Warn
+func (m *MockMonitor) Warnln(a ...interface{}) { m.Warn(fmt.Sprintln(a...)) }
+
+// Warnf writes debug message labelled as Warn
+func (m *MockMonitor) Warnf(f string, a ...interface{}) { m.Warn(fmt.Sprintf(f, a...)) }
+
+// Errorln writes debug message labelled as Error, and panics if panicOnError was set
+func (m *MockMonitor) Errorln(a ...interface{}) { m.Error(fmt.Sprintln(a...)) }
+
+// Errorf writes debug message labelled as Error, and panics if panicOnError was set
+func (m *MockMonitor) Errorf(f string, a ...interface{}) { m.Error(fmt.Sprintf(f, a...)) }
+
+// Panicln writes debug message labelled as Panic, and panics
+func (m *MockMonitor) Panicln(a ...interface{}) { m.Panic(fmt.Sprintln(a...)) }
+
+// Panicf writes debug message labelled as Panic, and panics
+func (m *MockMonitor) Panicf(f string, a ...interface{}) { m.Panic(fmt.Sprintf(f, a...)) }
+
+// Error writes debug message labelled as Error, and panics if panicOnError was set
+func (m *MockMonitor) Error(a ...interface{}) {
+	m.output("ERROR", a...)
+	if m.panicOnError {
+		panic(fmt.Sprint(a...))
+	}
+}
+
+// Panic writes debug message labelled as Panic, and panics
+func (m *MockMonitor) Panic(a ...interface{}) {
+	m.output("PANIC", a...)
+	panic(fmt.Sprint(a...))
+}
+
+// WithTags creates a new child Monitor with given tags
+func (m *MockMonitor) WithTags(tags map[string]string) runtime.Monitor {
+	allTags := make(map[string]string, len(m.tags))
+	for k, v := range m.tags {
+		allTags[k] = v
+	}
+	for k, v := range tags {
+		allTags[k] = v
+	}
+	return &MockMonitor{
+		tags:         allTags,
+		prefix:       m.prefix,
+		metadata:     mockMonitorMetadata(allTags, m.prefix),
+		panicOnError: m.panicOnError,
+		cache:        m.cache,
+	}
+}
+
+// WithTag creates a new child Monitor with given tag
+func (m *MockMonitor) WithTag(key, value string) runtime.Monitor {
+	return m.WithTags(map[string]string{key: value})
+}
+
+// WithPrefix creates a new child Monitor with given prefix
+func (m *MockMonitor) WithPrefix(prefix string) runtime.Monitor {
+	if prefix != "" {
+		prefix += "."
+	}
+	return &MockMonitor{
+		tags:         m.tags,
+		prefix:       m.prefix + prefix,
+		metadata:     mockMonitorMetadata(m.tags, m.prefix+prefix),
+		panicOnError: m.panicOnError,
+		cache:        m.cache,
+	}
+}
+
+func mockMonitorMetadata(tags map[string]string, prefix string) string {
+	if strings.HasSuffix(prefix, ".") {
+		prefix = prefix[:len(prefix)-1]
+	}
+
+	keys := make([]string, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, len(tags)+1)
+	pairs = append(pairs, fmt.Sprintf("prefix=%s", prefix))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, tags[k]))
+	}
+	return strings.Join(pairs, " ")
+}

--- a/runtime/monitor.go
+++ b/runtime/monitor.go
@@ -1,0 +1,240 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	raven "github.com/getsentry/raven-go"
+	"github.com/pborman/uuid"
+	"github.com/taskcluster/statsum"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
+)
+
+// A Monitor is responsible for collecting logs, stats and error messages.
+type Monitor interface {
+	// Measure values in statsum
+	Measure(name string, value ...float64)
+	// Increment counters in statsum
+	Count(name string, value float64)
+	// Measure time of fn in statsum
+	Time(name string, fn func())
+
+	// Report error/warning to sentry and write to log, returns incidentId which
+	// can be included in task-logs, if relevant.
+	ReportError(err error) string
+	ReportWarning(err error) string
+
+	// Write log messages to system log
+	Debug(...interface{})
+	Debugln(...interface{})
+	Debugf(string, ...interface{})
+	Print(...interface{})
+	Println(...interface{})
+	Printf(string, ...interface{})
+	Info(...interface{})
+	Infoln(...interface{})
+	Infof(string, ...interface{})
+	Warn(...interface{})
+	Warnln(...interface{})
+	Warnf(string, ...interface{})
+	Error(...interface{})
+	Errorln(...interface{})
+	Errorf(string, ...interface{})
+	Panic(...interface{})
+	Panicln(...interface{})
+	Panicf(string, ...interface{})
+
+	// Create child monitor with given tags (tags don't apply to statsum)
+	WithTags(tags map[string]string) Monitor
+	WithTag(key, value string) Monitor
+	// Create child monitor with given prefix (prefix applies to everything)
+	WithPrefix(prefix string) Monitor
+}
+
+// NewMonitor creates a new monitor
+func NewMonitor(project string, auth client.Auth, logLevel string, tags map[string]string) Monitor {
+	// Create statsumConfigurer
+	statsumConfigurer := func(project string) (statsum.Config, error) {
+		res, err := auth.StatsumToken(project)
+		if err != nil {
+			return statsum.Config{}, err
+		}
+		return statsum.Config{
+			Project: res.Project,
+			BaseURL: res.BaseURL,
+			Token:   res.Token,
+			Expires: time.Time(res.Expires),
+		}, nil
+	}
+
+	// Create logger and parse logLevel
+	logger := logrus.New()
+	switch strings.ToLower(logLevel) {
+	case "panic":
+		logger.Level = logrus.PanicLevel
+	case "fatal":
+		logger.Level = logrus.FatalLevel
+	case "error":
+		logger.Level = logrus.ErrorLevel
+	case "warn":
+		logger.Level = logrus.WarnLevel
+	case "info":
+		logger.Level = logrus.InfoLevel
+	case "debug":
+		logger.Level = logrus.DebugLevel
+	default:
+		panic(fmt.Sprintf("Unsupported log-level: %s", logLevel))
+	}
+
+	// Convert tags to logrus.Fields
+	fields := make(logrus.Fields, len(tags))
+	for k, v := range tags {
+		fields[k] = v
+	}
+
+	// Declare monitor so we can reference it in OnError
+	var m *monitor
+	m = &monitor{
+		Statsum: statsum.New(project, statsumConfigurer, statsum.Options{
+			OnError: func(err error) { m.ReportWarning(err) },
+		}),
+		Entry: logrus.NewEntry(logger).WithFields(fields),
+		sentry: &sentry{
+			client:  nil,
+			project: project,
+			auth:    auth,
+		},
+	}
+	return m
+}
+
+type sentry struct {
+	client     *raven.Client
+	m          sync.Mutex
+	project    string
+	expiration time.Time
+	auth       client.Auth
+}
+
+type monitor struct {
+	*statsum.Statsum
+	*logrus.Entry
+	*sentry
+	tags   map[string]string
+	prefix string
+}
+
+func (m *monitor) Time(name string, fn func()) {
+	m.Statsum.Time(name, fn)
+}
+
+func (m *monitor) ReportError(err error) string {
+	incidentID := uuid.NewRandom().String()
+	m.Entry.WithField("incidentId", incidentID).Error(err)
+	m.submitError(err, raven.ERROR, incidentID)
+	return incidentID
+}
+
+func (m *monitor) ReportWarning(err error) string {
+	incidentID := uuid.NewRandom().String()
+	m.Entry.WithField("incidentId", incidentID).Warn(err)
+	m.submitError(err, raven.WARNING, incidentID)
+	return incidentID
+}
+
+func (m *monitor) submitError(err error, level raven.Severity, incidentID string) {
+	// Capture stack trace
+	exception := raven.NewException(err, raven.NewStacktrace(2, 5, []string{
+		"github.com/taskcluster/",
+	}))
+
+	// Create error packet
+	packet := raven.NewPacket(err.Error(), nil, exception)
+	packet.Level = level
+	packet.EventID = incidentID
+
+	// Add incidentID and prefix to tags
+	tags := make(map[string]string, len(m.tags)+2)
+	for tag, value := range m.tags {
+		tags[tag] = value
+	}
+	tags["incidentId"] = incidentID
+	tags["prefix"] = m.prefix
+
+	// Refresh sentry DSN
+	m.sentry.m.Lock()
+	if m.sentry.expiration.Before(time.Now()) {
+		// Fetch DSN
+		res, rerr := m.sentry.auth.SentryDSN(m.sentry.project)
+		if rerr != nil {
+			m.Error("Failed to obtain sentry DSN, error: ", rerr)
+			m.Error("Failed to send error: ", err)
+			m.sentry.m.Unlock()
+			return
+		}
+		// Create or update DSN for the client
+		if m.sentry.client == nil {
+			m.sentry.client, rerr = raven.New(res.Dsn.Secret)
+		} else {
+			rerr = m.sentry.client.SetDSN(res.Dsn.Secret)
+		}
+		if rerr != nil {
+			m.Error("Obtained invalid sentry DSN, error: ", rerr)
+			m.Error("Failed to send error: ", err)
+			m.sentry.m.Unlock()
+			return
+		}
+		// Set expiration, so we remember to refresh
+		m.sentry.expiration = time.Time(res.Expires)
+	}
+	m.sentry.m.Unlock()
+
+	// Send packet
+	_, done := m.sentry.client.Capture(packet, tags)
+	<-done
+}
+
+func (m *monitor) WithTags(tags map[string]string) Monitor {
+	// Merge tags from monitor and tags
+	allTags := make(map[string]string, len(tags))
+	for k, v := range m.tags {
+		allTags[k] = v
+	}
+	for k, v := range tags {
+		allTags[k] = v
+	}
+	// Construct fields for logrus (just satisfiying the type system)
+	fields := make(map[string]interface{}, len(allTags))
+	for k, v := range allTags {
+		fields[k] = v
+	}
+	fields["prefix"] = m.prefix // don't allow overwrite "prefix"
+	return &monitor{
+		Statsum: m.Statsum,
+		Entry:   m.Entry.WithFields(fields),
+		sentry:  m.sentry,
+		tags:    allTags,
+		prefix:  m.prefix,
+	}
+}
+
+func (m *monitor) WithTag(key, value string) Monitor {
+	return m.WithTags(map[string]string{key: value})
+}
+
+func (m *monitor) WithPrefix(prefix string) Monitor {
+	completePrefix := prefix
+	if m.prefix != "" {
+		completePrefix = m.prefix + "." + prefix
+	}
+	return &monitor{
+		Statsum: m.Statsum.WithPrefix(prefix),
+		Entry:   m.Entry.WithField("prefix", completePrefix),
+		sentry:  m.sentry,
+		tags:    m.tags,
+		prefix:  completePrefix,
+	}
+}

--- a/runtime/monitor.go
+++ b/runtime/monitor.go
@@ -24,8 +24,8 @@ type Monitor interface {
 
 	// Report error/warning to sentry and write to log, returns incidentId which
 	// can be included in task-logs, if relevant.
-	ReportError(err error, comment ...interface{}) string
-	ReportWarning(err error, comment ...interface{}) string
+	ReportError(err error, message ...interface{}) string
+	ReportWarning(err error, message ...interface{}) string
 
 	// Write log messages to system log
 	Debug(...interface{})
@@ -73,18 +73,18 @@ func NewMonitor(project string, auth client.Auth, logLevel string, tags map[stri
 	// Create logger and parse logLevel
 	logger := logrus.New()
 	switch strings.ToLower(logLevel) {
-	case "panic":
-		logger.Level = logrus.PanicLevel
-	case "fatal":
-		logger.Level = logrus.FatalLevel
-	case "error":
-		logger.Level = logrus.ErrorLevel
-	case "warn":
-		logger.Level = logrus.WarnLevel
-	case "info":
-		logger.Level = logrus.InfoLevel
-	case "debug":
+	case logrus.DebugLevel.String():
 		logger.Level = logrus.DebugLevel
+	case logrus.InfoLevel.String():
+		logger.Level = logrus.InfoLevel
+	case logrus.WarnLevel.String():
+		logger.Level = logrus.WarnLevel
+	case logrus.ErrorLevel.String():
+		logger.Level = logrus.ErrorLevel
+	case logrus.FatalLevel.String():
+		logger.Level = logrus.FatalLevel
+	case logrus.PanicLevel.String():
+		logger.Level = logrus.PanicLevel
 	default:
 		panic(fmt.Sprintf("Unsupported log-level: %s", logLevel))
 	}
@@ -237,5 +237,98 @@ func (m *monitor) WithPrefix(prefix string) Monitor {
 		sentry:  m.sentry,
 		tags:    m.tags,
 		prefix:  completePrefix,
+	}
+}
+
+type loggingMonitor struct {
+	*logrus.Entry
+	prefix string
+}
+
+// NewLoggingMonitor creates a monitor that just logs everything. This won't
+// attempt to to send anything to sentry or statsum.
+func NewLoggingMonitor(logLevel string, tags map[string]string) Monitor {
+	// Create logger and parse logLevel
+	logger := logrus.New()
+	switch strings.ToLower(logLevel) {
+	case logrus.DebugLevel.String():
+		logger.Level = logrus.DebugLevel
+	case logrus.InfoLevel.String():
+		logger.Level = logrus.InfoLevel
+	case logrus.WarnLevel.String():
+		logger.Level = logrus.WarnLevel
+	case logrus.ErrorLevel.String():
+		logger.Level = logrus.ErrorLevel
+	case logrus.FatalLevel.String():
+		logger.Level = logrus.FatalLevel
+	case logrus.PanicLevel.String():
+		logger.Level = logrus.PanicLevel
+	default:
+		panic(fmt.Sprintf("Unsupported log-level: %s", logLevel))
+	}
+
+	// Convert tags to logrus.Fields
+	fields := make(logrus.Fields, len(tags))
+	for k, v := range tags {
+		fields[k] = v
+	}
+
+	return &loggingMonitor{
+		Entry: logrus.NewEntry(logger).WithFields(fields),
+	}
+}
+
+func (m *loggingMonitor) Measure(name string, value ...float64) {
+	strs := make([]string, len(value))
+	for _, v := range value {
+		strs = append(strs, fmt.Sprintf("%f", v))
+	}
+	m.Debugf("measure: %s%s recorded %s", m.prefix, name, strings.Join(strs, ","))
+}
+
+func (m *loggingMonitor) Count(name string, value float64) {
+	m.Debugf("counter: %s%s incremented by %f", m.prefix, name, value)
+}
+
+func (m *loggingMonitor) Time(name string, fn func()) {
+	start := time.Now()
+	fn()
+	m.Measure(name, time.Since(start).Seconds()*1000)
+}
+
+func (m *loggingMonitor) ReportError(err error, message ...interface{}) string {
+	incidentID := uuid.NewRandom().String()
+	m.Entry.WithField("incidentId", incidentID).WithError(err).Error(message...)
+	return incidentID
+}
+
+func (m *loggingMonitor) ReportWarning(err error, message ...interface{}) string {
+	incidentID := uuid.NewRandom().String()
+	m.Entry.WithField("incidentId", incidentID).WithError(err).Warn(message...)
+	return incidentID
+}
+
+func (m *loggingMonitor) WithTags(tags map[string]string) Monitor {
+	// Construct fields for logrus (just satisfiying the type system)
+	fields := make(map[string]interface{}, len(tags))
+	for k, v := range tags {
+		fields[k] = v
+	}
+	fields["prefix"] = m.prefix // don't allow overwrite "prefix"
+	return &monitor{
+		Entry:  m.Entry.WithFields(fields),
+		prefix: m.prefix,
+	}
+}
+
+func (m *loggingMonitor) WithTag(key, value string) Monitor {
+	return m.WithTags(map[string]string{key: value})
+}
+
+func (m *loggingMonitor) WithPrefix(prefix string) Monitor {
+	prefix = m.prefix + prefix
+	return &monitor{
+		Entry:  m.Entry.WithField("prefix", prefix),
+		prefix: prefix + ".",
 	}
 }

--- a/runtime/monitor.go
+++ b/runtime/monitor.go
@@ -315,7 +315,7 @@ func (m *loggingMonitor) WithTags(tags map[string]string) Monitor {
 		fields[k] = v
 	}
 	fields["prefix"] = m.prefix // don't allow overwrite "prefix"
-	return &monitor{
+	return &loggingMonitor{
 		Entry:  m.Entry.WithFields(fields),
 		prefix: m.prefix,
 	}
@@ -327,7 +327,7 @@ func (m *loggingMonitor) WithTag(key, value string) Monitor {
 
 func (m *loggingMonitor) WithPrefix(prefix string) Monitor {
 	prefix = m.prefix + prefix
-	return &monitor{
+	return &loggingMonitor{
 		Entry:  m.Entry.WithField("prefix", prefix),
 		prefix: prefix + ".",
 	}

--- a/runtime/monitor_test.go
+++ b/runtime/monitor_test.go
@@ -1,0 +1,44 @@
+// +build monitor
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/auth"
+)
+
+func TestLoggingMonitor(t *testing.T) {
+	m := NewLoggingMonitor("debug", nil)
+	m.Debug("hello world")
+	m.Measure("my-measure", 56)
+	m.Count("my-counter", 1)
+	m.WithPrefix("my-prefix").Count("counter-2", 1)
+	m.WithPrefix("my-prefix").Info("info message")
+	m.WithTag("myTag", "myValue").Warn("some warning")
+	m.WithTag("myTag", "myValue").ReportWarning(fmt.Errorf("error message"), "this is a warning")
+}
+
+func TestMonitor(t *testing.T) {
+	clientID := os.Getenv("TASKCLUSTER_CLIENT_ID")
+	accessToken := os.Getenv("TASKCLUSTER_ACCESS_TOKEN")
+	if clientID == "" || accessToken == "" {
+		t.Skip("TASKCLUSTER_CLIENT_ID and TASKCLUSTER_ACCESS_TOKEN not defined")
+	}
+	a := auth.New(&tcclient.Credentials{
+		ClientID:    clientID,
+		AccessToken: accessToken,
+	})
+
+	m := NewMonitor("test-dummy-worker", a, "debug", nil)
+	m.Debug("hello world")
+	m.Measure("my-measure", 56)
+	m.Count("my-counter", 1)
+	m.WithPrefix("my-prefix").Count("counter-2", 1)
+	m.WithPrefix("my-prefix").Info("info message")
+	m.WithTag("myTag", "myValue").Warn("some warning")
+	m.WithTag("myTag", "myValue").ReportWarning(fmt.Errorf("error message"), "this is a warning")
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -191,9 +191,30 @@
 			"revision": "b984ec7fa9ff9e428bd0cf0abf429384dfbe3e37"
 		},
 		{
+			"checksumSHA1": "mbhJnsNwGAwkTQH5c2hVRO9YmxA=",
+			"origin": "github.com/taskcluster/statsum/vendor/github.com/philhofer/fwd",
+			"path": "github.com/philhofer/fwd",
+			"revision": "b67a889bdf09b2f267017f12c794758112f6b344",
+			"revisionTime": "2017-02-22T01:37:00Z"
+		},
+		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2"
+		},
+		{
+			"checksumSHA1": "D1JbeyQhazKyXOokR5w7XrHWWw8=",
+			"origin": "github.com/taskcluster/statsum/vendor/github.com/pquerna/ffjson/fflib/v1",
+			"path": "github.com/pquerna/ffjson/fflib/v1",
+			"revision": "b67a889bdf09b2f267017f12c794758112f6b344",
+			"revisionTime": "2017-02-22T01:37:00Z"
+		},
+		{
+			"checksumSHA1": "iZHmHPBzKJiS6ROUaVOf4DVOhbA=",
+			"origin": "github.com/taskcluster/statsum/vendor/github.com/pquerna/ffjson/fflib/v1/internal",
+			"path": "github.com/pquerna/ffjson/fflib/v1/internal",
+			"revision": "b67a889bdf09b2f267017f12c794758112f6b344",
+			"revisionTime": "2017-02-22T01:37:00Z"
 		},
 		{
 			"checksumSHA1": "9rCHOi3ELajBtQUPWxxmEo/Nalk=",
@@ -317,6 +338,12 @@
 			"revisionTime": "2017-02-22T01:37:00Z"
 		},
 		{
+			"checksumSHA1": "tpbXWdz3j1GRxGRq+J0ZE6R/I1A=",
+			"path": "github.com/taskcluster/statsum/payload",
+			"revision": "b67a889bdf09b2f267017f12c794758112f6b344",
+			"revisionTime": "2017-02-22T01:37:00Z"
+		},
+		{
 			"checksumSHA1": "rbm4FbK+OdUno8jhGG/aQo/gmwM=",
 			"path": "github.com/taskcluster/taskcluster-base-go/jsontest",
 			"revision": "3e5fe97ee400d93aa8eab4eb4ba7e24e1e8df3ce"
@@ -345,6 +372,13 @@
 			"checksumSHA1": "Jggs+SsefVhBtVaWOqlFnsXICkk=",
 			"path": "github.com/tent/hawk-go",
 			"revision": "d4fa08268f573f25df477fedc813f26bfb833761"
+		},
+		{
+			"checksumSHA1": "aTiJJQgo4zVRwQ9O3y0IY7O9cAk=",
+			"origin": "github.com/taskcluster/statsum/vendor/github.com/tinylib/msgp/msgp",
+			"path": "github.com/tinylib/msgp/msgp",
+			"revision": "b67a889bdf09b2f267017f12c794758112f6b344",
+			"revisionTime": "2017-02-22T01:37:00Z"
 		},
 		{
 			"checksumSHA1": "drSl/ipSHSsHWWTrp3WZw4LN/No=",
@@ -385,6 +419,12 @@
 			"checksumSHA1": "+mjMyJPLBPu7vIHaXkDuvqcDk0s=",
 			"path": "golang.org/x/tools/imports",
 			"revision": "3f4088edb48e8a4e3c66a5f8e7b2a78615fcb83f"
+		},
+		{
+			"checksumSHA1": "BoDMXJFal8LyM35n5LKhZGIxLyk=",
+			"path": "gopkg.in/dgrijalva/jwt-go.v2",
+			"revision": "268038b363c7a8d7306b8e35bf77a1fde4b0c402",
+			"revisionTime": "2016-06-16T19:14:24Z"
 		},
 		{
 			"checksumSHA1": "NwR8Jfz6xyRq+6z/ZDOmqssnsq8=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -311,6 +311,12 @@
 			"revision": "dceab83a80cf8a20ddcb1cf50087c7d72fcf23dc"
 		},
 		{
+			"checksumSHA1": "lsCypwrrrl9RyiA69oq6eTBA/fM=",
+			"path": "github.com/taskcluster/statsum",
+			"revision": "b67a889bdf09b2f267017f12c794758112f6b344",
+			"revisionTime": "2017-02-22T01:37:00Z"
+		},
+		{
 			"checksumSHA1": "rbm4FbK+OdUno8jhGG/aQo/gmwM=",
 			"path": "github.com/taskcluster/taskcluster-base-go/jsontest",
 			"revision": "3e5fe97ee400d93aa8eab4eb4ba7e24e1e8df3ce"

--- a/worker/config.go
+++ b/worker/config.go
@@ -23,7 +23,6 @@ type configType struct {
 	WorkerGroup      string                 `json:"workerGroup"`
 	WorkerID         string                 `json:"workerId"`
 	TemporaryFolder  string                 `json:"temporaryFolder"`
-	LogLevel         string                 `json:"logLevel"`
 	ServerIP         string                 `json:"serverIp"`
 	ServerPort       int                    `json:"serverPort"`
 	NetworkInterface string                 `json:"networkInterface"`
@@ -36,6 +35,8 @@ type configType struct {
 	MinimumDiskSpace int64                  `json:"minimumDiskSpace"`
 	MinimumMemory    int64                  `json:"minimumMemory"`
 	MaxTasksToRun    int                    `json:"maxTasksToRun"`
+	LogLevel         string                 `json:"logLevel"`
+	MonitorProject   string                 `json:"monitorProject"`
 }
 
 type credentials struct {
@@ -187,16 +188,6 @@ func ConfigSchema() schematypes.Object {
 							overwritten.`,
 				},
 			},
-			"logLevel": schematypes.StringEnum{
-				Options: []string{
-					logrus.DebugLevel.String(),
-					logrus.InfoLevel.String(),
-					logrus.WarnLevel.String(),
-					logrus.ErrorLevel.String(),
-					logrus.FatalLevel.String(),
-					logrus.PanicLevel.String(),
-				},
-			},
 			"serverIp": schematypes.String{},
 			"serverPort": schematypes.Integer{
 				Minimum: 0,
@@ -255,6 +246,26 @@ func ConfigSchema() schematypes.Object {
 				},
 				Minimum: 0,
 				Maximum: math.MaxInt32,
+			},
+			"logLevel": schematypes.StringEnum{
+				Options: []string{
+					logrus.DebugLevel.String(),
+					logrus.InfoLevel.String(),
+					logrus.WarnLevel.String(),
+					logrus.ErrorLevel.String(),
+					logrus.FatalLevel.String(),
+					logrus.PanicLevel.String(),
+				},
+			},
+			"monitorProject": schematypes.String{
+				MetaData: schematypes.MetaData{
+					Title: "Sentry Statsum Project",
+					Description: "Project name to be used for statsum and sentry " +
+						"reporting. Requires scopes `auth:statsum:<project>` and " +
+						"`auth:sentry:<project>`. If not specified error reports and " +
+						"metrics will be logged and otherwise discarded.",
+				},
+				Pattern: "^[a-zA-Z0-9_-]{1,22}$",
 			},
 		},
 		Required: []string{

--- a/worker/task_test.go
+++ b/worker/task_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
+	"github.com/taskcluster/taskcluster-worker/runtime/mocks"
 )
 
 var logger, _ = runtime.CreateLogger(os.Getenv("LOGGING_LEVEL"))
@@ -91,6 +92,7 @@ func ensureEnvironment(t *testing.T) (*runtime.Environment, engines.Engine, plug
 
 	environment := &runtime.Environment{
 		TemporaryStorage: tempStorage,
+		Monitor:          mocks.NewMockMonitor(true),
 	}
 	engineProvider := engines.Engines()["mock"]
 	engine, err := engineProvider.NewEngine(engines.EngineOptions{

--- a/worker/taskmanager_test.go
+++ b/worker/taskmanager_test.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/taskcluster/taskcluster-worker/plugins/success"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+	"github.com/taskcluster/taskcluster-worker/runtime/mocks"
 	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
 )
 
@@ -94,6 +95,7 @@ func TestTaskManagerRunTask(t *testing.T) {
 		GarbageCollector: gc,
 		TemporaryStorage: tempStorage,
 		WebHookServer:    localServer,
+		Monitor:          mocks.NewMockMonitor(true),
 	}
 	engineProvider := engines.Engines()["mock"]
 	engine, err := engineProvider.NewEngine(engines.EngineOptions{
@@ -189,6 +191,7 @@ func TestCancelTask(t *testing.T) {
 		GarbageCollector: gc,
 		TemporaryStorage: tempStorage,
 		WebHookServer:    localServer,
+		Monitor:          mocks.NewMockMonitor(true),
 	}
 	engineProvider := engines.Engines()["mock"]
 	engine, err := engineProvider.NewEngine(engines.EngineOptions{
@@ -301,6 +304,7 @@ func TestWorkerShutdown(t *testing.T) {
 		GarbageCollector: gc,
 		TemporaryStorage: tempStorage,
 		WebHookServer:    localServer,
+		Monitor:          mocks.NewMockMonitor(true),
 	}
 	engineProvider := engines.Engines()["mock"]
 	engine, err := engineProvider.NewEngine(engines.EngineOptions{


### PR DESCRIPTION
This is stuff isn't easy to write tests for... statsum has tests in the statsum client... 
but tests for the integration bits is hard, can't really be automated because they require scopes and we don't have a good API to test if something was submitted to sentry/statsum..

Maybe we can add some later, but for now this is a good start.

note: The mockMonitor and logging monitor are not particular important, most important is to review the monitor interface...

I'll start a PR removing logrus logging, instead we should pass around this the Monitor object, so we have logging, metrics and error reporting all in one :)