### PR TITLE
Refactor errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,5 @@ lint:
 	go get github.com/alecthomas/gometalinter
 	gometalinter --install
 	# not enabled: aligncheck, deadcode, dupl, errcheck, gas, gocyclo, structcheck, unused, varcheck
-	gometalinter --deadline=10m --line-length=180 --vendor --vendored-linters --disable-all --enable=goconst --enable=gofmt --enable=goimports --enable=golint --enable=gosimple --enable=gotype --enable=ineffassign --enable=interfacer --enable=lll --enable=misspell --enable=staticcheck --enable=test --enable=testify --enable=unconvert --enable=vet --enable=vetshadow ./...
+	# Disabled: testify, test (these two show test errors, hence, they run tests)
+	gometalinter --deadline=10m --line-length=180 --vendor --vendored-linters --disable-all --enable=goconst --enable=gofmt --enable=goimports --enable=golint --enable=gosimple --enable=gotype --enable=ineffassign --enable=interfacer --enable=lll --enable=misspell --enable=staticcheck --enable=unconvert --enable=vet --enable=vetshadow ./...

--- a/engines/enginetest/environmentvariable.go
+++ b/engines/enginetest/environmentvariable.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/runtime"
 )
 
 // The EnvVarTestCase contains information sufficient to setting an environment
@@ -56,7 +57,7 @@ func (c *EnvVarTestCase) TestInvalidVariableNames() {
 	r.NewSandboxBuilder(c.Payload)
 	for _, name := range c.InvalidVariableNames {
 		err := r.sandboxBuilder.SetEnvironmentVariable(name, "hello world")
-		if _, ok := err.(*engines.MalformedPayloadError); ok {
+		if _, ok := runtime.IsMalformedPayloadError(err); !ok {
 			log.Panic("Expected MalformedPayloadError from invalid variable name: ", name)
 		}
 	}

--- a/engines/errors.go
+++ b/engines/errors.go
@@ -111,25 +111,3 @@ func MergeMalformedPayload(errors ...MalformedPayloadError) MalformedPayloadErro
 	}
 	return MalformedPayloadError{messages: messages}
 }
-
-// InternalError are errors that could not be completed because of issues related to the
-// host.  These issues could include issues with the engine, host resources, and worker
-// configuration.
-type InternalError struct {
-	message string
-}
-
-// Error returns the error message and adheres to the Error interface
-func (e InternalError) Error() string {
-	return e.message
-}
-
-// NewInternalError creates an InternalError object, please
-// make sure to include a detailed description of the error, preferably using
-// multiple lines and with examples.
-//
-// These will be printed in the logs and end-users will rely on them to debug
-// their tasks.
-func NewInternalError(message string) InternalError {
-	return InternalError{message: message}
-}

--- a/engines/errors.go
+++ b/engines/errors.go
@@ -1,9 +1,6 @@
 package engines
 
-import (
-	"errors"
-	"fmt"
-)
+import "errors"
 
 // ErrFeatureNotSupported is a common error that may be returned from optional
 // Engine methods to indicate the engine implementation doesn't support the
@@ -67,47 +64,3 @@ var ErrMaxConcurrencyExceeded = errors.New("Engine is cannot run more than " +
 // ErrEngineNotSupported is used to indicate that the engine isn't supported in
 // the current configuration.
 var ErrEngineNotSupported = errors.New("Engine is not available in the current configuration")
-
-// TODO: MalformedPayloadError should be define in the runtime
-// TODO: MalformedPayloadError should have a merge to join two of these
-//       errors (useful if we have multiple of them)
-
-// The MalformedPayloadError error type is used to indicate that some operation
-// failed because of malformed-payload. For example a string expected to be
-// path contained invalid characters, a required property was missing, or an
-// integer was outside the permitted range.
-type MalformedPayloadError struct {
-	messages []string
-}
-
-// Error returns the error message and adheres to the Error interface
-func (e MalformedPayloadError) Error() string {
-	if len(e.messages) == 1 {
-		return e.messages[0]
-	}
-	//TODO: Make this smarter in some way please!
-	msg := ""
-	for _, m := range e.messages {
-		msg += m + "\n"
-	}
-	return msg
-}
-
-// NewMalformedPayloadError creates a MalformedPayloadError object, please
-// make sure to include a detailed description of the error, preferably using
-// multiple lines and with examples.
-//
-// These will be printed in the logs and end-users will rely on them to debug
-// their tasks.
-func NewMalformedPayloadError(a ...interface{}) MalformedPayloadError {
-	return MalformedPayloadError{messages: []string{fmt.Sprint(a...)}}
-}
-
-// MergeMalformedPayload merges a list of MalformedPayloadError objects
-func MergeMalformedPayload(errors ...MalformedPayloadError) MalformedPayloadError {
-	messages := []string{}
-	for _, e := range errors {
-		messages = append(messages, e.messages...)
-	}
-	return MalformedPayloadError{messages: messages}
-}

--- a/engines/errors.go
+++ b/engines/errors.go
@@ -55,10 +55,6 @@ var ErrNoSuchDisplay = errors.New("No such display exists")
 // ErrNamingConflict is used to indicate that a name is already in use.
 var ErrNamingConflict = errors.New("Conflicting name is already in use")
 
-// ErrNonFatalInternalError is used to indicate that the operation failed
-// because of internal error that isn't expected to affect other tasks.
-var ErrNonFatalInternalError = errors.New("Engine encountered a non-fatal internal error")
-
 // ErrContractViolation is returned when a contract with the engine has been
 // violated.
 var ErrContractViolation = errors.New("Engine has detected a contract violation")

--- a/engines/mock/mocksandbox.go
+++ b/engines/mock/mocksandbox.go
@@ -61,7 +61,7 @@ func (s *sandbox) AttachVolume(mountpoint string, v engines.Volume, readOnly boo
 	s.Lock()
 	defer s.Unlock()
 	if strings.ContainsAny(mountpoint, " ") {
-		return engines.NewMalformedPayloadError("MockEngine mountpoints cannot contain space")
+		return runtime.NewMalformedPayloadError("MockEngine mountpoints cannot contain space")
 	}
 	if s.mounts[mountpoint] != nil {
 		return engines.ErrNamingConflict
@@ -78,7 +78,7 @@ func (s *sandbox) AttachProxy(name string, handler http.Handler) error {
 	s.Lock()
 	defer s.Unlock()
 	if strings.ContainsAny(name, " ") {
-		return engines.NewMalformedPayloadError(
+		return runtime.NewMalformedPayloadError(
 			"MockEngine proxy names cannot contain space.",
 			"Was given proxy name: '", name, "' which isn't allowed!",
 		)
@@ -94,7 +94,7 @@ func (s *sandbox) SetEnvironmentVariable(name string, value string) error {
 	s.Lock()
 	defer s.Unlock()
 	if strings.Contains(name, " ") {
-		return engines.NewMalformedPayloadError(
+		return runtime.NewMalformedPayloadError(
 			"MockEngine environment variable names cannot contain space.",
 			"Was given environment variable name: '", name, "' which isn't allowed!",
 		)
@@ -181,7 +181,7 @@ func (s *sandbox) WaitForResult() (engines.ResultSet, error) {
 		// No need to lock access mounts and proxies either
 		f := functions[s.payload.Function]
 		if f == nil {
-			return nil, engines.NewMalformedPayloadError("Unknown function")
+			return nil, runtime.NewMalformedPayloadError("Unknown function")
 		}
 		result := f(s, s.payload.Argument)
 		s.Lock()

--- a/engines/native/engine.go
+++ b/engines/native/engine.go
@@ -41,12 +41,10 @@ func (engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine, 
 	for _, name := range c.Groups {
 		group, err := system.FindGroup(name)
 		if err != nil {
-			errorMsg := fmt.Sprintf(
-				"Unable to find system user-group: %s from engine config.",
-				name,
+			return nil, fmt.Errorf(
+				"unable to find system user-group: %s from engine config, error: %s",
+				name, err,
 			)
-			options.Monitor.ReportError(err, errorMsg)
-			return nil, engines.NewInternalError(errorMsg)
 		}
 		groups = append(groups, group)
 	}

--- a/engines/native/resultset.go
+++ b/engines/native/resultset.go
@@ -33,7 +33,7 @@ func (r *resultSet) ExtractFile(path string) (ioext.ReadSeekCloser, error) {
 		if _, ok := err.(*os.PathError); ok {
 			return nil, engines.ErrResourceNotFound
 		}
-		return nil, engines.NewMalformedPayloadError(
+		return nil, runtime.NewMalformedPayloadError(
 			"Unable to evaluate path: ", path,
 		)
 	}
@@ -77,7 +77,7 @@ func (r *resultSet) ExtractFolder(path string, handler engines.FileHandler) erro
 		if _, ok := err.(*os.PathError); ok {
 			return engines.ErrResourceNotFound
 		}
-		return engines.NewMalformedPayloadError(
+		return runtime.NewMalformedPayloadError(
 			"Unable to evaluate path: ", path,
 		)
 	}

--- a/engines/native/sandbox.go
+++ b/engines/native/sandbox.go
@@ -69,7 +69,7 @@ func newSandbox(b *sandboxBuilder) (s *sandbox, err error) {
 
 	if b.payload.Context != "" {
 		if err = fetchContext(b.payload.Context, user); err != nil {
-			err = engines.NewMalformedPayloadError(
+			err = runtime.NewMalformedPayloadError(
 				fmt.Sprintf("Error downloading %s: %v", b.payload.Context, err),
 			)
 			b.context.LogError(err)
@@ -99,7 +99,7 @@ func newSandbox(b *sandboxBuilder) (s *sandbox, err error) {
 	if err != nil {
 		// StartProcess provides human-readable error messages (see docs)
 		// We'll convert it to a MalformedPayloadError
-		err = engines.NewMalformedPayloadError(
+		err = runtime.NewMalformedPayloadError(
 			"Unable to start specified command: ", b.payload.Command, "error: ", err,
 		)
 		b.context.LogError(err)
@@ -172,7 +172,7 @@ func (s *sandbox) NewShell(command []string, tty bool) (engines.Shell, error) {
 	if err != nil {
 		debug("Failed to start shell, error: %s", err)
 		s.wg.Done()
-		return nil, engines.NewMalformedPayloadError(
+		return nil, runtime.NewMalformedPayloadError(
 			"Unable to spawn command: ", command, " error: ", err,
 		)
 	}

--- a/engines/native/sandboxbuilder.go
+++ b/engines/native/sandboxbuilder.go
@@ -20,7 +20,7 @@ var envVarPattern = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 
 func (b *sandboxBuilder) SetEnvironmentVariable(name string, value string) error {
 	if !envVarPattern.MatchString(name) {
-		return engines.NewMalformedPayloadError(
+		return runtime.NewMalformedPayloadError(
 			"Environment variables name: '", name, "' doesn't match: ",
 			envVarPattern.String(),
 		)

--- a/engines/qemu/image/util.go
+++ b/engines/qemu/image/util.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/taskcluster/go-got"
-	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/runtime"
 )
 
 // copyFile copies source to destination, and returns an error if one occurs
@@ -84,7 +84,7 @@ func DownloadImage(url string) Downloader {
 				goto retry
 			}
 			if res.StatusCode != 200 {
-				return engines.NewMalformedPayloadError(
+				return runtime.NewMalformedPayloadError(
 					"Image download failed with status code: ", res.StatusCode,
 				)
 			}

--- a/engines/qemu/metaservice/metaservice.go
+++ b/engines/qemu/metaservice/metaservice.go
@@ -355,7 +355,7 @@ func (s *MetaService) getArtifactWithoutRetry(path string) (
 	// Create result values to be set in the callback
 	var File ioext.ReadSeekCloser
 	var Err error
-	Err = engines.ErrNonFatalInternalError
+	Err = runtime.ErrNonFatalInternalError
 
 	s.asyncRequest(Action{
 		Type: "get-artifact",
@@ -416,7 +416,7 @@ func (s *MetaService) GetArtifact(path string) (ioext.ReadSeekCloser, error) {
 	for {
 		f, err := s.getArtifactWithoutRetry(path)
 		retries--
-		if err == engines.ErrNonFatalInternalError && retries > 0 {
+		if err == runtime.ErrNonFatalInternalError && retries > 0 {
 			continue
 		}
 		return f, err
@@ -426,7 +426,7 @@ func (s *MetaService) GetArtifact(path string) (ioext.ReadSeekCloser, error) {
 func (s *MetaService) listFolderWithoutRetries(path string) ([]string, error) {
 	var Result []string
 	var Err error
-	Err = engines.ErrNonFatalInternalError
+	Err = runtime.ErrNonFatalInternalError
 
 	s.asyncRequest(Action{
 		Type: "list-folder",
@@ -483,7 +483,7 @@ func (s *MetaService) ListFolder(path string) ([]string, error) {
 	for {
 		files, err := s.listFolderWithoutRetries(path)
 		retries--
-		if err == engines.ErrNonFatalInternalError && retries > 0 {
+		if err == runtime.ErrNonFatalInternalError && retries > 0 {
 			continue
 		}
 		return files, err
@@ -502,7 +502,7 @@ var upgrader = websocket.Upgrader{
 func (s *MetaService) ExecShell(command []string, tty bool) (engines.Shell, error) {
 	var Shell engines.Shell
 	var Err error
-	Err = engines.ErrNonFatalInternalError
+	Err = runtime.ErrNonFatalInternalError
 
 	s.asyncRequest(Action{
 		Type:    "exec-shell",
@@ -512,7 +512,7 @@ func (s *MetaService) ExecShell(command []string, tty bool) (engines.Shell, erro
 		ws, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			debug("Failed to upgrade request to websocket, error: %s", err)
-			Err = engines.ErrNonFatalInternalError
+			Err = runtime.ErrNonFatalInternalError
 			return
 		}
 

--- a/engines/qemu/sandboxbuilder.go
+++ b/engines/qemu/sandboxbuilder.go
@@ -70,13 +70,13 @@ var proxyNamePattern = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 func (sb *sandboxBuilder) AttachProxy(hostname string, handler http.Handler) error {
 	// Validate hostname against allowed patterns
 	if !proxyNamePattern.MatchString(hostname) {
-		return engines.NewMalformedPayloadError("Proxy hostname: '", hostname, "'",
+		return runtime.NewMalformedPayloadError("Proxy hostname: '", hostname, "'",
 			" is not allowed for QEMU engine. The hostname must match: ",
 			proxyNamePattern.String())
 	}
 	// Ensure that we're not using the magic "engine" hostname
 	if hostname == "engine" {
-		return engines.NewMalformedPayloadError("Proxy hostname: 'engine' is " +
+		return runtime.NewMalformedPayloadError("Proxy hostname: 'engine' is " +
 			"reserved for internal use (meta-data service)")
 	}
 
@@ -100,7 +100,7 @@ var envVarPattern = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 func (sb *sandboxBuilder) SetEnvironmentVariable(name, value string) error {
 	// Simple sanity check of environment variable names
 	if !envVarPattern.MatchString(name) {
-		return engines.NewMalformedPayloadError("Environment variable name: '",
+		return runtime.NewMalformedPayloadError("Environment variable name: '",
 			name, "' is not allowed for QEMU engine. Environment variable names",
 			" must be on the form: ", envVarPattern.String())
 	}

--- a/engines/qemu/vm/machine.go
+++ b/engines/qemu/vm/machine.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -165,7 +165,7 @@ func LoadMachine(machineFile string) (*Machine, error) {
 	// Load the machine configuration
 	machineData, err := ioext.BoundedReadFile(machineFile, 1024*1024)
 	if err == ioext.ErrFileTooBig {
-		return nil, engines.NewMalformedPayloadError(
+		return nil, runtime.NewMalformedPayloadError(
 			"The file 'machine.json' larger than 1MiB. JSON files must be small.")
 	}
 	if err != nil {
@@ -176,7 +176,7 @@ func LoadMachine(machineFile string) (*Machine, error) {
 	m := &Machine{}
 	err = json.Unmarshal(machineData, m)
 	if err != nil {
-		return nil, engines.NewMalformedPayloadError(
+		return nil, runtime.NewMalformedPayloadError(
 			"Invalid JSON in 'machine.json', error: ", err)
 	}
 
@@ -231,7 +231,7 @@ func (m *Machine) Validate() error {
 
 	// Return any errors collected
 	if hasError {
-		return engines.NewMalformedPayloadError(errs)
+		return runtime.NewMalformedPayloadError(errs)
 	}
 	return nil
 }
@@ -264,7 +264,7 @@ func (m *Machine) SetDefaults(options MachineOptions) error {
 
 	// Validate limitations
 	if m.Memory > options.MaxMemory {
-		return engines.NewMalformedPayloadError(
+		return runtime.NewMalformedPayloadError(
 			"Image memory ", m.Memory, " MiB is larger than allowed machine memory ",
 			options.MaxMemory, " MiB",
 		)

--- a/plugins/artifacts/artifacts.go
+++ b/plugins/artifacts/artifacts.go
@@ -109,7 +109,7 @@ func (tp taskPlugin) errorHandled(name string, expires time.Time, err error) boo
 	var reason string
 	if _, ok := err.(*engines.MalformedPayloadError); ok {
 		reason = "invalid-resource-on-worker"
-	} else if err == engines.ErrFeatureNotSupported || err == engines.ErrNonFatalInternalError || err == engines.ErrHandlerInterrupt {
+	} else if err == engines.ErrFeatureNotSupported || err == runtime.ErrNonFatalInternalError || err == engines.ErrHandlerInterrupt {
 		reason = "invalid-resource-on-worker"
 	} else if err == engines.ErrResourceNotFound {
 		reason = "file-missing-on-worker"

--- a/plugins/artifacts/artifacts.go
+++ b/plugins/artifacts/artifacts.go
@@ -58,7 +58,7 @@ func (tp *taskPlugin) Prepare(context *runtime.TaskContext) error {
 }
 
 func (tp *taskPlugin) Stopped(result engines.ResultSet) (bool, error) {
-	nonFatalErrs := []engines.MalformedPayloadError{}
+	nonFatalErrs := []runtime.MalformedPayloadError{}
 
 	for _, artifact := range tp.artifacts {
 		// If expires is set to this time it's the default value
@@ -70,7 +70,7 @@ func (tp *taskPlugin) Stopped(result engines.ResultSet) (bool, error) {
 			err := result.ExtractFolder(artifact.Path, tp.createUploadHandler(artifact.Name, artifact.Expires))
 			if err != nil {
 				if tp.errorHandled(artifact.Name, artifact.Expires, err) {
-					nonFatalErrs = append(nonFatalErrs, engines.NewMalformedPayloadError(err.Error()))
+					nonFatalErrs = append(nonFatalErrs, runtime.NewMalformedPayloadError(err.Error()))
 					continue
 				}
 				return false, err
@@ -79,7 +79,7 @@ func (tp *taskPlugin) Stopped(result engines.ResultSet) (bool, error) {
 			fileReader, err := result.ExtractFile(artifact.Path)
 			if err != nil {
 				if tp.errorHandled(artifact.Name, artifact.Expires, err) {
-					nonFatalErrs = append(nonFatalErrs, engines.NewMalformedPayloadError(err.Error()))
+					nonFatalErrs = append(nonFatalErrs, runtime.NewMalformedPayloadError(err.Error()))
 					continue
 				}
 				return false, err
@@ -97,7 +97,7 @@ func (tp *taskPlugin) Stopped(result engines.ResultSet) (bool, error) {
 		// expected for a succeeded run, but failed tasks might be missing
 		// some artifacts.
 		if result.Success() {
-			return false, engines.MergeMalformedPayload(nonFatalErrs...)
+			return false, runtime.MergeMalformedPayload(nonFatalErrs...)
 		}
 
 		return false, nil
@@ -107,7 +107,7 @@ func (tp *taskPlugin) Stopped(result engines.ResultSet) (bool, error) {
 
 func (tp taskPlugin) errorHandled(name string, expires time.Time, err error) bool {
 	var reason string
-	if _, ok := err.(*engines.MalformedPayloadError); ok {
+	if _, ok := runtime.IsMalformedPayloadError(err); ok {
 		reason = "invalid-resource-on-worker"
 	} else if err == engines.ErrFeatureNotSupported || err == runtime.ErrNonFatalInternalError || err == engines.ErrHandlerInterrupt {
 		reason = "invalid-resource-on-worker"

--- a/plugins/env/env.go
+++ b/plugins/env/env.go
@@ -9,6 +9,7 @@ import (
 	schematypes "github.com/taskcluster/go-schematypes"
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/plugins"
+	"github.com/taskcluster/taskcluster-worker/runtime"
 )
 
 type plugin struct {
@@ -87,9 +88,9 @@ func (p *taskPlugin) BuildSandbox(sandboxBuilder engines.SandboxBuilder) error {
 		// We can only return MalFormedPayloadError
 		switch err {
 		case engines.ErrNamingConflict:
-			return engines.NewMalformedPayloadError("Environment variable ", k, " has already been set.")
+			return runtime.NewMalformedPayloadError("Environment variable ", k, " has already been set.")
 		case engines.ErrFeatureNotSupported:
-			return engines.NewMalformedPayloadError(
+			return runtime.NewMalformedPayloadError(
 				"Cannot set environment variable ",
 				k,
 				". Engine does not support this operation")

--- a/plugins/interactive/shellclient/shellclient.go
+++ b/plugins/interactive/shellclient/shellclient.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/plugins/interactive/shellconsts"
+	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
 	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
 )
@@ -92,7 +93,7 @@ func (s *ShellClient) send(message []byte) bool {
 		s.resolve.Do(func() {
 			debug("Resolving internal error: Failed to send message, error: %s", err)
 			s.success = false
-			s.err = engines.ErrNonFatalInternalError
+			s.err = runtime.ErrNonFatalInternalError
 			s.dispose()
 		})
 		return false
@@ -116,7 +117,7 @@ func (s *ShellClient) sendPings() {
 			s.resolve.Do(func() {
 				debug("Resolving with internal-error, failed to send ping, error: %s", err)
 				s.success = false
-				s.err = engines.ErrNonFatalInternalError
+				s.err = runtime.ErrNonFatalInternalError
 				s.dispose()
 			})
 			return
@@ -185,7 +186,7 @@ func (s *ShellClient) writeMessages() {
 			s.resolve.Do(func() {
 				debug("Resolving internal error: Failed to read stdin, error: %s", err)
 				s.success = false
-				s.err = engines.ErrNonFatalInternalError
+				s.err = runtime.ErrNonFatalInternalError
 				s.dispose()
 			})
 			return
@@ -200,7 +201,7 @@ func (s *ShellClient) readMessages() {
 			s.resolve.Do(func() {
 				debug("Resolving internal error: Failed to read message, error: %s", err)
 				s.success = false
-				s.err = engines.ErrNonFatalInternalError
+				s.err = runtime.ErrNonFatalInternalError
 				s.dispose()
 			})
 			return
@@ -243,7 +244,7 @@ func (s *ShellClient) readMessages() {
 				s.resolve.Do(func() {
 					debug("Resolving internal error: Failed to write streamID: %d, error: %s", mStream, err)
 					s.success = false
-					s.err = engines.ErrNonFatalInternalError
+					s.err = runtime.ErrNonFatalInternalError
 					s.dispose()
 				})
 				return
@@ -312,7 +313,7 @@ func (s *ShellClient) SetSize(columns, rows uint16) error {
 		case <-s.done:
 			return s.err
 		default:
-			return engines.ErrNonFatalInternalError
+			return runtime.ErrNonFatalInternalError
 		}
 	}
 

--- a/plugins/reboot/reboot.go
+++ b/plugins/reboot/reboot.go
@@ -4,6 +4,8 @@
 package reboot
 
 import (
+	"fmt"
+
 	schematypes "github.com/taskcluster/go-schematypes"
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/plugins"
@@ -59,7 +61,7 @@ func (plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlug
 func (tp taskPlugin) Dispose() error {
 	if tp.reboot {
 		if err := reboot(); err != nil {
-			return engines.NewInternalError(err.Error())
+			return fmt.Errorf("Failed to force reboot, error: %s", err)
 		}
 	}
 

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -1,0 +1,29 @@
+package runtime
+
+import "errors"
+
+// ErrNonFatalInternalError is used to indicate that the operation failed
+// because of internal error that isn't expected to affect other tasks.
+//
+// Worker need not worry about logging the error to system log or task log as
+// the engine/plugin which returned this error already reported it, log it
+// and/or deemed the error inconsequential.
+//
+// Worker should, however, report the task as exception and resolve it with
+// reason 'internal-error'. If the worker gets a lot of these non-fatal internal
+// errors, it may employ a heuristic to decide if it has entered a bad state.
+// For example, worker might reboot if it has seen more than 5 non-fatal
+// internal errors within the span of 15min or 5 tasks.
+var ErrNonFatalInternalError = errors.New("Encountered a non-fatal internal error")
+
+// ErrFatalInternalError is used to signal that a fatal internal error has
+// been logged and that the worker should gracefully terminate/reset.
+//
+// Engines and plugins can return any unknown error in-order to trigger the same
+// effect. As the worker will report, log and terminate/reset when it encounters
+// an unknown error. This error is ONLY used when the error has already been
+// reported and logged to both system log and task log.
+//
+// This is only useful for plugins and engines that wishes to manually handle
+// error reporting.
+var ErrFatalInternalError = errors.New("Encountered a fatal internal error")

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -1,0 +1,14 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMalformedPayloadError(t *testing.T) {
+	var err error
+	err = NewMalformedPayloadError("test")
+	_, ok := IsMalformedPayloadError(err)
+	assert.True(t, ok)
+}

--- a/worker/task.go
+++ b/worker/task.go
@@ -199,7 +199,7 @@ func (t *TaskRun) prepareStage() error {
 	payload := map[string]interface{}{}
 	err := json.Unmarshal([]byte(t.definition.Payload), &payload)
 	if err != nil {
-		err = engines.NewMalformedPayloadError(fmt.Sprintf("Invalid task payload. %s", err))
+		err = runtime.NewMalformedPayloadError(fmt.Sprintf("Invalid task payload. %s", err))
 		t.context.LogError(err.Error())
 		return err
 	}
@@ -218,7 +218,7 @@ func (t *TaskRun) prepareStage() error {
 	// Validate payload against schema
 	err = payloadSchema.Validate(payload)
 	if err != nil {
-		err = engines.NewMalformedPayloadError("Schema violation: ", err)
+		err = runtime.NewMalformedPayloadError("Schema violation: ", err)
 		t.context.LogError(err.Error())
 		return err
 	}
@@ -355,7 +355,7 @@ func (t *TaskRun) exceptionStage(taskError error) {
 		reason = runtime.WorkerShutdown
 	} else {
 		switch taskError.(type) {
-		case engines.MalformedPayloadError:
+		case runtime.MalformedPayloadError:
 			reason = runtime.MalformedPayload
 		default:
 			reason = runtime.InternalError


### PR DESCRIPTION
Moving generic errors into `runtime` fixing some cast bugs for `MalformedPayloadError`...

I imagine the following error cases going forward:
```
Error cases: (how the worker will handle these errors)
 - engines.MalformedPayloadError
     Message is printed to task log.
     Task resolved exception with malformed-payload.
 - unknown error
     1) Message forwarded to sentry + syslog, with context tags from monitor.
     2) IncidentId is printed to task log.
     3) Task resolved exception with internal-error.
     4) Worker resets/retarts/destroys itself.
 - engines.ErrFatalInternalError
     The event is logged as Error is syslog, steps (1-2) is assumed done by
     plugin/engine implementor. This is useful, if you have an internal error
     that you feel comfortable writing to task log.
     Task resolved exception with internal-error.
     Worker resets/retarts/destroys itself.
 - engines.ErrNonFatalInternalError
     The event is logged as Warn is syslog, steps (1-2) is assumed done by
     plugin/engine implementor. This is useful, if you have an internal error
     that you feel comfortable isn't fatal for the worker.
     Task resolved exception with internal-error.
     (if worker sees many of these, it will reset the machine)
 - engines|plugins.ErrXXX, context.Canceled,
     Error indicates cancelation, unexpected state or unsupported feature,
     these cases must be handled by caller.
```

@walac  ^ you might want to read that too...

-----
Note: we can introduce more errors in the future... And have more special cases for how they should be handled... The reboot plugin might return a `ErrRebootRequired` from `TaskPlugin.Dispose()` who knows...

But I think this is a good start that'll cover most of our initial use-cases reasonably. Later we might find we have other use-cases or want to optimize the flow..

Example: for `ErrNonFatalInternalError` is couldn't talk to metadata service inside the QEMU virtual machine. This would normally be because someone killed the process inside the VM, which I can't do anything about. But it's also not something I want to cause a worker shutdown. It's just an unfortunate turn of events for the given task. Or maybe I learn later that it ought to be an `ErrResourceNotFound` instead, since task author can produce it by force killing the metadata service.