### PR TITLE
[bugreport] Disabled broken test, we should not put a file in testdata/\n\nWe sho…

### DIFF
--- a/test/artifacts_test.go
+++ b/test/artifacts_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestUpload(t *testing.T) {
+	t.Skip(`Test case is broken because native engine runs with $HOME as cwd,
+		and extracts artifacts relative to cwd. In fact it doesn't even allow
+		export of artifacts outside of cwd == $HOME.`)
 	if runtime.GOOS == "windows" {
 		t.Skip("Currently not supported on Windows")
 	}


### PR DESCRIPTION
…uld create the file from the command in the payload...

Basically, artifact paths isn't global paths... they are always engine specific... for native they are relative to $HOME, and always required to be under $HOME, so you don't go around exporting random..

This makes a lot of sense when native engine creates a new user account per task. But we could consider disabling it, if we don't do that... Still it's not a crazy limitation... This way you don't need to know what the location of the current working folder is... which is pretty nice.

Besides what business do you have exporting arbitrary files from around the system?