### PR TITLE
Worker2

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -47,7 +47,8 @@ tasks:
           git fetch --tags
           git checkout -f '{{ event.head.sha }}'
           git clean -d -f -e '/vendor/*' -x
-          govendor sync
+          # sometimes `govendor sync` fails first time, so run again, if fails first time
+          govendor sync || govendor sync
           make rebuild check
       artifacts:
         public/build/taskcluster-worker-linux-amd64:
@@ -83,11 +84,11 @@ tasks:
           type: file
           path: public/build/taskcluster-worker-windows-amd64.exe
       command:
+        - 'set GOROOT=%CD%\go1.8\go'
+        - 'set GOPATH=%CD%\gopath'
+        - 'set PATH=%GOPATH%\bin;%GOROOT%\bin;%PATH%'
         - 'mkdir public\build'
-        - 'mklink public\build\taskcluster-worker-windows-amd64.exe go\bin\taskcluster-worker.exe'
-        - 'set GOPATH=%CD%\go'
-        - 'set PATH=%GOPATH%\bin;%PATH%'
-        - ':: source "${TASKCLUSTER_CREDS_BOOTSTRAP}"'
+        - 'mklink public\build\taskcluster-worker-windows-amd64.exe "%GOPATH%\bin\taskcluster-worker.exe"'
         - 'go get -v github.com/kardianos/govendor'
         - 'if not exist "%GOPATH%\src\github.com\taskcluster" mkdir "%GOPATH%\src\github.com\taskcluster"'
         - 'cd "%GOPATH%\src\github.com\taskcluster"'
@@ -97,15 +98,16 @@ tasks:
         - 'git fetch --tags'
         - 'git checkout -f {{ event.head.sha }}'
         - 'git clean -d -f -e /vendor/* -x'
-        - 'govendor sync'
+        - ':: sometimes `govendor sync` fails first time, so run again, if fails first time'
+        - 'govendor sync || govendor sync'
         - 'C:\taskcluster-worker-test-creds.cmd'
         - '"C:\mozilla-build\msys\bin\bash.exe" --login -c "cd ${GOPATH}/src/github.com/taskcluster/taskcluster-worker && make rebuild check"'
       mounts:
         - cacheName: taskcluster-worker-checkout
-          directory: go/src
+          directory: gopath/src
         - content:
-            url: https://storage.googleapis.com/golang/go1.7.5.windows-amd64.zip
-          directory: .
+            url: https://storage.googleapis.com/golang/go1.8.windows-amd64.zip
+          directory: go1.8
           format: zip
         - content:
             url: https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.3/MinGit-2.11.0.3-64-bit.zip
@@ -141,7 +143,9 @@ tasks:
         - - /bin/bash
           - -vxec
           - |
-            export GOPATH="$(pwd)/go"
+            export GOROOT="$(pwd)/go1.8/go"
+            export GOPATH="$(pwd)/gopath"
+            export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
             source "${TASKCLUSTER_CREDS_BOOTSTRAP}"
             go get -v "github.com/kardianos/govendor"
             mkdir -p "${GOPATH}/src/github.com/taskcluster"
@@ -151,11 +155,16 @@ tasks:
             git fetch --tags
             git checkout -f '{{ event.head.sha }}'
             git clean -d -f -e '/vendor/*' -x
-            govendor sync
+            # sometimes `govendor sync` fails first time, so run again, if fails first time
+            govendor sync || govendor sync
             make rebuild check
             cd ../../../../..
             mkdir -p public/build
-            mv go/bin/taskcluster-worker public/build/taskcluster-worker-darwin-amd64
+            mv "${GOPATH}/bin/taskcluster-worker" public/build/taskcluster-worker-darwin-amd64
       mounts:
         - cacheName: taskcluster-worker-checkout
-          directory: go/src
+          directory: gopath/src
+        - content:
+            url: https://storage.googleapis.com/golang/go1.8.darwin-amd64.tar.gz
+          directory: go1.8
+          format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint:
 	# not enabled: aligncheck, deadcode, dupl, errcheck, gas, gocyclo, structcheck, unused, varcheck
 	# Disabled: testify, test (these two show test errors, hence, they run tests)
 	# Disabled: gotype (same as go compiler, also it has issues and was recently removed)
-	gometalinter -j4 --deadline=15m --line-length=180 --vendor --vendored-linters --disable-all \
+	gometalinter -j4 --deadline=30m --line-length=180 --vendor --vendored-linters --disable-all \
 		--enable=goconst \
 		--enable=gofmt \
 		--enable=goimports \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 TaskCluster Worker
 ==================
 
-<img src="https://tools.taskcluster.net/lib/assets/taskcluster-120.png" />
+[![logo](https://tools.taskcluster.net/lib/assets/taskcluster-120.png)](https://tools.taskcluster.net/lib/assets/taskcluster-120.png)
+
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-worker.svg?branch=master)](http://travis-ci.org/taskcluster/taskcluster-worker)
 [![GoDoc](https://godoc.org/github.com/taskcluster/taskcluster-worker?status.svg)](https://godoc.org/github.com/taskcluster/taskcluster-worker)
 [![Coverage Status](https://coveralls.io/repos/taskcluster/taskcluster-worker/badge.svg?branch=master&service=github)](https://coveralls.io/github/taskcluster/taskcluster-worker?branch=master)
@@ -27,7 +28,7 @@ See https://github.com/taskcluster/taskcluster-worker/releases
 Installing From Source
 ----------------------
 
-1. [Install go 1.7](https://golang.org/doc/install) or higher
+1. [Install go 1.8](https://golang.org/doc/install) or higher
 2. `go get -u -t -d github.com/taskclustertaskcluster-worker/...`
 3. `cd "${GOPATH}/src/github.com/taskcluster-worker"`
 4. `go get -u github.com/kardianos/govendor`

--- a/commands/daemon/service.go
+++ b/commands/daemon/service.go
@@ -38,7 +38,7 @@ func (svc *service) Run() (string, error) {
 	}
 
 	sigTerm := make(chan os.Signal, 1)
-	signal.Notify(sigTerm, os.Interrupt, os.Kill, syscall.SIGTERM)
+	signal.Notify(sigTerm, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigTerm
 		w.ImmediateStop()

--- a/commands/qemu-run/run.go
+++ b/commands/qemu-run/run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	graceful "gopkg.in/tylerb/graceful.v1"
@@ -152,7 +153,7 @@ func (cmd) Execute(arguments map[string]interface{}) bool {
 
 	// Wait for SIGINT/SIGKILL or vm.Done
 	c := make(chan os.Signal, 2)
-	signal.Notify(c, os.Interrupt, os.Kill) // This pattern leaks, acceptable here
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM) // This pattern leaks, acceptable here
 	select {
 	case <-c:
 		signal.Stop(c)

--- a/commands/work/work.go
+++ b/commands/work/work.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/taskcluster/taskcluster-worker/commands"
 	"github.com/taskcluster/taskcluster-worker/config"
@@ -45,7 +46,7 @@ func (cmd) Execute(args map[string]interface{}) bool {
 		close(done)
 	}()
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, os.Kill)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	select {
 	case <-c:
 		signal.Stop(c)

--- a/engines/qemu/metaservice/metaservice.go
+++ b/engines/qemu/metaservice/metaservice.go
@@ -353,8 +353,10 @@ func (s *MetaService) getArtifactWithoutRetry(path string) (
 	ioext.ReadSeekCloser, error,
 ) {
 	// Create result values to be set in the callback
-	var File ioext.ReadSeekCloser
-	var Err error
+	var (
+		File ioext.ReadSeekCloser
+		Err  error
+	)
 	Err = runtime.ErrNonFatalInternalError
 
 	s.asyncRequest(Action{
@@ -424,8 +426,10 @@ func (s *MetaService) GetArtifact(path string) (ioext.ReadSeekCloser, error) {
 }
 
 func (s *MetaService) listFolderWithoutRetries(path string) ([]string, error) {
-	var Result []string
-	var Err error
+	var (
+		Result []string
+		Err    error
+	)
 	Err = runtime.ErrNonFatalInternalError
 
 	s.asyncRequest(Action{
@@ -500,8 +504,10 @@ var upgrader = websocket.Upgrader{
 // for guest-tools to callback establish a websocket and connect to an
 // implementation of engines.Shell
 func (s *MetaService) ExecShell(command []string, tty bool) (engines.Shell, error) {
-	var Shell engines.Shell
-	var Err error
+	var (
+		Shell engines.Shell
+		Err   error
+	)
 	Err = runtime.ErrNonFatalInternalError
 
 	s.asyncRequest(Action{

--- a/engines/qemu/resultset.go
+++ b/engines/qemu/resultset.go
@@ -48,7 +48,7 @@ func (r *resultSet) ExtractFolder(path string, handler engines.FileHandler) erro
 		}
 		// If guest uses backslashes our input paths should have that, but the ones
 		// we return should be intepreted as names.
-		p = strings.Replace(p[len(path):], "\\", "/", 0)
+		p = strings.Replace(p[len(path):], "\\", "/", -1)
 		if len(p) > 0 && p[0] == '\\' {
 			p = p[1:]
 		}

--- a/engines/qemu/vm/machine.go
+++ b/engines/qemu/vm/machine.go
@@ -190,8 +190,7 @@ func LoadMachine(machineFile string) (*Machine, error) {
 
 // Clone returns a copy of this machine definition
 func (m *Machine) Clone() *Machine {
-	var machine Machine
-	machine = *m
+	machine := *m
 	return &machine
 }
 

--- a/lifecyclepolicy/config.go
+++ b/lifecyclepolicy/config.go
@@ -1,0 +1,51 @@
+package lifecyclepolicy
+
+import (
+	"fmt"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+)
+
+// ConfigSchema returns schema for config parameter passed to New()
+//
+// This will compose a schema of config options from all registered providers.
+// For any providers to available users should import modules that register
+// these as side-effects, typically, all sub-folders of this package.
+func ConfigSchema() schematypes.Schema {
+	options := make(schematypes.OneOf, 0, len(providers))
+	for name, provider := range providers {
+		option, err := schematypes.Merge(schematypes.Object{
+			Properties: schematypes.Properties{
+				"provider": schematypes.StringEnum{Options: []string{name}},
+			},
+			Required: []string{"provider"},
+		}, provider.ConfigSchema())
+		if err != nil {
+			// This should never happen as we don't allow registring providers which
+			// has AdditionalProperties: true, or defines a property "provider"
+			panic(fmt.Sprintf("lifecyclepolicy.ConfigSchema(): cannot merge schemas, error: %s", err))
+		}
+		option.MetaData = provider.ConfigSchema().MetaData
+		options = append(options, option)
+	}
+	return options
+}
+
+// New returns a new LifeCyclePolicy from config matching ConfigSchema().
+// The resulting LifeCyclePolicy will control the given worker.
+func New(options Options) LifeCyclePolicy {
+	schematypes.MustValidate(ConfigSchema(), options.Config)
+	// This cast must pass as the config must match ConfigSchema, this is the
+	// callers responsibility
+	provider := options.Config.(map[string]interface{})["provider"].(string)
+
+	mProviders.Lock()
+	p := providers[provider]
+	mProviders.Unlock()
+
+	return p.NewLifeCyclePolicy(Options{
+		Worker:  &StoppableOnce{Stoppable: options.Worker},
+		Monitor: options.Monitor.WithTag("life-cycle-policy", provider),
+		Config:  p.ConfigSchema().Filter(options.Config.(map[string]interface{})),
+	})
+}

--- a/lifecyclepolicy/config_test.go
+++ b/lifecyclepolicy/config_test.go
@@ -1,0 +1,44 @@
+package lifecyclepolicy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigSchema(t *testing.T) {
+	c := map[string]interface{}{
+		"provider": "forever",
+	}
+	assert.NoError(t, ConfigSchema().Validate(c))
+}
+
+func TestNewForeverPolicy(t *testing.T) {
+	c := map[string]interface{}{
+		"provider":    "forever",
+		"stopOnError": true,
+	}
+	s := &mockStoppable{
+		stopNow:        make(chan struct{}),
+		stopGracefully: make(chan struct{}),
+	}
+	policy := New(Options{
+		Worker: s,
+		Config: c,
+	})
+
+	// Let's just try some random operations...
+	for i := 0; i < 100; i++ {
+		policy.ReportIdle(500 * time.Second)
+		policy.ReportTaskClaimed(10)
+		policy.ReportTaskResolved(500 * time.Second)
+	}
+	assert.False(t, isClosed(s.stopGracefully))
+	assert.False(t, isClosed(s.stopNow))
+
+	policy.ReportNonFatalError()
+	assert.True(t, isClosed(s.stopGracefully))
+	assert.False(t, isClosed(s.stopNow))
+
+}

--- a/lifecyclepolicy/doc.go
+++ b/lifecyclepolicy/doc.go
@@ -1,0 +1,16 @@
+// Package lifecyclepolicy defines the interface that lifecyclepolicy providers
+// must satisfy and exposes a plugin register that life-cycle policies must be
+// registered with.
+//
+// A life-cycle policy is given a Stoppable object representing the worker,
+// which can be used to stop the worker either gracefully or immediately.
+// Further more a LifeCyclePolicy is called when certain events occur such as
+// idle time, non-fatal events, tasks claimed, or resolved. A LifeCyclePolicy
+// uses these events in addition to internal logic and timers to decide when/if
+// the workers should be stopped.
+//
+// A LifeCyclePolicy can stop the worker gracefully or immediately at any time.
+// The LifeCyclePolicy is not responsible for tracking whether or not the worker
+// has active tasks, if it wishes the stop gracefully it can call initiate such
+// action at any time and the worker is responsible for not claiming new tasks.
+package lifecyclepolicy

--- a/lifecyclepolicy/forever.go
+++ b/lifecyclepolicy/forever.go
@@ -1,0 +1,54 @@
+package lifecyclepolicy
+
+import (
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+type foreverProvider struct{}
+
+func (foreverProvider) ConfigSchema() schematypes.Object {
+	return schematypes.Object{
+		MetaData: schematypes.MetaData{
+			Title:       "Forever Life-Cycle Policy",
+			Description: "A forever life-cycle policy does nothing to end the life-cycle of the worker.",
+		},
+		Properties: schematypes.Properties{
+			"stopOnError": schematypes.Boolean{
+				MetaData: schematypes.MetaData{
+					Title:       "Stop On Non-Fatal Errors",
+					Description: "If true, this policy will gracefully stop on non-fatal errors.",
+				},
+			},
+		},
+	}
+}
+
+func (foreverProvider) NewLifeCyclePolicy(options Options) LifeCyclePolicy {
+	var c struct {
+		StopError bool `json:"stopOnError"`
+	}
+	schematypes.MustValidateAndMap(foreverProvider{}.ConfigSchema(), options.Config, &c)
+	return &ForeverLifeCyclePolicy{
+		Stoppable: options.Worker,
+		StopError: c.StopError,
+	}
+}
+
+// A ForeverLifeCyclePolicy never stops the worker.
+type ForeverLifeCyclePolicy struct {
+	Base
+	runtime.Stoppable
+	StopError bool
+}
+
+// ReportNonFatalError will gracefully stop the worker if StopError is true
+func (p *ForeverLifeCyclePolicy) ReportNonFatalError() {
+	if p.StopError && p.Stoppable != nil {
+		p.StopGracefully()
+	}
+}
+
+func init() {
+	Register("forever", foreverProvider{})
+}

--- a/lifecyclepolicy/lifecyclepolicy.go
+++ b/lifecyclepolicy/lifecyclepolicy.go
@@ -1,0 +1,39 @@
+package lifecyclepolicy
+
+import "time"
+
+// A LifeCyclePolicy implements the logic for when to stop a worker.
+type LifeCyclePolicy interface {
+	// ReportIdle is called when the worker has been idle for some time.
+	// The parameter d is the time since the worker was last busy.
+	ReportIdle(d time.Duration)
+
+	// ReportTaskClaimed is called when the worker has claimed N task.
+	ReportTaskClaimed(N int)
+
+	// ReportTaskResolved is called when the worker has resolved a task.
+	// The parameter d is the time it took to resolve the task, notice that
+	// multiple tasks may be running at the same time, so this does not add up
+	// with the time given in ReportIdle.
+	ReportTaskResolved(d time.Duration)
+
+	// ReportNonFatalError is called when the worker has encountered a non-fatal
+	// error of some sort..
+	ReportNonFatalError()
+}
+
+// Base provides a base implemetation of LifeCyclePolicy, implementors should
+// always embed this to ensure forward compatibility.
+type Base struct{}
+
+// ReportIdle does nothing, but serves to provide an empty implementation
+func (Base) ReportIdle(time.Duration) {}
+
+// ReportTaskClaimed does nothing, but serves to provide an empty implementation
+func (Base) ReportTaskClaimed(int) {}
+
+// ReportTaskResolved does nothing, but serves to provide an empty implementation
+func (Base) ReportTaskResolved(time.Duration) {}
+
+// ReportNonFatalError does nothing, but serves to provide an empty implementation
+func (Base) ReportNonFatalError() {}

--- a/lifecyclepolicy/provider.go
+++ b/lifecyclepolicy/provider.go
@@ -1,0 +1,58 @@
+package lifecyclepolicy
+
+import (
+	"fmt"
+	"sync"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+var (
+	mProviders = sync.Mutex{}
+	providers  = make(map[string]Provider)
+)
+
+// Options for creating a LifeCyclePolicy
+type Options struct {
+	Worker  runtime.Stoppable
+	Monitor runtime.Monitor
+	Config  interface{}
+}
+
+// A Provider is a factory for a LifeCyclePolicy
+type Provider interface {
+	NewLifeCyclePolicy(Options) LifeCyclePolicy
+	ConfigSchema() schematypes.Object
+}
+
+// Register will register an Provider, this is intended to be called
+// from func init() {}, to register providers as an import side-effect.
+//
+// If an provider with the given name is already registered this will panic.
+func Register(name string, provider Provider) {
+	mProviders.Lock()
+	defer mProviders.Unlock()
+
+	// A few simple schema restrictions that people probably won't hit.
+	// Notably they allow us to flatten the config structure a bit, so that's nice.
+	if provider.ConfigSchema().AdditionalProperties {
+		panic(fmt.Sprintf("lifecyclepolicy.Provider implementation '%s' "+
+			"allows additionalProperties in ConfigSchema()", name))
+	}
+	if _, ok := provider.ConfigSchema().Properties["provider"]; ok {
+		panic(fmt.Sprintf("lifecyclepolicy.Provider implementation '%s' "+
+			"defines property 'provider' in ConfigSchema()", name))
+	}
+
+	// Panic, if name is in use. This is okay as we always call this from init()
+	// so it'll happen before any tests or code runs.
+	if _, ok := providers[name]; ok {
+		panic(fmt.Sprintf(
+			"a lifecyclepolicy.Provider with the name '%s' is already registered", name,
+		))
+	}
+
+	// Register the engine
+	providers[name] = provider
+}

--- a/lifecyclepolicy/stoppableonce.go
+++ b/lifecyclepolicy/stoppableonce.go
@@ -1,0 +1,58 @@
+package lifecyclepolicy
+
+import (
+	"sync"
+
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+// StoppableOnce is a wrapper that ensures we only call StopGracefully and
+// StopNow once and never call StopGracefully after StopNow.
+//
+// There is never any harm in wrapping with this, it merely limits excessive
+// calls to StopNow() and StopGracefully(). Please note that Stoppable.StopNow()
+// may still be invoked after Stoppable.StopGracefully(), it can even be invoked
+// concurrently.
+type StoppableOnce struct {
+	Stoppable          runtime.Stoppable
+	m                  sync.Mutex
+	stoppingNow        chan struct{}
+	stoppingGracefully chan struct{}
+}
+
+// StopGracefully calls StopGracefully() on the s.Stoppable, if neither
+// StopGracefully() or StopNow() have been called.
+func (s *StoppableOnce) StopGracefully() {
+	s.m.Lock()
+	if s.stoppingGracefully == nil && s.stoppingNow == nil {
+		s.stoppingGracefully = make(chan struct{})
+		go func() {
+			s.Stoppable.StopGracefully()
+			close(s.stoppingGracefully)
+		}()
+	}
+	var stopped chan struct{}
+	if s.stoppingNow != nil {
+		stopped = s.stoppingNow
+	} else {
+		stopped = s.stoppingGracefully
+	}
+	s.m.Unlock()
+
+	<-stopped
+}
+
+// StopNow calls StopNow() on s.Stoppable, if StopNow() haven't been called yet.
+func (s *StoppableOnce) StopNow() {
+	s.m.Lock()
+	if s.stoppingNow == nil {
+		s.stoppingNow = make(chan struct{})
+		go func() {
+			s.Stoppable.StopNow()
+			close(s.stoppingNow)
+		}()
+	}
+	s.m.Unlock()
+
+	<-s.stoppingNow
+}

--- a/lifecyclepolicy/stoppableonce_test.go
+++ b/lifecyclepolicy/stoppableonce_test.go
@@ -1,0 +1,60 @@
+package lifecyclepolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockStoppable struct {
+	stopNow        chan struct{}
+	stopGracefully chan struct{}
+}
+
+func (s *mockStoppable) StopNow() {
+	close(s.stopNow)
+}
+
+func (s *mockStoppable) StopGracefully() {
+	close(s.stopGracefully)
+}
+
+func isClosed(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestStoppableOnceStopNowOnce(t *testing.T) {
+	s := &mockStoppable{
+		stopNow:        make(chan struct{}),
+		stopGracefully: make(chan struct{}),
+	}
+
+	o := StoppableOnce{Stoppable: s}
+	o.StopNow()
+	o.StopNow()
+	o.StopGracefully()
+	o.StopGracefully()
+	assert.True(t, isClosed(s.stopNow))
+	assert.False(t, isClosed(s.stopGracefully))
+}
+
+func TestStoppableOnceStopNowOverwritesGracefully(t *testing.T) {
+	s := &mockStoppable{
+		stopNow:        make(chan struct{}),
+		stopGracefully: make(chan struct{}),
+	}
+
+	o := StoppableOnce{Stoppable: s}
+	o.StopGracefully()
+	o.StopNow()
+	o.StopNow()
+	o.StopGracefully()
+	o.StopNow()
+	assert.True(t, isClosed(s.stopNow))
+	assert.True(t, isClosed(s.stopGracefully))
+}

--- a/runtime/atomics/barrier.go
+++ b/runtime/atomics/barrier.go
@@ -1,0 +1,110 @@
+package atomics
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// A Barrier is an atomic primitive that can be unblocked once, after which it
+// stays permanently unblocked. Useful for communicating the permanent state
+// changes like shutdown.
+type Barrier struct {
+	m         sync.Mutex
+	b         chan struct{}
+	callbacks []func()
+}
+
+func (b *Barrier) init() {
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	if b.b == nil {
+		b.b = make(chan struct{})
+	}
+}
+
+// Fall lowers the barrier permanently unblocking anyone waiting for the barrier
+func (b *Barrier) Fall() {
+	b.init()
+
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	select {
+	case <-b.b:
+	default:
+		for _, cb := range b.callbacks {
+			cb()
+		}
+		b.callbacks = nil
+		close(b.b)
+	}
+}
+
+// IsFallen returns true, if the barrier is lowered.
+func (b *Barrier) IsFallen() bool {
+	select {
+	case <-b.Barrier():
+		return true
+	default:
+		return false
+	}
+}
+
+// Barrier returns a channel that is closed when the barrier is lowered.
+func (b *Barrier) Barrier() <-chan struct{} {
+	b.init()
+	return b.b
+}
+
+// Forward ensures that cb is called when b is lowered.
+//
+// If already lowered, cb will be called immediately.
+// This can be used to lower another barrier when b is lowered as follows:
+//   var b1 atomics.Barrier
+//   var b2 atomics.Barrier
+//   b1.Forward(b2.Fall)
+//   b1.Fall() // Lowers both b1 and b2
+func (b *Barrier) Forward(cb func()) {
+	b.init()
+
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	select {
+	case <-b.b:
+		cb()
+	default:
+		b.callbacks = append(b.callbacks, cb)
+	}
+}
+
+// AsContext returns the Barrier as a context.Context that is canceled when the
+// barrier is lowered.
+func (b *Barrier) AsContext() context.Context {
+	return &barrierAsContext{b}
+}
+
+type barrierAsContext struct {
+	b *Barrier
+}
+
+func (c *barrierAsContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c *barrierAsContext) Done() <-chan struct{} {
+	return c.b.Barrier()
+}
+
+func (c *barrierAsContext) Err() error {
+	if c.b.IsFallen() {
+		return context.Canceled
+	}
+	return nil
+}
+
+func (c *barrierAsContext) Value(interface{}) interface{} {
+	return nil
+}

--- a/runtime/atomics/counter.go
+++ b/runtime/atomics/counter.go
@@ -1,0 +1,82 @@
+package atomics
+
+import "sync"
+
+// Counter can be changed atomically and conditionally waited on.
+type Counter struct {
+	m       sync.Mutex
+	c       sync.Cond
+	value   int
+	changed chan struct{}
+}
+
+func (c *Counter) init() {
+	if c.c.L == nil {
+		c.c.L = &c.m
+	}
+}
+
+// Add value to counter
+func (c *Counter) Add(value int) {
+	if value == 0 {
+		return
+	}
+
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.init()
+
+	c.value += value
+	if c.changed != nil {
+		close(c.changed)
+		c.changed = nil
+	}
+	c.c.Broadcast()
+}
+
+// Value of the counter
+func (c *Counter) Value() int {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.init()
+
+	return c.value
+}
+
+// WaitFor predicate over the value to be true
+func (c *Counter) WaitFor(predicate func(val int) bool) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.init()
+
+	for !predicate(c.value) {
+		c.c.Wait()
+	}
+}
+
+// WaitForLessThan blocks until the counter is less than val
+func (c *Counter) WaitForLessThan(val int) {
+	c.WaitFor(func(v int) bool {
+		return v < val
+	})
+}
+
+// WaitForZero blocks until counter has reach zero
+func (c *Counter) WaitForZero() {
+	c.WaitFor(func(val int) bool {
+		return val == 0
+	})
+}
+
+// Changed returns a channel that is closed when the Counter is changed
+// without leaking if the counter is never changed.
+func (c *Counter) Changed() <-chan struct{} {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.init()
+
+	if c.changed == nil {
+		c.changed = make(chan struct{})
+	}
+	return c.changed
+}

--- a/runtime/atomics/stopwatch.go
+++ b/runtime/atomics/stopwatch.go
@@ -1,0 +1,53 @@
+package atomics
+
+import (
+	"sync"
+	"time"
+)
+
+// A StopWatch can be used to measure time. In contracts to using time.Duration
+// this structure is thread-safe.
+type StopWatch struct {
+	m       sync.Mutex
+	started time.Time
+}
+
+// Reset will stop the timer, reset it to zero and return the time elapsed
+// before resetting.
+func (s *StopWatch) Reset() time.Duration {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	// If zero value then it's not started yet
+	if s.started == (time.Time{}) {
+		return 0
+	}
+
+	elapsed := time.Since(s.started)
+	s.started = time.Time{}
+	return elapsed
+}
+
+// Start the StopWatch, this will increase the elapsed time as time goes.
+// This will not reset the StopWatch if it's already started.
+func (s *StopWatch) Start() {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.started != (time.Time{}) {
+		s.started = time.Now()
+	}
+}
+
+// Elapsed returns the time elapsed since the StopWatch was started.
+func (s *StopWatch) Elapsed() time.Duration {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	// If zero value then it's not started yet
+	if s.started == (time.Time{}) {
+		return 0
+	}
+
+	return time.Since(s.started)
+}

--- a/runtime/client/queue.go
+++ b/runtime/client/queue.go
@@ -23,6 +23,7 @@ type Queue interface {
 	ReportException(string, string, *queue.TaskExceptionRequest) (*queue.TaskStatusResponse, error)
 	ReportFailed(string, string) (*queue.TaskStatusResponse, error)
 	ClaimTask(string, string, *queue.TaskClaimRequest) (*queue.TaskClaimResponse, error)
+	ClaimWork(provisionerID, workerType string, payload *queue.ClaimWorkRequest) (*queue.ClaimWorkResponse, error)
 	ReclaimTask(string, string) (*queue.TaskReclaimResponse, error)
 	PollTaskUrls(string, string) (*queue.PollTaskUrlsResponse, error)
 	CancelTask(string) (*queue.TaskStatusResponse, error)
@@ -67,6 +68,12 @@ func (m *MockQueue) CancelTask(taskID string) (*queue.TaskStatusResponse, error)
 func (m *MockQueue) ClaimTask(taskID, runID string, payload *queue.TaskClaimRequest) (*queue.TaskClaimResponse, error) {
 	args := m.Called(taskID, runID, payload)
 	return args.Get(0).(*queue.TaskClaimResponse), args.Error(1)
+}
+
+// ClaimWork is a mock implementation of github.com/taskcluster/taskcluster-client-go/queue#Queue.ClaimWork
+func (m *MockQueue) ClaimWork(provisionerID, workerType string, payload *queue.ClaimWorkRequest) (*queue.ClaimWorkResponse, error) {
+	args := m.Called(provisionerID, workerType, payload)
+	return args.Get(0).(*queue.ClaimWorkResponse), args.Error(1)
 }
 
 // ReportFailed is a mock implementation of github.com/taskcluster/taskcluster-client-go/queue.ReportFailed

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -15,3 +15,13 @@ type Environment struct {
 	webhookserver.WebHookServer
 	Monitor
 }
+
+// Stoppable is an worker with a life-cycle that can be can be stopped.
+type Stoppable interface {
+	// StopNow causes the worker to stop processing tasks, resolving all active
+	// tasks exception w. worker-shutdown.
+	StopNow()
+	// StopGracefully causes the worker to stop claiming tasks and stop gracefully
+	// when all active tasks have been resolved.
+	StopGracefully()
+}

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestIsMalformedPayloadError(t *testing.T) {
-	var err error
-	err = NewMalformedPayloadError("test")
+	err := NewMalformedPayloadError("test")
 	_, ok := IsMalformedPayloadError(err)
 	assert.True(t, ok)
 }

--- a/runtime/taskcontext.go
+++ b/runtime/taskcontext.go
@@ -230,7 +230,7 @@ func (c *TaskContext) log(prefix string, a ...interface{}) {
 	a = append([]interface{}{prefix}, a...)
 	_, err := fmt.Fprintln(c.logStream, a...)
 	if err != nil {
-		//TODO: Forward this to the system log, it's not a critical error
+		_ = err //TODO: Forward this to the system log, it's not a critical error
 	}
 }
 

--- a/runtime/webhookserver/config.go
+++ b/runtime/webhookserver/config.go
@@ -1,0 +1,122 @@
+package webhookserver
+
+import (
+	"net"
+	"time"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+)
+
+var localhostConfigSchema = schematypes.Object{
+	Properties: schematypes.Properties{
+		"provider": schematypes.StringEnum{Options: []string{"localhost"}},
+	},
+	Required: []string{"provider"},
+}
+
+var localtunnelConfigSchema = schematypes.Object{
+	Properties: schematypes.Properties{
+		"provider": schematypes.StringEnum{Options: []string{"localtunnel"}},
+		"baseUrl":  schematypes.URI{},
+	},
+	Required: []string{"provider"},
+}
+
+var statelessDNSConfigSchema = schematypes.Object{
+	Properties: schematypes.Properties{
+		"provider": schematypes.StringEnum{Options: []string{"stateless-dns"}},
+		"serverIp": schematypes.String{},
+		"serverPort": schematypes.Integer{
+			Minimum: 0,
+			Maximum: 65535,
+		},
+		"networkInterface": schematypes.String{
+			MetaData: schematypes.MetaData{
+				Description: "Network device webhookserver should listen on. If not supplied, it binds to the interface from serverIp address",
+			},
+		},
+		"exposedPort": schematypes.Integer{
+			MetaData: schematypes.MetaData{
+				Description: "Port webhookserver should listen on. If not supplied, it uses the serverPort value.",
+			},
+			Minimum: 0,
+			Maximum: 65535,
+		},
+		"tlsCertificate":     schematypes.String{},
+		"tlsKey":             schematypes.String{},
+		"statelessDNSSecret": schematypes.String{},
+		"statelessDNSDomain": schematypes.String{},
+		"maxLifeCycle": schematypes.Integer{
+			MetaData: schematypes.MetaData{
+				Title:       "Maximum lifetime of the worker in seconds",
+				Description: "Used to limit the time period for which the DNS server will return an IP for the given worker hostname",
+			},
+			Minimum: 5 * 60,
+			Maximum: 31 * 24 * 60 * 60,
+		},
+	},
+	Required: []string{
+		"provider",
+		"serverIp",
+		"serverPort",
+		"statelessDNSSecret",
+		"statelessDNSDomain",
+		"maxLifeCycle",
+	},
+}
+
+// ConfigSchema specifies schema for configuration passed to NewServer.
+var ConfigSchema schematypes.Schema = schematypes.OneOf{
+	localhostConfigSchema,
+	localtunnelConfigSchema,
+	statelessDNSConfigSchema,
+}
+
+// Server abstracts various WebHookServer implementations
+type Server interface {
+	WebHookServer
+	Stop()
+}
+
+// NewServer returns a Server implementing WebHookServer, choosing the
+// implemetation based on the configuration passed in.
+//
+// Config passed must match ConfigSchema.
+func NewServer(config interface{}) (Server, error) {
+	var c struct {
+		Provider           string `json:"provider"`
+		ServerIP           string `json:"serverIp"`
+		ServerPort         int    `json:"serverPort"`
+		NetworkInterface   string `json:"networkInterface"`
+		ExposedPort        int    `json:"exposedPort"`
+		TLSCertificate     string `json:"tlsCertificate"`
+		TLSKey             string `json:"tlsKey"`
+		StatelessDNSSecret string `json:"statelessDNSSecret"`
+		StatelessDNSDomain string `json:"statelessDNSDomain"`
+		MaxLifeCycle       int    `json:"maxLifeCycle"`
+		BaseURL            string `json:"baseUrl"`
+	}
+	schematypes.MustValidate(ConfigSchema, config)
+	if schematypes.MustMap(localhostConfigSchema, config, &c) == nil {
+		return NewTestServer()
+	}
+	if schematypes.MustMap(localtunnelConfigSchema, config, &c) == nil {
+		return NewLocalTunnel(c.BaseURL)
+	}
+	if schematypes.MustMap(statelessDNSConfigSchema, config, &c) == nil {
+		s, err := NewLocalServer(
+			net.ParseIP(c.ServerIP), c.ServerPort,
+			c.NetworkInterface, c.ExposedPort,
+			c.StatelessDNSSecret,
+			c.StatelessDNSDomain,
+			c.TLSCertificate,
+			c.TLSKey,
+			time.Duration(c.MaxLifeCycle)*time.Second,
+		)
+		if err == nil {
+			go s.ListenAndServe()
+		}
+		return s, err
+	}
+	panic("Invalid config shouldn't be valid")
+}

--- a/runtime/webhookserver/localtunnel.go
+++ b/runtime/webhookserver/localtunnel.go
@@ -1,0 +1,91 @@
+package webhookserver
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/jonasfj/go-localtunnel"
+	"github.com/taskcluster/slugid-go/slugid"
+)
+
+// LocalTunnel is a WebHookServer implementation based on localtunnel.me
+//
+// Useful when testing on localhost, should obviously never be used in
+// production due to stability, security and scalability constraints.
+type LocalTunnel struct {
+	m        sync.RWMutex
+	listener *localtunnel.Listener
+	hooks    map[string]http.Handler
+}
+
+// NewLocalTunnel creates a LocalTunnel
+//
+// Defaults to localtunnel.me if no baseURL is specified.
+func NewLocalTunnel(baseURL string) (*LocalTunnel, error) {
+	l, err := localtunnel.Listen(localtunnel.Options{
+		BaseURL: baseURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	lt := &LocalTunnel{
+		listener: l,
+		hooks:    make(map[string]http.Handler),
+	}
+	go http.Serve(l, http.HandlerFunc(lt.handle))
+	return lt, nil
+}
+
+// Stop will close the localtunnel and break all connections
+func (lt *LocalTunnel) Stop() {
+	lt.listener.Close()
+}
+
+func (lt *LocalTunnel) handle(w http.ResponseWriter, r *http.Request) {
+	if len(r.URL.Path) < 24 || r.URL.Path[23] != '/' {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Find the hook
+	id := r.URL.Path[1:23]
+	lt.m.RLock()
+	hook := lt.hooks[id]
+	lt.m.RUnlock()
+
+	if hook == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	r.URL.Path = r.URL.Path[23:]
+	r.URL.RawPath = "" // TODO: Implement this if we need it someday
+
+	hook.ServeHTTP(w, r)
+}
+
+// AttachHook setups handler such that it gets called when a request arrives
+// at the returned url.
+func (lt *LocalTunnel) AttachHook(handler http.Handler) (url string, detach func()) {
+	lt.m.Lock()
+	defer lt.m.Unlock()
+
+	// Add hook
+	id := slugid.Nice()
+	lt.hooks[id] = handler
+
+	// Create url and detach function
+	url = lt.listener.URL()
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+	url += id + "/"
+	detach = func() {
+		lt.m.Lock()
+		defer lt.m.Unlock()
+		delete(lt.hooks, id)
+	}
+	return
+}

--- a/runtime/webhookserver/localtunnel_test.go
+++ b/runtime/webhookserver/localtunnel_test.go
@@ -1,0 +1,104 @@
+package webhookserver
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLocalTunnel(*testing.T) {
+	s, err := NewLocalTunnel("")
+	defer s.Stop()
+	time.Sleep(500 * time.Millisecond) // give the service time...
+	nilOrPanic(err)
+
+	path := ""
+	url, _ := s.AttachHook(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("Hello World"))
+		path = r.URL.Path
+	}))
+
+	// Test that we can do GET requests
+	r, err := http.Get(url)
+	nilOrPanic(err)
+	assert(r.StatusCode == 200, "Wrong response")
+	assert(path == "/", "Wrong path")
+
+	// Test with different suffix
+	r, err = http.Get(url + "myfile")
+	nilOrPanic(err)
+	assert(r.StatusCode == 200, "Wrong response")
+	assert(path == "/myfile", "Wrong path")
+
+	url, detach := s.AttachHook(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("Hello World"))
+	}))
+
+	// Call in parallel for race detector
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		res, rerr := http.Get(url)
+		nilOrPanic(rerr)
+		assert(res.StatusCode == 200, "Wrong response")
+		wg.Done()
+	}()
+	go func() {
+		res, rerr := http.Post(url, "", nil)
+		nilOrPanic(rerr)
+		assert(res.StatusCode == 200, "Wrong response")
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// Test wrong id
+	badurl := url[:len(url)-4] + "333/"
+	r, err = http.Get(badurl)
+	nilOrPanic(err)
+	assert(r.StatusCode != 200, "Wrong response")
+
+	// Test id too short
+	shorturl := url[:len(url)-4] + "/"
+	r, err = http.Get(shorturl)
+	nilOrPanic(err)
+	assert(r.StatusCode != 200, "Wrong response")
+
+	detach()
+	r, err = http.Get(url)
+	nilOrPanic(err)
+	assert(r.StatusCode == 404, "Expected 404")
+}
+
+func TestLocalTunnelStop(*testing.T) {
+	s, err := NewLocalTunnel("")
+	time.Sleep(500 * time.Millisecond) // give the service some time...
+	nilOrPanic(err)
+
+	link, detach := s.AttachHook(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("Hello World"))
+	}))
+
+	// Try a request
+	r, err := http.NewRequest("GET", link, nil)
+	nilOrPanic(err)
+
+	res, err := http.DefaultClient.Do(r)
+	nilOrPanic(err)
+	assert(res.StatusCode == 200, "Wrong status")
+
+	// Try again after detaching
+	detach()
+	r, err = http.NewRequest("GET", link, nil)
+	nilOrPanic(err)
+
+	res, err = http.DefaultClient.Do(r)
+	nilOrPanic(err)
+	assert(res.StatusCode == 404, "Wrong status")
+
+	// Stop server, and wait for it to be done
+	s.Stop()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -160,6 +160,12 @@
 			"revisionTime": "2015-02-23T21:27:18Z"
 		},
 		{
+			"checksumSHA1": "Grz0paMpctITy78Xtrqzp5MK4oA=",
+			"path": "github.com/jonasfj/go-localtunnel",
+			"revision": "b4dea4bbdea102d9a11b9568aca894cf87307949",
+			"revisionTime": "2017-03-19T06:52:38Z"
+		},
+		{
 			"checksumSHA1": "eIjJhEqZZmQwt++0jlQhbIhAcH4=",
 			"path": "github.com/kr/pty",
 			"revision": "ce7fa45920dc37a92de8377972e52bc55ffa8d57",

--- a/worker/queueservice.go
+++ b/worker/queueservice.go
@@ -433,7 +433,7 @@ func (q *queueService) shouldRefreshQueueUrls() bool {
 	}
 	// If the duration between Expiration and current time is less than the expiration
 	// off set then it's time to refresh the urls
-	if int(time.Time(q.expires).Sub(time.Now()).Seconds()) < q.expirationOffset {
+	if int(time.Until(time.Time(q.expires)).Seconds()) < q.expirationOffset {
 		return true
 	}
 	return false

--- a/worker/task.go
+++ b/worker/task.go
@@ -97,7 +97,7 @@ func newTaskRun(
 
 func (t *TaskRun) reclaim(until time.Time) {
 	for {
-		duration := until.Sub(time.Now()).Seconds()
+		duration := time.Until(until).Seconds()
 		// Using a reclaim divisor of 1.3 with the default reclaim deadline (20 minutes),
 		// means that a reclaim event will happen with a few minutes left of the origin claim.
 		nextReclaim := duration / 1.3

--- a/worker2/config.go
+++ b/worker2/config.go
@@ -1,0 +1,34 @@
+package worker
+
+import (
+	"time"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/plugins"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
+	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
+)
+
+// Options for creating a Worker
+type Options struct {
+	runtime.Environment
+	webhookserver.Server
+	engines.Engine
+	plugins.Plugin
+	client.Queue
+	LifeCyclePolicyConfig interface{}
+	ProvisionerID         string
+	WorkerType            string
+	WorkerGroup           string
+	WorkerID              string
+	PollingInterval       time.Duration
+	ReclaimOffset         time.Duration
+	Concurrency           int
+}
+
+// ConfigSchema returns the schema for configuration.
+func ConfigSchema() schematypes.Schema {
+	return schematypes.Object{}
+}

--- a/worker2/worker.go
+++ b/worker2/worker.go
@@ -1,0 +1,206 @@
+package worker
+
+import (
+	"time"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/queue"
+	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/lifecyclepolicy"
+	"github.com/taskcluster/taskcluster-worker/plugins"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
+	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
+)
+
+// A Worker processes tasks
+type Worker struct {
+	environment           runtime.Environment
+	server                webhookserver.Server
+	monitor               runtime.Monitor
+	engine                engines.Engine
+	plugin                plugins.Plugin
+	queue                 client.Queue
+	lifeCyclePolicyConfig interface{}
+	provisionerID         string
+	workerType            string
+	workerGroup           string
+	workerID              string
+	pollingInterval       time.Duration
+	reclaimOffset         time.Duration
+	concurrency           int
+	// State
+	running        atomics.Bool
+	activeTasks    atomics.Counter
+	stopNow        atomics.Barrier
+	stopGracefully atomics.Barrier
+}
+
+// New creates a new Worker
+func New(options Options) (*Worker, error) {
+	w := &Worker{}
+
+	return w, nil
+}
+
+// PayloadSchema returns the schema for task.payload
+func (w *Worker) PayloadSchema() schematypes.Schema {
+	return nil
+}
+
+// Start process tasks, returns nil if stopped gracefully
+func (w *Worker) Start() error {
+	// Ensure that we don't start running twice
+	if w.running.Swap(true) {
+		panic("Worker.Start() called while worker is already running")
+	}
+	defer w.running.Set(false)
+
+	// Reset barriers
+	w.stopNow = atomics.Barrier{}
+	w.stopGracefully = atomics.Barrier{}
+	w.stopNow.Forward(w.stopGracefully.Fall) // stopNow implies stopGracefully
+	defer w.stopNow.Fall()                   // Always lower the barrier
+
+	// Create LifeCyclePolicy
+	lifecycle := lifecyclepolicy.New(lifecyclepolicy.Options{
+		Monitor: w.environment.Monitor.WithPrefix("life-cycle-policy"),
+		Config:  w.lifeCyclePolicyConfig,
+		Worker:  w,
+	})
+
+	// Track idle time
+	idleTimer := atomics.StopWatch{}
+	go func() {
+		for {
+			select {
+			case <-w.activeTasks.Changed():
+				if w.activeTasks.Value() > 0 {
+					idleTimer.Reset() // Reset also stop the timer
+				} else {
+					idleTimer.Start()
+				}
+			case <-w.stopGracefully.Barrier():
+				break
+			}
+		}
+	}()
+
+	for !w.stopGracefully.IsFallen() {
+		// Claim tasks
+		claims, err := w.queue.ClaimWork(w.provisionerID, w.workerType, &queue.ClaimWorkRequest{
+			WorkerGroup: w.workerGroup,
+			WorkerID:    w.workerID,
+			Tasks:       w.concurrency - w.activeTasks.Value(),
+		})
+		if err != nil {
+			w.monitor.ReportError(err, "failed to ClaimWork")
+			lifecycle.ReportNonFatalError()
+		}
+
+		// If we have claims we MUST always handle, even if we have stopNow!
+		if claims != nil {
+			for _, claim := range claims.Tasks {
+				// Start processing tasks
+				w.activeTasks.Add(1)
+				go w.processClaim(taskClaim{
+					TaskID: claim.Status.TaskID,
+					RunID:  claim.RunID,
+					Task:   claim.Task,
+					Credentials: tcclient.Credentials{
+						ClientID:    claim.Credentials.ClientID,
+						AccessToken: claim.Credentials.AccessToken,
+						Certificate: claim.Credentials.Certificate,
+					},
+					TakenUntil: time.Time(claim.TakenUntil),
+				}, lifecycle)
+			}
+			if len(claims.Tasks) > 0 {
+				lifecycle.ReportTaskClaimed(len(claims.Tasks))
+			}
+		}
+
+		// If we received zero claims or encountered an error, we wait at-least
+		// pollingInterval before polling again. We start the timer here, so it's
+		// counting while we wait for capacity to be available.
+		var delay <-chan time.Time
+		if claims == nil || len(claims.Tasks) == 0 {
+			delay = time.After(w.pollingInterval)
+		} else {
+			delay = time.After(0)
+		}
+
+		// Wait for capacity to be available (delay is ticking while this happens)
+		w.activeTasks.WaitForLessThan(w.concurrency)
+
+		// Wait for delay or stopGracefully
+		select {
+		case <-delay:
+		case <-w.stopGracefully.Barrier():
+			break
+		}
+
+		idle := idleTimer.Elapsed()
+		if idle != 0 {
+			lifecycle.ReportIdle(idle)
+		}
+	}
+
+	// Wait for tasks to be done, or stopNow happens
+	w.activeTasks.WaitForZero()
+
+	return nil
+}
+
+type taskClaim struct {
+	TaskID      string
+	RunID       int
+	Task        queue.TaskDefinitionResponse
+	Credentials tcclient.Credentials
+	TakenUntil  time.Time
+}
+
+// processClaim is responsible for processing a task, reclaiming the task and
+// aborting it with worker-shutdown with w.stopNow is unblocked, and decrements
+// activeTasks when done
+func (w *Worker) processClaim(claim taskClaim, lifecycle lifecyclepolicy.LifeCyclePolicy) {
+	// Decrement number of active tasks when we're done processing the task
+	defer w.activeTasks.Add(-1)
+	// Measure resolution time and report it
+	resolutionTimer := atomics.StopWatch{}
+	resolutionTimer.Start()
+	defer func() {
+		lifecycle.ReportTaskResolved(resolutionTimer.Elapsed())
+	}()
+
+	go func() {
+		select {
+		case <-w.stopNow.Barrier():
+			// Abort task with worker-shutdown
+		}
+	}()
+
+	//TODO: Reclaim task
+	//TODO: Create taskrun
+}
+
+// StopNow aborts current tasks resolving worker-shutdown, and causes Work()
+// to return an error.
+func (w *Worker) StopNow() {
+	w.stopNow.Fall()
+}
+
+// StopGracefully stops claiming new tasks and returns nil from Work() when
+// all currently running tasks are done.
+func (w *Worker) StopGracefully() {
+	w.stopGracefully.Fall()
+}
+
+// Dispose worker
+func (w *Worker) Dispose() {
+	if w.running.Get() { // Just a safety check
+		panic("Worker.Dispose() called while worker is running")
+	}
+}


### PR DESCRIPTION
can I get a 30% review on this..

I think I could replace the `atomics.Barrier` primitive with `context.Context` it just feels a bit abusive..
Note: I'm adding functions concurrency primitivies in the atomics package to try and avoid making the code too complicated elsewhere...

hmm.. the more I play with it in my mind... I'm starting to think I have to create a non-generic concurrency primitive that does what `activeTasks` and `idleTimer` tries to do...