### PR TITLE
Relocated artifact uploading functions to methods of *runtime.TaskContext

### DIFF
--- a/engines/script/sandbox.go
+++ b/engines/script/sandbox.go
@@ -127,12 +127,12 @@ func (s *sandbox) uploadArtifacts() error {
 		}
 
 		// Upload artifact
-		err = runtime.UploadS3Artifact(runtime.S3Artifact{
+		err = s.context.UploadS3Artifact(runtime.S3Artifact{
 			Name:     filepath.ToSlash(name),
 			Mimetype: mimeType,
 			Expires:  tcclient.Time(expires),
 			Stream:   f,
-		}, s.context)
+		})
 
 		// Ensure that we close the file
 		cerr := f.Close()

--- a/plugins/artifacts/artifacts.go
+++ b/plugins/artifacts/artifacts.go
@@ -117,12 +117,12 @@ func (tp taskPlugin) errorHandled(name string, expires time.Time, err error) boo
 
 	if reason != "" {
 		tp.context.Log("Artifact upload error handled. Continuing...", name, err.Error())
-		runtime.CreateErrorArtifact(runtime.ErrorArtifact{
+		tp.context.CreateErrorArtifact(runtime.ErrorArtifact{
 			Name:    name,
 			Message: err.Error(),
 			Reason:  reason,
 			Expires: tcclient.Time(expires),
-		}, tp.context)
+		})
 		return true
 	}
 	return false
@@ -140,12 +140,12 @@ func (tp taskPlugin) attemptUpload(fileReader ioext.ReadSeekCloser, path string,
 		// application/octet-stream is the mime type for "unknown"
 		mimeType = "application/octet-stream"
 	}
-	return runtime.UploadS3Artifact(runtime.S3Artifact{
+	return tp.context.UploadS3Artifact(runtime.S3Artifact{
 		Name:     name,
 		Mimetype: mimeType,
 		Stream:   fileReader,
 		Expires:  tcclient.Time(expires),
-	}, tp.context)
+	})
 }
 
 func init() {

--- a/plugins/interactive/interactive.go
+++ b/plugins/interactive/interactive.go
@@ -243,12 +243,12 @@ func (p *taskPlugin) setupShell() error {
 	query.Set("runId", fmt.Sprintf("%d", p.context.RunID))
 	query.Set("socketUrl", p.shellURL)
 
-	return runtime.CreateRedirectArtifact(runtime.RedirectArtifact{
+	return p.context.CreateRedirectArtifact(runtime.RedirectArtifact{
 		Name:     p.opts.ArtifactPrefix + "shell.html",
 		Mimetype: "text/html",
 		URL:      p.parent.config.ShellToolURL + "?" + query.Encode(),
 		Expires:  p.context.TaskInfo.Deadline,
-	}, p.context)
+	})
 }
 
 func (p *taskPlugin) setupDisplay() error {
@@ -277,12 +277,12 @@ func (p *taskPlugin) setupDisplay() error {
 	//       URLs. Hence, introducing v=2, so leaving it for later.
 	query.Set("shared", "true")
 
-	return runtime.CreateRedirectArtifact(runtime.RedirectArtifact{
+	return p.context.CreateRedirectArtifact(runtime.RedirectArtifact{
 		Name:     p.opts.ArtifactPrefix + "display.html",
 		Mimetype: "text/html",
 		URL:      p.parent.config.DisplayToolURL + "?" + query.Encode(),
 		Expires:  p.context.TaskInfo.Deadline,
-	}, p.context)
+	})
 }
 
 func (p *taskPlugin) createSocketsFile() error {
@@ -301,12 +301,12 @@ func (p *taskPlugin) createSocketsFile() error {
 		sockets["displaySocketUrl"] = p.displaySocketURL
 	}
 	data, _ := json.MarshalIndent(sockets, "", "  ")
-	return runtime.UploadS3Artifact(runtime.S3Artifact{
+	return p.context.UploadS3Artifact(runtime.S3Artifact{
 		Name:     p.opts.ArtifactPrefix + "sockets.json",
 		Mimetype: "application/json",
 		Expires:  p.context.TaskInfo.Deadline,
 		Stream:   ioext.NopCloser(bytes.NewReader(data)),
-	}, p.context)
+	})
 }
 
 func urlProtocolToWebsocket(u string) string {

--- a/plugins/livelog/livelog.go
+++ b/plugins/livelog/livelog.go
@@ -77,12 +77,12 @@ func (tp *taskPlugin) Prepare(context *runtime.TaskContext) error {
 		ioext.CopyAndFlush(wf, logReader, 100*time.Millisecond)
 	}))
 
-	err := runtime.CreateRedirectArtifact(runtime.RedirectArtifact{
+	err := tp.context.CreateRedirectArtifact(runtime.RedirectArtifact{
 		Name:     "public/logs/live.log",
 		Mimetype: "text/plain",
 		URL:      tp.url,
 		Expires:  tp.context.TaskInfo.Expires,
-	}, tp.context)
+	})
 	if err != nil {
 		tp.context.LogError(fmt.Sprintf("Could not initialize live log plugin. Error: %s", err))
 	}
@@ -130,7 +130,7 @@ func (tp *taskPlugin) uploadLog() error {
 		return err
 	}
 
-	err = runtime.UploadS3Artifact(runtime.S3Artifact{
+	err = tp.context.UploadS3Artifact(runtime.S3Artifact{
 		Name:     "public/logs/live_backing.log",
 		Mimetype: "text/plain",
 		Expires:  tp.context.TaskInfo.Expires,
@@ -138,19 +138,19 @@ func (tp *taskPlugin) uploadLog() error {
 		AdditionalHeaders: map[string]string{
 			"Content-Encoding": "gzip",
 		},
-	}, tp.context)
+	})
 
 	if err != nil {
 		return err
 	}
 
 	backingURL := fmt.Sprintf("https://queue.taskcluster.net/v1/task/%s/runs/%d/artifacts/public/logs/live_backing.log", tp.context.TaskInfo.TaskID, tp.context.TaskInfo.RunID)
-	err = runtime.CreateRedirectArtifact(runtime.RedirectArtifact{
+	err = tp.context.CreateRedirectArtifact(runtime.RedirectArtifact{
 		Name:     "public/logs/live.log",
 		Mimetype: "text/plain",
 		URL:      backingURL,
 		Expires:  tp.context.TaskInfo.Expires,
-	}, tp.context)
+	})
 	if err != nil {
 		tp.monitor.Error(err)
 		return err

--- a/runtime/artifact.go
+++ b/runtime/artifact.go
@@ -42,7 +42,7 @@ type RedirectArtifact struct {
 
 // UploadS3Artifact is responsible for creating new artifacts
 // in the queue and then performing the upload to s3.
-func UploadS3Artifact(artifact S3Artifact, context *TaskContext) error {
+func (context *TaskContext) UploadS3Artifact(artifact S3Artifact) error {
 	req, err := json.Marshal(queue.S3ArtifactRequest{
 		ContentType: artifact.Mimetype,
 		Expires:     artifact.Expires,
@@ -52,7 +52,7 @@ func UploadS3Artifact(artifact S3Artifact, context *TaskContext) error {
 		return err
 	}
 
-	parsed, err := createArtifact(context, artifact.Name, req)
+	parsed, err := context.createArtifact(artifact.Name, req)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func UploadS3Artifact(artifact S3Artifact, context *TaskContext) error {
 
 // CreateErrorArtifact is responsible for inserting error
 // artifacts into the queue.
-func CreateErrorArtifact(artifact ErrorArtifact, context *TaskContext) error {
+func (context *TaskContext) CreateErrorArtifact(artifact ErrorArtifact) error {
 	req, err := json.Marshal(queue.ErrorArtifactRequest{
 		Message:     artifact.Message,
 		Reason:      artifact.Reason,
@@ -78,7 +78,7 @@ func CreateErrorArtifact(artifact ErrorArtifact, context *TaskContext) error {
 		return err
 	}
 
-	parsed, err := createArtifact(context, artifact.Name, req)
+	parsed, err := context.createArtifact(artifact.Name, req)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func CreateErrorArtifact(artifact ErrorArtifact, context *TaskContext) error {
 
 // CreateRedirectArtifact is responsible for inserting redirect
 // artifacts into the queue.
-func CreateRedirectArtifact(artifact RedirectArtifact, context *TaskContext) error {
+func (context *TaskContext) CreateRedirectArtifact(artifact RedirectArtifact) error {
 	req, err := json.Marshal(queue.RedirectArtifactRequest{
 		ContentType: artifact.Mimetype,
 		URL:         artifact.URL,
@@ -100,7 +100,7 @@ func CreateRedirectArtifact(artifact RedirectArtifact, context *TaskContext) err
 		return err
 	}
 
-	parsed, err := createArtifact(context, artifact.Name, req)
+	parsed, err := context.createArtifact(artifact.Name, req)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func CreateRedirectArtifact(artifact RedirectArtifact, context *TaskContext) err
 	return json.Unmarshal(parsed, &resp)
 }
 
-func createArtifact(context *TaskContext, name string, req []byte) ([]byte, error) {
+func (context *TaskContext) createArtifact(name string, req []byte) ([]byte, error) {
 	par := queue.PostArtifactRequest(req)
 	parsp, err := context.Queue().CreateArtifact(
 		context.TaskID,

--- a/runtime/artifact_test.go
+++ b/runtime/artifact_test.go
@@ -55,7 +55,7 @@ func TestS3Artifact(t *testing.T) {
 
 	context, mockedQueue := setupArtifactTest(artifact.Name, s3resp)
 
-	UploadS3Artifact(*artifact, context)
+	context.UploadS3Artifact(*artifact)
 	mockedQueue.AssertExpectations(t)
 }
 
@@ -72,7 +72,7 @@ func TestErrorArtifact(t *testing.T) {
 
 	context, mockedQueue := setupArtifactTest(artifact.Name, errorResp)
 
-	CreateErrorArtifact(*artifact, context)
+	context.CreateErrorArtifact(*artifact)
 	mockedQueue.AssertExpectations(t)
 }
 
@@ -89,7 +89,7 @@ func TestRedirectArtifact(t *testing.T) {
 
 	context, mockedQueue := setupArtifactTest(artifact.Name, redirResp)
 
-	CreateRedirectArtifact(*artifact, context)
+	context.CreateRedirectArtifact(*artifact)
 	mockedQueue.AssertExpectations(t)
 }
 


### PR DESCRIPTION
@jonasfj @walac Trivial to implement, but paves the way for being able to query taskContext in a `Finished` stage to get artifacts uploaded in a `Stopped` stage in other plugins.