### PR TITLE
Life-Cycle Policy extension register

### DIFF
--- a/lifecyclepolicy/config.go
+++ b/lifecyclepolicy/config.go
@@ -32,7 +32,6 @@ func ConfigSchema() schematypes.Schema {
 }
 
 // New returns a new LifeCyclePolicy from config matching ConfigSchema().
-// The resulting LifeCyclePolicy will control the given worker.
 func New(options Options) LifeCyclePolicy {
 	schematypes.MustValidate(ConfigSchema(), options.Config)
 	// This cast must pass as the config must match ConfigSchema, this is the
@@ -44,7 +43,6 @@ func New(options Options) LifeCyclePolicy {
 	mProviders.Unlock()
 
 	return p.NewLifeCyclePolicy(Options{
-		Worker:  &StoppableOnce{Stoppable: options.Worker},
 		Monitor: options.Monitor.WithTag("life-cycle-policy", provider),
 		Config:  p.ConfigSchema().Filter(options.Config.(map[string]interface{})),
 	})

--- a/lifecyclepolicy/config.go
+++ b/lifecyclepolicy/config.go
@@ -1,0 +1,51 @@
+package lifecyclepolicy
+
+import (
+	"fmt"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+)
+
+// ConfigSchema returns schema for config parameter passed to New()
+//
+// This will compose a schema of config options from all registered providers.
+// For any providers to available users should import modules that register
+// these as side-effects, typically, all sub-folders of this package.
+func ConfigSchema() schematypes.Schema {
+	options := make(schematypes.OneOf, 0, len(providers))
+	for name, provider := range providers {
+		option, err := schematypes.Merge(schematypes.Object{
+			Properties: schematypes.Properties{
+				"provider": schematypes.StringEnum{Options: []string{name}},
+			},
+			Required: []string{"provider"},
+		}, provider.ConfigSchema())
+		if err != nil {
+			// This should never happen as we don't allow registring providers which
+			// has AdditionalProperties: true, or defines a property "provider"
+			panic(fmt.Sprintf("lifecyclepolicy.ConfigSchema(): cannot merge schemas, error: %s", err))
+		}
+		option.MetaData = provider.ConfigSchema().MetaData
+		options = append(options, option)
+	}
+	return options
+}
+
+// New returns a new LifeCyclePolicy from config matching ConfigSchema().
+// The resulting LifeCyclePolicy will control the given worker.
+func New(options Options) LifeCyclePolicy {
+	schematypes.MustValidate(ConfigSchema(), options.Config)
+	// This cast must pass as the config must match ConfigSchema, this is the
+	// callers responsibility
+	provider := options.Config.(map[string]interface{})["provider"].(string)
+
+	mProviders.Lock()
+	p := providers[provider]
+	mProviders.Unlock()
+
+	return p.NewLifeCyclePolicy(Options{
+		Worker:  &StoppableOnce{Stoppable: options.Worker},
+		Monitor: options.Monitor.WithTag("life-cycle-policy", provider),
+		Config:  p.ConfigSchema().Filter(options.Config.(map[string]interface{})),
+	})
+}

--- a/lifecyclepolicy/config_test.go
+++ b/lifecyclepolicy/config_test.go
@@ -1,0 +1,44 @@
+package lifecyclepolicy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigSchema(t *testing.T) {
+	c := map[string]interface{}{
+		"provider": "forever",
+	}
+	assert.NoError(t, ConfigSchema().Validate(c))
+}
+
+func TestNewForeverPolicy(t *testing.T) {
+	c := map[string]interface{}{
+		"provider":    "forever",
+		"stopOnError": true,
+	}
+	s := &mockStoppable{
+		stopNow:        make(chan struct{}),
+		stopGracefully: make(chan struct{}),
+	}
+	policy := New(Options{
+		Worker: s,
+		Config: c,
+	})
+
+	// Let's just try some random operations...
+	for i := 0; i < 100; i++ {
+		policy.ReportIdle(500 * time.Second)
+		policy.ReportTaskClaimed(10)
+		policy.ReportTaskResolved(500 * time.Second)
+	}
+	assert.False(t, isClosed(s.stopGracefully))
+	assert.False(t, isClosed(s.stopNow))
+
+	policy.ReportNonFatalError()
+	assert.True(t, isClosed(s.stopGracefully))
+	assert.False(t, isClosed(s.stopNow))
+
+}

--- a/lifecyclepolicy/doc.go
+++ b/lifecyclepolicy/doc.go
@@ -1,0 +1,16 @@
+// Package lifecyclepolicy defines the interface that lifecyclepolicy providers
+// must satisfy and exposes a plugin register that life-cycle policies must be
+// registered with.
+//
+// A life-cycle policy is given a Stoppable object representing the worker,
+// which can be used to stop the worker either gracefully or immediately.
+// Further more a LifeCyclePolicy is called when certain events occur such as
+// idle time, non-fatal events, tasks claimed, or resolved. A LifeCyclePolicy
+// uses these events in addition to internal logic and timers to decide when/if
+// the workers should be stopped.
+//
+// A LifeCyclePolicy can stop the worker gracefully or immediately at any time.
+// The LifeCyclePolicy is not responsible for tracking whether or not the worker
+// has active tasks, if it wishes the stop gracefully it can call initiate such
+// action at any time and the worker is responsible for not claiming new tasks.
+package lifecyclepolicy

--- a/lifecyclepolicy/forever.go
+++ b/lifecyclepolicy/forever.go
@@ -1,0 +1,54 @@
+package lifecyclepolicy
+
+import (
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+type foreverProvider struct{}
+
+func (foreverProvider) ConfigSchema() schematypes.Object {
+	return schematypes.Object{
+		MetaData: schematypes.MetaData{
+			Title:       "Forever Life-Cycle Policy",
+			Description: "A forever life-cycle policy does nothing to end the life-cycle of the worker.",
+		},
+		Properties: schematypes.Properties{
+			"stopOnError": schematypes.Boolean{
+				MetaData: schematypes.MetaData{
+					Title:       "Stop On Non-Fatal Errors",
+					Description: "If true, this policy will gracefully stop on non-fatal errors.",
+				},
+			},
+		},
+	}
+}
+
+func (foreverProvider) NewLifeCyclePolicy(options Options) LifeCyclePolicy {
+	var c struct {
+		StopError bool `json:"stopOnError"`
+	}
+	schematypes.MustValidateAndMap(foreverProvider{}.ConfigSchema(), options.Config, &c)
+	return &ForeverLifeCyclePolicy{
+		Stoppable: options.Worker,
+		StopError: c.StopError,
+	}
+}
+
+// A ForeverLifeCyclePolicy never stops the worker.
+type ForeverLifeCyclePolicy struct {
+	Base
+	runtime.Stoppable
+	StopError bool
+}
+
+// ReportNonFatalError will gracefully stop the worker if StopError is true
+func (p *ForeverLifeCyclePolicy) ReportNonFatalError() {
+	if p.StopError && p.Stoppable != nil {
+		p.StopGracefully()
+	}
+}
+
+func init() {
+	Register("forever", foreverProvider{})
+}

--- a/lifecyclepolicy/lifecyclepolicy.go
+++ b/lifecyclepolicy/lifecyclepolicy.go
@@ -1,0 +1,39 @@
+package lifecyclepolicy
+
+import "time"
+
+// A LifeCyclePolicy implements the logic for when to stop a worker.
+type LifeCyclePolicy interface {
+	// ReportIdle is called when the worker has been idle for some time.
+	// The parameter d is the time since the worker was last busy.
+	ReportIdle(d time.Duration)
+
+	// ReportTaskClaimed is called when the worker has claimed N task.
+	ReportTaskClaimed(N int)
+
+	// ReportTaskResolved is called when the worker has resolved a task.
+	// The parameter d is the time it took to resolve the task, notice that
+	// multiple tasks may be running at the same time, so this does not add up
+	// with the time given in ReportIdle.
+	ReportTaskResolved(d time.Duration)
+
+	// ReportNonFatalError is called when the worker has encountered a non-fatal
+	// error of some sort..
+	ReportNonFatalError()
+}
+
+// Base provides a base implemetation of LifeCyclePolicy, implementors should
+// always embed this to ensure forward compatibility.
+type Base struct{}
+
+// ReportIdle does nothing, but serves to provide an empty implementation
+func (Base) ReportIdle(time.Duration) {}
+
+// ReportTaskClaimed does nothing, but serves to provide an empty implementation
+func (Base) ReportTaskClaimed(int) {}
+
+// ReportTaskResolved does nothing, but serves to provide an empty implementation
+func (Base) ReportTaskResolved(time.Duration) {}
+
+// ReportNonFatalError does nothing, but serves to provide an empty implementation
+func (Base) ReportNonFatalError() {}

--- a/lifecyclepolicy/lifecyclepolicy.go
+++ b/lifecyclepolicy/lifecyclepolicy.go
@@ -1,9 +1,20 @@
 package lifecyclepolicy
 
-import "time"
+import (
+	"time"
 
-// A LifeCyclePolicy implements the logic for when to stop a worker.
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+// A LifeCyclePolicy provides a way to construct a Controller for a Stoppable
+// worker.
 type LifeCyclePolicy interface {
+	NewController(worker runtime.Stoppable) Controller
+}
+
+// A Controller implements a life-cycle policy for the worker given when it
+// was created in NewController()
+type Controller interface {
 	// ReportIdle is called when the worker has been idle for some time.
 	// The parameter d is the time since the worker was last busy.
 	ReportIdle(d time.Duration)
@@ -22,7 +33,7 @@ type LifeCyclePolicy interface {
 	ReportNonFatalError()
 }
 
-// Base provides a base implemetation of LifeCyclePolicy, implementors should
+// Base provides a base implemetation of Controller, implementors should
 // always embed this to ensure forward compatibility.
 type Base struct{}
 

--- a/lifecyclepolicy/provider.go
+++ b/lifecyclepolicy/provider.go
@@ -15,7 +15,6 @@ var (
 
 // Options for creating a LifeCyclePolicy
 type Options struct {
-	Worker  runtime.Stoppable
 	Monitor runtime.Monitor
 	Config  interface{}
 }

--- a/lifecyclepolicy/provider.go
+++ b/lifecyclepolicy/provider.go
@@ -1,0 +1,58 @@
+package lifecyclepolicy
+
+import (
+	"fmt"
+	"sync"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+var (
+	mProviders = sync.Mutex{}
+	providers  = make(map[string]Provider)
+)
+
+// Options for creating a LifeCyclePolicy
+type Options struct {
+	Worker  runtime.Stoppable
+	Monitor runtime.Monitor
+	Config  interface{}
+}
+
+// A Provider is a factory for a LifeCyclePolicy
+type Provider interface {
+	NewLifeCyclePolicy(Options) LifeCyclePolicy
+	ConfigSchema() schematypes.Object
+}
+
+// Register will register an Provider, this is intended to be called
+// from func init() {}, to register providers as an import side-effect.
+//
+// If an provider with the given name is already registered this will panic.
+func Register(name string, provider Provider) {
+	mProviders.Lock()
+	defer mProviders.Unlock()
+
+	// A few simple schema restrictions that people probably won't hit.
+	// Notably they allow us to flatten the config structure a bit, so that's nice.
+	if provider.ConfigSchema().AdditionalProperties {
+		panic(fmt.Sprintf("lifecyclepolicy.Provider implementation '%s' "+
+			"allows additionalProperties in ConfigSchema()", name))
+	}
+	if _, ok := provider.ConfigSchema().Properties["provider"]; ok {
+		panic(fmt.Sprintf("lifecyclepolicy.Provider implementation '%s' "+
+			"defines property 'provider' in ConfigSchema()", name))
+	}
+
+	// Panic, if name is in use. This is okay as we always call this from init()
+	// so it'll happen before any tests or code runs.
+	if _, ok := providers[name]; ok {
+		panic(fmt.Sprintf(
+			"a lifecyclepolicy.Provider with the name '%s' is already registered", name,
+		))
+	}
+
+	// Register the engine
+	providers[name] = provider
+}

--- a/lifecyclepolicy/stoppableonce.go
+++ b/lifecyclepolicy/stoppableonce.go
@@ -1,0 +1,58 @@
+package lifecyclepolicy
+
+import (
+	"sync"
+
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+// StoppableOnce is a wrapper that ensures we only call StopGracefully and
+// StopNow once and never call StopGracefully after StopNow.
+//
+// There is never any harm in wrapping with this, it merely limits excessive
+// calls to StopNow() and StopGracefully(). Please note that Stoppable.StopNow()
+// may still be invoked after Stoppable.StopGracefully(), it can even be invoked
+// concurrently.
+type StoppableOnce struct {
+	Stoppable          runtime.Stoppable
+	m                  sync.Mutex
+	stoppingNow        chan struct{}
+	stoppingGracefully chan struct{}
+}
+
+// StopGracefully calls StopGracefully() on the s.Stoppable, if neither
+// StopGracefully() or StopNow() have been called.
+func (s *StoppableOnce) StopGracefully() {
+	s.m.Lock()
+	if s.stoppingGracefully == nil && s.stoppingNow == nil {
+		s.stoppingGracefully = make(chan struct{})
+		go func() {
+			s.Stoppable.StopGracefully()
+			close(s.stoppingGracefully)
+		}()
+	}
+	var stopped chan struct{}
+	if s.stoppingNow != nil {
+		stopped = s.stoppingNow
+	} else {
+		stopped = s.stoppingGracefully
+	}
+	s.m.Unlock()
+
+	<-stopped
+}
+
+// StopNow calls StopNow() on s.Stoppable, if StopNow() haven't been called yet.
+func (s *StoppableOnce) StopNow() {
+	s.m.Lock()
+	if s.stoppingNow == nil {
+		s.stoppingNow = make(chan struct{})
+		go func() {
+			s.Stoppable.StopNow()
+			close(s.stoppingNow)
+		}()
+	}
+	s.m.Unlock()
+
+	<-s.stoppingNow
+}

--- a/lifecyclepolicy/stoppableonce_test.go
+++ b/lifecyclepolicy/stoppableonce_test.go
@@ -1,0 +1,60 @@
+package lifecyclepolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockStoppable struct {
+	stopNow        chan struct{}
+	stopGracefully chan struct{}
+}
+
+func (s *mockStoppable) StopNow() {
+	close(s.stopNow)
+}
+
+func (s *mockStoppable) StopGracefully() {
+	close(s.stopGracefully)
+}
+
+func isClosed(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestStoppableOnceStopNowOnce(t *testing.T) {
+	s := &mockStoppable{
+		stopNow:        make(chan struct{}),
+		stopGracefully: make(chan struct{}),
+	}
+
+	o := StoppableOnce{Stoppable: s}
+	o.StopNow()
+	o.StopNow()
+	o.StopGracefully()
+	o.StopGracefully()
+	assert.True(t, isClosed(s.stopNow))
+	assert.False(t, isClosed(s.stopGracefully))
+}
+
+func TestStoppableOnceStopNowOverwritesGracefully(t *testing.T) {
+	s := &mockStoppable{
+		stopNow:        make(chan struct{}),
+		stopGracefully: make(chan struct{}),
+	}
+
+	o := StoppableOnce{Stoppable: s}
+	o.StopGracefully()
+	o.StopNow()
+	o.StopNow()
+	o.StopGracefully()
+	o.StopNow()
+	assert.True(t, isClosed(s.stopNow))
+	assert.True(t, isClosed(s.stopGracefully))
+}

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -12,3 +12,13 @@ type Environment struct {
 	webhookserver.WebHookServer
 	Monitor
 }
+
+// Stoppable is an worker with a life-cycle that can be can be stopped.
+type Stoppable interface {
+	// StopNow causes the worker to stop processing tasks, resolving all active
+	// tasks exception w. worker-shutdown.
+	StopNow()
+	// StopGracefully causes the worker to stop claiming tasks and stop gracefully
+	// when all active tasks have been resolved.
+	StopGracefully()
+}


### PR DESCRIPTION
@petemoore, I don't know if we want this as a new top-level folder... It doesn't seem like it belongs a subpackage of runtime, since it depends on runtime... and it's not really worker a subpackage of the worker/ package either...

Btw, placed the `Stoppable` interface in runtime as `runtime.Stoppable` my thinking is that we can add `Stoppable` to `runtime.Environment` that way any engine/plugin can call `StopNow()` or `StopGracefully()` giving us the ability to write the `reboot` plugin the right way :)

@walac, if curious I'm hoping this will be abstraction we hide EC2 shutdown logic behind... ie. we'll implement an `LifeCyclePolicy` for EC2, another one for datacenter, a third one for say packet.net, etc... Similar to how we pick an engine in config we just pick a life-cycle policy too.