### PR TITLE
Fix linter by disabling gotype, which is afaik checks similar to what…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,19 @@ lint:
 	gometalinter --install
 	# not enabled: aligncheck, deadcode, dupl, errcheck, gas, gocyclo, structcheck, unused, varcheck
 	# Disabled: testify, test (these two show test errors, hence, they run tests)
-	gometalinter -j4 --deadline=15m --line-length=180 --vendor --vendored-linters --disable-all --enable=goconst --enable=gofmt --enable=goimports --enable=golint --enable=gosimple --enable=gotype --enable=ineffassign --enable=interfacer --enable=lll --enable=misspell --enable=staticcheck --enable=unconvert --enable=vet --enable=vetshadow --tests ./...
+	# Disabled: gotype (same as go compiler, also it has issues and was recently removed)
+	gometalinter -j4 --deadline=15m --line-length=180 --vendor --vendored-linters --disable-all \
+		--enable=goconst \
+		--enable=gofmt \
+		--enable=goimports \
+		--enable=golint \
+		--enable=gosimple \
+		--enable=ineffassign \
+		--enable=interfacer \
+		--enable=lll \
+		--enable=misspell \
+		--enable=staticcheck \
+		--enable=unconvert \
+		--enable=vet \
+		--enable=vetshadow \
+		--tests ./...


### PR DESCRIPTION
… go compiler does

For a longer discussion see:
https://github.com/alecthomas/gometalinter/issues/206