### PR TITLE
Fixing the README.md to show the build status, godoc, coverage and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ TaskCluster Worker
 ==================
 
 <img src="https://tools.taskcluster.net/lib/assets/taskcluster-120.png" />
+
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-worker.svg?branch=master)](http://travis-ci.org/taskcluster/taskcluster-worker)
 [![GoDoc](https://godoc.org/github.com/taskcluster/taskcluster-worker?status.svg)](https://godoc.org/github.com/taskcluster/taskcluster-worker)
 [![Coverage Status](https://coveralls.io/repos/taskcluster/taskcluster-worker/badge.svg?branch=master&service=github)](https://coveralls.io/github/taskcluster/taskcluster-worker?branch=master)


### PR DESCRIPTION
Fixes: https://github.com/taskcluster/taskcluster-worker/issues/208
Fixing the README.md to show the build status, godoc, coverage and license badges
