### PR TITLE
Remove ErrContractViolation in favor of panic()

### DIFF
--- a/engines/errors.go
+++ b/engines/errors.go
@@ -52,10 +52,6 @@ var ErrNoSuchDisplay = errors.New("No such display exists")
 // ErrNamingConflict is used to indicate that a name is already in use.
 var ErrNamingConflict = errors.New("Conflicting name is already in use")
 
-// ErrContractViolation is returned when a contract with the engine has been
-// violated.
-var ErrContractViolation = errors.New("Engine has detected a contract violation")
-
 // ErrMaxConcurrencyExceeded is returned when the engine has limitation on how
 // many sandboxes it can run in parallel and this limit is violated.
 var ErrMaxConcurrencyExceeded = errors.New("Engine is cannot run more than " +

--- a/engines/mock/mockengine.go
+++ b/engines/mock/mockengine.go
@@ -53,17 +53,7 @@ func (e engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.Sandb
 	}
 
 	var p payloadType
-	err := e.PayloadSchema().Map(options.Payload, &p)
-	if err == schematypes.ErrTypeMismatch {
-		// This should pretty much either always happen or never happen.
-		// So while this runtime error is bad we're pretty sure it'll get caught
-		// during testing.
-		panic("TypeMismatch: PayloadSchema doesn't work with payloadType")
-	}
-	if err != nil {
-		// TODO: Write to some sort of log if the type assertion fails
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(payloadSchema, options.Payload, &p)
 	return &sandbox{
 		payload: p,
 		context: options.TaskContext,

--- a/engines/mock/mocksandbox.go
+++ b/engines/mock/mocksandbox.go
@@ -3,6 +3,7 @@ package mockengine
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -55,7 +56,7 @@ func (s *sandbox) AttachVolume(mountpoint string, v engines.Volume, readOnly boo
 	vol, valid := v.(*volume)
 	if !valid {
 		// TODO: Write to some sort of log if the type assertion fails
-		return engines.ErrContractViolation
+		return fmt.Errorf("invalid volume type")
 	}
 	// Lock before we access mounts as this method may be called concurrently
 	s.Lock()

--- a/engines/native/engine.go
+++ b/engines/native/engine.go
@@ -31,10 +31,7 @@ func (engineProvider) ConfigSchema() schematypes.Schema {
 
 func (engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine, error) {
 	var c config
-
-	if schematypes.MustMap(configSchema, options.Config, &c) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(configSchema, options.Config, &c)
 
 	// Load user-groups
 	groups := []*system.Group{}
@@ -63,9 +60,8 @@ func (e *engine) PayloadSchema() schematypes.Object {
 
 func (e *engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.SandboxBuilder, error) {
 	var p payload
-	if schematypes.MustMap(payloadSchema, options.Payload, &p) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(payloadSchema, options.Payload, &p)
+
 	b := &sandboxBuilder{
 		engine:  e,
 		payload: p,

--- a/engines/qemu/engine.go
+++ b/engines/qemu/engine.go
@@ -69,12 +69,7 @@ func (p engineProvider) ConfigSchema() schematypes.Schema {
 
 func (p engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine, error) {
 	var c configType
-	err := configSchema.Map(options.Config, &c)
-	if err == schematypes.ErrTypeMismatch {
-		panic("Type mismatch")
-	} else if err != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(configSchema, options.Config, &c)
 
 	// Create image manager
 	imageManager, err := image.NewManager(
@@ -141,9 +136,7 @@ func (e *engine) PayloadSchema() schematypes.Object {
 
 func (e *engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.SandboxBuilder, error) {
 	var p payloadType
-	if schematypes.MustMap(payloadSchema, options.Payload, &p) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(payloadSchema, options.Payload, &p)
 
 	// Get an idle network
 	net, err := e.networkPool.Network()

--- a/engines/script/engine.go
+++ b/engines/script/engine.go
@@ -30,9 +30,8 @@ func (engineProvider) ConfigSchema() schematypes.Schema {
 
 func (engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine, error) {
 	var config configType
-	if schematypes.MustMap(configSchema, options.Config, &config) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(configSchema, options.Config, &config)
+
 	// Construct payload schema as schematypes.Object using schema.properties
 	properties := schematypes.Properties{}
 	for k, s := range config.Schema.Properties {
@@ -58,9 +57,8 @@ func (e *engine) PayloadSchema() schematypes.Object {
 }
 
 func (e *engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.SandboxBuilder, error) {
-	if e.schema.Validate(options.Payload) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidate(e.schema, options.Payload)
+
 	return &sandboxBuilder{
 		payload: options.Payload,
 		engine:  e,

--- a/plugins/artifacts/artifacts.go
+++ b/plugins/artifacts/artifacts.go
@@ -33,12 +33,7 @@ func (plugin) PayloadSchema() schematypes.Object {
 
 func (plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
 	var p payloadType
-	err := payloadSchema.Map(options.Payload, &p)
-	if err == schematypes.ErrTypeMismatch {
-		panic("internal error -- type mismatch")
-	} else if err != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(payloadSchema, options.Payload, &p)
 
 	return &taskPlugin{
 		TaskPluginBase: plugins.TaskPluginBase{},

--- a/plugins/interactive/interactive.go
+++ b/plugins/interactive/interactive.go
@@ -36,9 +36,8 @@ func (provider) ConfigSchema() schematypes.Schema {
 }
 func (provider) NewPlugin(options plugins.PluginOptions) (plugins.Plugin, error) {
 	var c config
-	if schematypes.MustMap(configSchema, options.Config, &c) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(configSchema, options.Config, &c)
+
 	if c.ArtifactPrefix == "" {
 		c.ArtifactPrefix = defaultArtifactPrefix
 	}
@@ -109,9 +108,8 @@ func (p *plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (
 	plugins.TaskPlugin, error,
 ) {
 	var P payload
-	if schematypes.MustMap(p.PayloadSchema(), options.Payload, &P) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(p.PayloadSchema(), options.Payload, &P)
+
 	// If not always enabled or no options are given then this is disabled
 	if P.Interactive == nil && !p.config.AlwaysEnabled {
 		return nil, nil

--- a/plugins/maxruntime/maxruntime.go
+++ b/plugins/maxruntime/maxruntime.go
@@ -52,9 +52,7 @@ func (plugin) PayloadSchema() schematypes.Object {
 
 func (plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
 	var p payloadType
-	if err := schematypes.MustMap(payloadSchema, options.Payload, &p); err != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(payloadSchema, options.Payload, &p)
 
 	return &taskPlugin{
 		TaskPluginBase: plugins.TaskPluginBase{},

--- a/plugins/pluginmanager.go
+++ b/plugins/pluginmanager.go
@@ -105,17 +105,13 @@ func NewPluginManager(options PluginOptions) (Plugin, error) {
 	configSchema := PluginManagerConfigSchema()
 
 	// Ensure the config is valid
-	if err := configSchema.Validate(options.Config); err != nil {
-		return nil, fmt.Errorf("Invalid config, error: %s", err)
-	}
+	schematypes.MustValidate(configSchema, options.Config)
 	config := options.Config.(map[string]interface{})
 
 	// Find plugins to load
 	var enabled []string
 	var disabled []string
-	if configSchema.Properties["disabled"].Map(config["disabled"], &disabled) != nil {
-		panic("internal error -- shouldn't be possible")
-	}
+	schematypes.MustValidateAndMap(configSchema.Properties["disabled"], config["disabled"], &disabled)
 
 	// Find list of enabled plugins and ensure that config is present if required
 	for name, plugin := range pluginProviders {
@@ -181,9 +177,7 @@ func (m *pluginManager) PayloadSchema() schematypes.Object {
 
 func (m *pluginManager) NewTaskPlugin(options TaskPluginOptions) (manager TaskPlugin, err error) {
 	// Input must be valid
-	if m.payloadSchema.Validate(options.Payload) != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidate(m.payloadSchema, options.Payload)
 
 	taskPlugins := make([]TaskPlugin, len(m.plugins))
 	errors := make([]error, len(m.plugins))

--- a/plugins/reboot/reboot.go
+++ b/plugins/reboot/reboot.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	schematypes "github.com/taskcluster/go-schematypes"
-	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/plugins"
 )
 
@@ -45,12 +44,7 @@ func (plugin) PayloadSchema() schematypes.Object {
 
 func (plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
 	var p payloadType
-	err := payloadSchema.Map(options.Payload, &p)
-	if err == schematypes.ErrTypeMismatch {
-		panic("internal error -- type mismatch")
-	} else if err != nil {
-		return nil, engines.ErrContractViolation
-	}
+	schematypes.MustValidateAndMap(payloadSchema, options.Payload, &p)
 
 	return taskPlugin{
 		TaskPluginBase: plugins.TaskPluginBase{},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -288,10 +288,10 @@
 			"revisionTime": "2017-02-24T22:20:36Z"
 		},
 		{
-			"checksumSHA1": "f/4DVD5erXCtx064MeY3czcBhg8=",
+			"checksumSHA1": "lV1XEyOi9bH23M90Y9QmpvkBnCs=",
 			"path": "github.com/taskcluster/go-schematypes",
-			"revision": "cdf20839f12da41066dac992095a2322c2ad6e3a",
-			"revisionTime": "2016-10-06T20:30:29Z"
+			"revision": "a1195e860f14952214e9f5269459601e3266475b",
+			"revisionTime": "2017-03-03T21:59:25Z"
 		},
 		{
 			"checksumSHA1": "Y3FCWxJ8fakDsn6T3RxfRf+GQn4=",


### PR DESCRIPTION
I'm going to refactor the code that calls plugins and engines such that:
 1) Payload/Config is always valid
 2) Panics are caught and:
    1) reported to sentry,
    2) incidentId printed to task-log
    3) error + incident logged to syslog.

So panicing includes more information about the location than anything else... 
And honestly, we're not going to see these happen.. So we just reduce the amount of boilerplate code.
