### PR TITLE
Integration test framework

### DIFF
--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -2,6 +2,8 @@
 
 touch .bash_history
 ARGS="--tty --interactive --rm --privileged -e DEBUG";
+ARGS="$ARGS -e TASKCLUSTER_CLIENT_ID -e TASKCLUSTER_ACCESS_TOKEN -e TASKCLUSTER_CERTIFICATE";
+ARGS="$ARGS -e PULSE_USERNAME -e PULSE_PASSWORD";
 ARGS="$ARGS -v `pwd`/.bash_history:/root/.bash_history";
 ARGS="$ARGS -v `pwd`:/go/src/github.com/taskcluster/taskcluster-worker/";
 ARGS="$ARGS taskcluster/tc-worker-env";

--- a/engines/engine.go
+++ b/engines/engine.go
@@ -40,6 +40,12 @@ type SandboxOptions struct {
 // can be implemented on all platforms. See individual methods to see which are
 // required and which can be implemented by returning ErrFeatureNotSupported.
 type Engine interface {
+	// Documentation returns a list of sections with end-user documentation.
+	//
+	// These sections will be combined with documentation sections from all
+	// enabled plugins in-order to form end-user documentation.
+	Documentation() []runtime.Section
+
 	// PayloadSchema returns a JSON schema description of the payload options,
 	// accepted by this engine.
 	PayloadSchema() schematypes.Object
@@ -129,6 +135,11 @@ type Capabilities struct {
 // Implementors of Engine should embed this struct to ensure source
 // compatibility when we add more optional methods to Engine.
 type EngineBase struct{}
+
+// Documentation returns no documentation.
+func (EngineBase) Documentation() []runtime.Section {
+	return nil
+}
 
 // PayloadSchema returns an empty schematypes.Object indicating no contraints
 // on keys of the payload object.

--- a/engines/mock/mockengine.go
+++ b/engines/mock/mockengine.go
@@ -11,7 +11,8 @@ import (
 
 type engine struct {
 	engines.EngineBase
-	monitor runtime.Monitor
+	monitor     runtime.Monitor
+	environment runtime.Environment
 }
 
 type engineProvider struct {
@@ -36,7 +37,10 @@ func (e engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine
 	if options.Monitor == nil {
 		panic("EngineOptions.Monitor is nil, this is a contract violation")
 	}
-	return engine{monitor: options.Monitor}, nil
+	return engine{
+		monitor:     options.Monitor,
+		environment: *options.Environment,
+	}, nil
 }
 
 // mock config contains no fields
@@ -66,12 +70,13 @@ func (e engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.Sandb
 		return nil, runtime.NewMalformedPayloadError(p.Argument)
 	}
 	return &sandbox{
-		payload: p,
-		context: options.TaskContext,
-		mounts:  make(map[string]*mount),
-		proxies: make(map[string]http.Handler),
-		env:     make(map[string]string),
-		files:   make(map[string][]byte),
+		environment: e.environment,
+		payload:     p,
+		context:     options.TaskContext,
+		mounts:      make(map[string]*mount),
+		proxies:     make(map[string]http.Handler),
+		env:         make(map[string]string),
+		files:       make(map[string][]byte),
 	}, nil
 }
 

--- a/engines/mock/payloadschema.go
+++ b/engines/mock/payloadschema.go
@@ -40,6 +40,7 @@ var payloadSchema = schematypes.Object{
 				"malformed-payload-after-start",
 				"fatal-internal-error",
 				"nonfatal-internal-error",
+				"stopNow-sleep",
 			},
 		},
 		"argument": schematypes.String{

--- a/engines/native/config.go
+++ b/engines/native/config.go
@@ -1,6 +1,9 @@
 package nativeengine
 
-import schematypes "github.com/taskcluster/go-schematypes"
+import (
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
 
 type config struct {
 	Groups     []string `json:"groups,omitempty"`
@@ -10,16 +13,20 @@ type config struct {
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "Native Engine Config",
-		Description: "Configuration for the native engine, this engines creates " +
-			"a system user-account per task, and deletes user-account when task " +
-			"is completed.",
+		Description: util.Markdown(`
+			Configuration for the native engine, this engines creates
+			a system user-account per task, and deletes user-account when task
+			is completed.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"groups": schematypes.Array{
 			MetaData: schematypes.MetaData{
 				Title: "Group Memberships",
-				Description: "List of system user-groups that the temporary " +
-					"task-users should be be granted membership of.",
+				Description: util.Markdown(`
+					List of system user-groups that the temporary
+					task-users should be be granted membership of.
+				`),
 			},
 			Items: schematypes.String{
 				MetaData: schematypes.MetaData{
@@ -31,10 +38,15 @@ var configSchema = schematypes.Object{
 		},
 		"createUser": schematypes.Boolean{
 			MetaData: schematypes.MetaData{
-				Title: "Tells if a user should be created to run a command",
-				Description: `When set to true, a new user is created on the fly to run
-				the command. It runs the command from whitin the user's home directory.
-				If false, the command runs without changing userid`,
+				Title: "Create User per Task",
+				Description: util.Markdown(`
+					Tells if a system user should be created to run a command.
+
+					When set to 'true', a new user is created on-the-fly to run each task.
+					It runs the command from within the user's home directory.
+					If 'false', the command runs without changing userid, hence, tasks
+					will run with the same user as the worker does.
+				`),
 			},
 		},
 	},

--- a/engines/native/payload.go
+++ b/engines/native/payload.go
@@ -1,6 +1,9 @@
 package nativeengine
 
-import schematypes "github.com/taskcluster/go-schematypes"
+import (
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
 
 type payload struct {
 	Command []string `json:"command"`
@@ -19,8 +22,10 @@ var payloadSchema = schematypes.Object{
 		"context": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Task Context",
-				Description: "Optional URL for a gzipped tar-ball to downloaded " +
-					"and extracted in the HOME directory for running the command.",
+				Description: util.Markdown(`
+					Optional URL for a gzipped tar-ball to downloaded
+					and extracted in the 'HOME' directory for running the command.
+				`),
 			},
 		},
 	},

--- a/engines/qemu/engine.go
+++ b/engines/qemu/engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/engines/qemu/network"
 	"github.com/taskcluster/taskcluster-worker/engines/qemu/vm"
 	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type engine struct {
@@ -42,15 +43,19 @@ var configSchema = schematypes.Object{
 		"imageFolder": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Image Folder",
-				Description: `Path to folder to be used for image storage and cache.
-											Please ensure this has lots of space.`,
+				Description: util.Markdown(`
+					Path to folder to be used for image storage and cache.
+					Please ensure this has lots of space.
+				`),
 			},
 		},
 		"socketFolder": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Socket Folder",
-				Description: `Path to folder to be used for internal unix-domain sockets.
-											Ideally, this shouldn't be readable by anyone else.`,
+				Description: util.Markdown(`
+					Path to folder to be used for internal unix-domain sockets.
+					Ideally, this shouldn't be readable by anyone else.
+				`),
 			},
 		},
 		"machineOptions": vm.MachineOptionsSchema,
@@ -113,10 +118,12 @@ var payloadSchema = schematypes.Object{
 		"image": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Image to download",
-				Description: "URL to an image file. This is a zstd compressed " +
-					"tar-archive containing a raw disk image `disk.img`, a qcow2 " +
-					"overlay `layer.qcow2` and a machine definition file " +
-					"`machine.json`. Refer to engine documentation for more details.",
+				Description: util.Markdown(`
+					URL to an image file. This is a zstd compressed
+					tar-archive containing a raw disk image 'disk.img', a qcow2
+					overlay 'layer.qcow2' and a machine definition file
+					'machine.json'. Refer to engine documentation for more details.
+				`),
 			},
 		},
 		"command": schematypes.Array{

--- a/plugins/artifacts/payloadschema.go
+++ b/plugins/artifacts/payloadschema.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type payloadType struct {
@@ -28,9 +29,11 @@ var payloadSchema = schematypes.Object{
 					"type": schematypes.StringEnum{
 						MetaData: schematypes.MetaData{
 							Title: "Upload type",
-							Description: "Artifacts can be either an individual `file` or " +
-								"a `directory` containing potentially multiple files with " +
-								"recursively included subdirectories",
+							Description: util.Markdown(`
+								Artifacts can be either an individual 'file' or a 'directory'
+								containing potentially multiple files with recursively included
+								subdirectories
+							`),
 						},
 						Options: []string{"file", "directory"},
 					},
@@ -44,11 +47,12 @@ var payloadSchema = schematypes.Object{
 					"name": schematypes.String{
 						MetaData: schematypes.MetaData{
 							Title: "Artifact Name",
-							Description: "" +
-								"This will be the leading path to directories and the full name\n" +
-								"for files that are uploaded to s3. It must not begin or end\n" +
-								"with '/' and must only contain printable ascii characters\n" +
-								"otherwise.",
+							Description: util.Markdown(`
+								This will be the leading path to directories and the full name
+								for files that are uploaded to s3. It must not begin or end
+								with '/' and must only contain printable ascii characters
+								otherwise.
+							`),
 						},
 						Pattern: `^([\x20-\x2e\x30-\x7e][\x20-\x7e]*)[\x20-\x2e\x30-\x7e]$`,
 					},

--- a/plugins/interactive/config.go
+++ b/plugins/interactive/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type config struct {
@@ -19,16 +20,20 @@ type config struct {
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "Interactive Plugin",
-		Description: `Configuration for the 'interactive' plugin that allows user
-      to configure tasks that expose an interactive shell or noVNC sessions.`,
+		Description: util.Markdown(`
+			Configuration for the 'interactive' plugin that allows user
+			to configure tasks that expose an interactive shell or noVNC sessions.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"artifactPrefix": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Artifact Prefix",
-				Description: "Prefix that the `sockets.json`, `display.html` and " +
-					"`shell.html` should be created under. Defaults to " +
-					fmt.Sprintf("`%s`.", defaultArtifactPrefix),
+				Description: util.Markdown(`
+					Prefix that the 'sockets.json', 'display.html' and 'shell.html'
+					should be created under. Defaults to
+					` + fmt.Sprintf("'%s'", defaultArtifactPrefix) + `.
+				`),
 			},
 			Pattern:       `^[\x20-.0-\x7e][\x20-\x7e]*/$`,
 			MaximumLength: 255,
@@ -36,8 +41,10 @@ var configSchema = schematypes.Object{
 		"forbidCustomArtifactPrefix": schematypes.Boolean{
 			MetaData: schematypes.MetaData{
 				Title: "Forbid Custom ArtifactPrefix",
-				Description: "Prevent tasks from specifying a custom `artifactPrefix`" +
-					" , by default tasks are allowed to overwrite the global setting.",
+				Description: util.Markdown(`
+					Prevent tasks from specifying a custom 'artifactPrefix', by default
+					tasks are allowed to overwrite the global setting.
+				`),
 			},
 		},
 		"alwaysEnabled": schematypes.Boolean{
@@ -61,18 +68,22 @@ var configSchema = schematypes.Object{
 		"shellToolUrl": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Shell Tool URL",
-				Description: `URL to a tool that can take shell socket URL and display
+				Description: util.Markdown(`
+					URL to a tool that can take shell socket URL and display
 					an interactive shell session. The URL will be given the querystring
-					options: 'v=2', 'socketUrl', 'taskId', 'runId'.`,
+					options: 'v=2', 'socketUrl', 'taskId', 'runId'.
+				`),
 			},
 		},
 		"displayToolUrl": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Display Tool URL",
-				Description: `URL to a tool that can take display socket, list
+				Description: util.Markdown(`
+					URL to a tool that can take display socket, list
 					displays and render noVNC session. The URL will be given the
 					querystring options: 'v=1', 'socketUrl', 'displaysUrl', 'taskId' and
-					'runId'.`,
+					'runId'.
+				`),
 			},
 		},
 	},

--- a/plugins/interactive/interactive.go
+++ b/plugins/interactive/interactive.go
@@ -13,6 +13,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 // defaultArtifactPrefix is the default artifact prefix used if nothing is
@@ -63,23 +64,29 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 	s := schematypes.Object{
 		MetaData: schematypes.MetaData{
 			Title: "Interactive Features",
-			Description: `Settings for interactive features, all options are optional,
+			Description: util.Markdown(`
+				Settings for interactive features, all options are optional,
 				an empty object can be used to enable the interactive features with
-				default options.`,
+				default options.
+			`),
 		},
 		Properties: schematypes.Properties{
 			"disableDisplay": schematypes.Boolean{
 				MetaData: schematypes.MetaData{
 					Title: "Disable Display",
-					Description: "Disable the interactive display, defaults to enabled if " +
-						"any options is given for `interactive`, even an empty object.",
+					Description: util.Markdown(`
+						Disable the interactive display, defaults to enabled if any options
+						is given for 'interactive', even an empty object.
+					`),
 				},
 			},
 			"disableShell": schematypes.Boolean{
 				MetaData: schematypes.MetaData{
 					Title: "Disable Shell",
-					Description: "Disable the interactive shell, defaults to enabled if " +
-						"any options is given for `interactive`, even an empty object.",
+					Description: util.Markdown(`
+						Disable the interactive shell, defaults to enabled if any options
+						is given for 'interactive', even an empty object.
+					`),
 				},
 			},
 		},
@@ -88,10 +95,12 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 		s.Properties["artifactPrefix"] = schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Artifact Prefix",
-				Description: "Prefix for the interactive artifacts will be used to " +
-					"create `<prefix>/shell.html`, `<prefix>/display.html` and " +
-					"`<prefix>/sockets.json`. The prefix defaults to `" +
-					p.config.ArtifactPrefix + "`",
+				Description: util.Markdown(`
+					Prefix for the interactive artifacts will be used to create
+					'<prefix>/shell.html', '<prefix>/display.html' and
+					'<prefix>/sockets.json'. The prefix defaults to
+					'` + p.config.ArtifactPrefix + `'.
+				`),
 			},
 			Pattern:       `^[\x20-.0-\x7e][\x20-\x7e]*/$`,
 			MaximumLength: 255,

--- a/plugins/livelog/doc.go
+++ b/plugins/livelog/doc.go
@@ -1,0 +1,8 @@
+// Package livelog provides a taskcluster-worker plugin that makes the task log
+// available as a live log during task execution and finally uploads it as a
+// static log.
+package livelog
+
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
+
+var debug = util.Debug("livelog")

--- a/plugins/maxruntime/config.go
+++ b/plugins/maxruntime/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type config struct {
@@ -20,7 +21,7 @@ const (
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "`maxRunTime` Plugin",
-		Description: `
+		Description: util.Markdown(`
 			The maximum runtime plugin kills tasks that have a runtime exceeding the
 			'maxRunTime' specified. This means it kills the sandbox and any interactive
 			shells and display. Once killed the task will be resolved as failed.
@@ -32,26 +33,26 @@ var configSchema = schematypes.Object{
 			A 'maxRunTime' limit is given in the plugin configuration, and the
 			'perTaskLimit' option can be used to allow or require tasks to specify a
 			shorter 'maxRunTime'.
-		`,
+		`),
 	},
 	Properties: schematypes.Properties{
 		"maxRunTime": schematypes.Duration{
 			MetaData: schematypes.MetaData{
 				Title: "Maximum Task Run-Time",
-				Description: `
+				Description: util.Markdown(`
 					Maximum execution time before a task is killed, does not include
 					artifact upload or image download time, etc.
-				`,
+				`),
 			},
 		},
 		"perTaskLimit": schematypes.StringEnum{
 			MetaData: schematypes.MetaData{
 				Title: "Per Task Limits",
-				Description: `
+				Description: util.Markdown(`
 					This plugin can 'forbid', 'allow' or 'require' tasks to specify
 					'task.payload.maxRunTime', which if present must be less than
 					'maxRunTime' as configured at plugin level.
-				`,
+				`),
 			},
 			Options: []string{
 				limitRequire,

--- a/plugins/maxruntime/maxruntime.go
+++ b/plugins/maxruntime/maxruntime.go
@@ -8,6 +8,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type provider struct {
@@ -56,7 +57,7 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 			"maxRunTime": schematypes.Duration{
 				MetaData: schematypes.MetaData{
 					Title: "Maximum Task Run-Time",
-					Description: `
+					Description: util.Markdown(`
 						The maximum task run-time before the task is **killed** and resolved
 						as _failed_. Specified as an integer in seconds, or as string on
 						the form: '1 day 2 hours 3 minutes'.
@@ -66,7 +67,7 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 
 						For this worker-type the 'maxRunTime' may not exceed:
 						'` + p.MaxRunTime.String() + `'.
-					`,
+					`),
 				},
 			},
 		}

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -30,6 +30,12 @@ type TaskPluginOptions struct {
 //
 // All methods on this interface must be thread-safe.
 type Plugin interface {
+	// Documentation returns a list of sections with end-user documentation.
+	//
+	// These sections will be combined with documentation sections from all
+	// enabled plugins in-order to form end-user documentation.
+	Documentation() []runtime.Section
+
 	// PayloadSchema returns a schematypes.Object with the properties for
 	// for the TaskPluginOptions.Payload property.
 	//
@@ -173,6 +179,11 @@ type TaskPlugin interface {
 // Implementors should embed this to ensure forward compatibility when we add
 // new optional methods.
 type PluginBase struct{}
+
+// Documentation returns no documentation.
+func (PluginBase) Documentation() []runtime.Section {
+	return nil
+}
 
 // PayloadSchema returns a schema for an empty object for plugins that doesn't
 // take any payload.

--- a/plugins/watchdog/config.go
+++ b/plugins/watchdog/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type config struct {
@@ -14,33 +15,33 @@ type config struct {
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "Watchdog Plugin",
-		Description: `
-      The watchdog plugin resets a timer whenever the worker is reported as
-      idle or processes a step in a task. This ensure that the task-processing
-      loop remains alive. If the timeout is exceeded, the watchdog will report
-      to sentry and shutdown the worker immediately.
+		Description: util.Markdown(`
+			The watchdog plugin resets a timer whenever the worker is reported as
+			idle or processes a step in a task. This ensure that the task-processing
+			loop remains alive. If the timeout is exceeded, the watchdog will report
+			to sentry and shutdown the worker immediately.
 
-      This plugin is mainly useful to avoid stale workers cut in some livelock.
-      Note: This plugin won't cause a timeout between Started() and
-      Stopped(), as this would limit task run time, for this purpose use the
-      'maxruntime' plugin.
-    `,
+			This plugin is mainly useful to avoid stale workers cut in some livelock.
+			Note: This plugin won't cause a timeout between 'Started()' and
+			'Stopped()', as this would limit task run time, for this purpose use the
+			'maxruntime' plugin.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"timeout": schematypes.Duration{
 			MetaData: schematypes.MetaData{
 				Title: "Watchdog Timeout",
-				Description: `
-          Timeout after which to kill the worker, timeout is reset whenever a
-          task progresses, worker is reported idle or task is between Started()
-          and Stopped().
+				Description: util.Markdown(`
+					Timeout after which to kill the worker, timeout is reset whenever a
+					task progresses, worker is reported idle or task is between
+					'Started()' and 'Stopped()'.
 
-          Defaults to ` + strconv.Itoa(defaultTimeout) + ` minutes, if not
-          specified (or zero).
+					Defaults to ` + strconv.Itoa(defaultTimeout) + ` minutes, if not
+					specified (or zero).
 
-          This property is specified in seconds as integer or as string on the
-          form '1 day 2 hours 3 minutes'.
-        `,
+					This property is specified in seconds as integer or as string on the
+					form '1 day 2 hours 3 minutes'.
+				`),
 			},
 			AllowNegative: false,
 		},

--- a/plugins/watchdog/config.go
+++ b/plugins/watchdog/config.go
@@ -21,7 +21,7 @@ var configSchema = schematypes.Object{
       to sentry and shutdown the worker immediately.
 
       This plugin is mainly useful to avoid stale workers cut in some livelock.
-      Note: that this plugin won't cause a timeout between Started() and
+      Note: This plugin won't cause a timeout between Started() and
       Stopped(), as this would limit task run time, for this purpose use the
       'maxruntime' plugin.
     `,

--- a/runtime/docs.go
+++ b/runtime/docs.go
@@ -1,0 +1,27 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+)
+
+// A Section represents a section of markdown documentation.
+type Section struct {
+	Title   string // Title of section rendered as headline level 2
+	Content string // Section contents, maybe contains headline level 3 and higher
+}
+
+// RenderDocument creates a markdown document with given title from a list of
+// sections. Ordering sections alphabetically.
+func RenderDocument(title string, sections []Section) string {
+	sections = append([]Section{}, sections...)
+	sort.Slice(sections, func(i int, j int) bool {
+		return sections[i].Title < sections[j].Title
+	})
+
+	docs := fmt.Sprintf("# %s\n", title)
+	for _, section := range sections {
+		docs += fmt.Sprintf("\n\n## %s\n%s\n", section.Title, section.Content)
+	}
+	return docs
+}

--- a/runtime/util/debug.go
+++ b/runtime/util/debug.go
@@ -38,6 +38,7 @@ var debugPattern = func() *regexp.Regexp {
 	debug = regexp.QuoteMeta(debug)
 	debug = strings.Replace(debug, "\\*", ".*?", -1)
 	debug = strings.Replace(debug, ",", "|", -1)
+	debug = strings.Replace(debug, " ", "|", -1)
 	debug = "^(" + debug + ")$"
 	return regexp.MustCompile(debug)
 }()

--- a/runtime/util/parallel.go
+++ b/runtime/util/parallel.go
@@ -2,8 +2,8 @@ package util
 
 import "sync"
 
-// Parallel takes a list of functions and calls them all in parallel, returning
-// when all the functions are done.
+// Parallel takes a list of functions and calls them all in concurrently,
+// returning when all the functions are done.
 //
 // This doesn't have any nice error or panic handling and is aimed as construct
 // to be used inside other functions, mainly to reduce boiler-plate.
@@ -20,5 +20,20 @@ func Parallel(f ...func()) {
 	}
 
 	wg.Done()
+	wg.Wait()
+}
+
+// Spawn N go routines and wait for them to return.
+//
+// This utility is smart when instantiating elements in an array concurrently.
+func Spawn(N int, fn func(i int)) {
+	wg := sync.WaitGroup{}
+	wg.Add(N)
+	for index := 0; index < N; index++ {
+		go func(i int) {
+			defer wg.Done()
+			fn(i)
+		}(index)
+	}
 	wg.Wait()
 }

--- a/runtime/webhookserver/config.go
+++ b/runtime/webhookserver/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 var localhostConfigSchema = schematypes.Object{
@@ -32,12 +33,18 @@ var statelessDNSConfigSchema = schematypes.Object{
 		},
 		"networkInterface": schematypes.String{
 			MetaData: schematypes.MetaData{
-				Description: "Network device webhookserver should listen on. If not supplied, it binds to the interface from serverIp address",
+				Description: util.Markdown(`
+					Network device webhookserver should listen on. If not supplied, it
+					binds to the interface from 'serverIp' address
+				`),
 			},
 		},
 		"exposedPort": schematypes.Integer{
 			MetaData: schematypes.MetaData{
-				Description: "Port webhookserver should listen on. If not supplied, it uses the serverPort value.",
+				Description: util.Markdown(`
+					Port webhookserver should listen on. If not supplied, it uses the
+					'serverPort' value.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 65535,
@@ -48,8 +55,11 @@ var statelessDNSConfigSchema = schematypes.Object{
 		"statelessDNSDomain": schematypes.String{},
 		"maxLifeCycle": schematypes.Integer{
 			MetaData: schematypes.MetaData{
-				Title:       "Maximum lifetime of the worker in seconds",
-				Description: "Used to limit the time period for which the DNS server will return an IP for the given worker hostname",
+				Title: "Maximum lifetime of the worker in seconds",
+				Description: util.Markdown(`
+					Used to limit the time period for which the DNS server will return
+					an IP for the given worker hostname.
+				`),
 			},
 			Minimum: 5 * 60,
 			Maximum: 31 * 24 * 60 * 60,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -257,6 +257,12 @@
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
+			"checksumSHA1": "Om0cn0L5ewCIBcORQAXD8guTa9M=",
+			"path": "github.com/streadway/amqp",
+			"revision": "afe8eee29a74d213b1f3fb2586058157c397da60",
+			"revisionTime": "2017-03-13T17:48:48Z"
+		},
+		{
 			"checksumSHA1": "EO+jcRet/AJ6IY3lBO8l8BLsZWg=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/stretchr/objx",
 			"path": "github.com/stretchr/objx",
@@ -336,28 +342,28 @@
 			"revisionTime": "2017-02-22T01:37:00Z"
 		},
 		{
-			"checksumSHA1": "6zyHi0i8zjjUfQz5JLB0bPTv8w0=",
+			"checksumSHA1": "/D5Zh31yiQafcHoXxdfU8FErLM4=",
 			"path": "github.com/taskcluster/taskcluster-client-go",
-			"revision": "72514fa85efd9d7e22af0d61a6aa5bed471a95d9",
-			"revisionTime": "2017-02-23T05:21:19Z"
+			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
+			"revisionTime": "2017-04-13T22:51:09Z"
 		},
 		{
-			"checksumSHA1": "cltaekoYu2byVxBAV+N1m80QG4Q=",
+			"checksumSHA1": "mUzvuAzVrPU0206K5ti5q/sURck=",
 			"path": "github.com/taskcluster/taskcluster-client-go/auth",
-			"revision": "72514fa85efd9d7e22af0d61a6aa5bed471a95d9",
-			"revisionTime": "2017-02-23T05:21:19Z"
+			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
+			"revisionTime": "2017-04-13T22:51:09Z"
 		},
 		{
-			"checksumSHA1": "6MUpdvu1CxZQs2Xk+bn6uCLs91g=",
+			"checksumSHA1": "bNFuBG/RryZaHXV9krlZyU7KrGQ=",
 			"path": "github.com/taskcluster/taskcluster-client-go/queue",
-			"revision": "72514fa85efd9d7e22af0d61a6aa5bed471a95d9",
-			"revisionTime": "2017-02-23T05:21:19Z"
+			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
+			"revisionTime": "2017-04-13T22:51:09Z"
 		},
 		{
-			"checksumSHA1": "MZqc1OrFPyhQOkFZGEcptmvm7rQ=",
+			"checksumSHA1": "VIDHtEubzOxKcii86F5bSwcPMw8=",
 			"path": "github.com/taskcluster/taskcluster-client-go/secrets",
-			"revision": "72514fa85efd9d7e22af0d61a6aa5bed471a95d9",
-			"revisionTime": "2017-02-23T05:21:19Z"
+			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
+			"revisionTime": "2017-04-13T22:51:09Z"
 		},
 		{
 			"checksumSHA1": "Jggs+SsefVhBtVaWOqlFnsXICkk=",

--- a/worker/config.go
+++ b/worker/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	"github.com/taskcluster/taskcluster-worker/runtime/monitoring"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
 )
 
@@ -47,42 +48,50 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 		"provisionerId": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "ProvisionerId",
-				Description: `ProvisionerId for workerType that tasks should be claimed
-				from. Note, a 'workerType' is only unique given the 'provisionerId'.`,
+				Description: util.Markdown(`
+					ProvisionerId for workerType that tasks should be claimed
+					from. Note, a 'workerType' is only unique given the 'provisionerId'.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"workerType": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "WorkerType",
-				Description: `WorkerType to claim tasks for, combined with
-				'provisionerId' this identifies the pool of workers the machine
-				belongs to.`,
+				Description: util.Markdown(`
+					WorkerType to claim tasks for, combined with 'provisionerId' this
+					identifies the pool of workers the machine belongs to.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"workerGroup": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "WorkerGroup",
-				Description: `Group of workers this machine belongs to. This is any
-				identifier such that workerGroup and workerId uniquely identifies this
-				machine.`,
+				Description: util.Markdown(`
+					Group of workers this machine belongs to. This is any identifier such
+					that workerGroup and workerId uniquely identifies this machine.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"workerId": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "WorkerId",
-				Description: `Identifier for this machine. This is any identifier such
-				that workerGroup and workerId uniquely identifies this machine.`,
+				Description: util.Markdown(`
+					Identifier for this machine. This is any identifier such
+					that workerGroup and workerId uniquely identifies this machine.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"pollingInterval": schematypes.Integer{
 			MetaData: schematypes.MetaData{
 				Title: "Task Polling Interval",
-				Description: `The amount of time to wait between task polling
-				iterations in seconds.`,
+				Description: util.Markdown(`
+					The amount of time to wait between task polling
+					iterations in seconds.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 10 * 60,
@@ -90,8 +99,10 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 		"reclaimOffset": schematypes.Integer{
 			MetaData: schematypes.MetaData{
 				Title: "Reclaim Offset",
-				Description: `The number of seconds priorty task claim expiration the
-				claim should be reclamed.`,
+				Description: util.Markdown(`
+					The number of seconds priorty task claim expiration the
+					claim should be reclamed.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 10 * 60,
@@ -99,9 +110,11 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 		"minimumReclaimDelay": schematypes.Integer{
 			MetaData: schematypes.MetaData{
 				Title: "Minimum Reclaim Delay",
-				Description: `Minimum number of seconds to wait before reclaiming a task.
+				Description: util.Markdown(`
+					Minimum number of seconds to wait before reclaiming a task.
 					it is important that this is some reasonable non-zero minimum to avoid
-					overloading servers if there is some error.`,
+					overloading servers if there is some error.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 10 * 60,
@@ -130,9 +143,11 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 var credentialsSchema schematypes.Schema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "TaskCluster Credentials",
-		Description: `The set of credentials that should be used by the worker
-		when authenticating against taskcluster endpoints. This needs scopes
-		for claiming tasks for the given workerType.`,
+		Description: util.Markdown(`
+			The set of credentials that should be used by the worker
+			when authenticating against taskcluster endpoints. This needs scopes
+			for claiming tasks for the given workerType.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"clientId": schematypes.String{
@@ -152,8 +167,9 @@ var credentialsSchema schematypes.Schema = schematypes.Object{
 		"certificate": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Certificate",
-				Description: `The certificate for the client, if using temporary
-				credentials.`,
+				Description: util.Markdown(`
+					The certificate for the client, if using temporary credentials.
+				`),
 			},
 		},
 		"authorizedScopes": schematypes.Array{
@@ -176,20 +192,24 @@ func ConfigSchema() schematypes.Object {
 			"engine": schematypes.StringEnum{
 				MetaData: schematypes.MetaData{
 					Title: "Worker Engine",
-					Description: `Selected worker engine to use, notice that the
+					Description: util.Markdown(`
+						Selected worker engine to use, notice that the
 						configuration for this engine **must** be present under the
-						'engines.<engine>' configuration key.`,
+						'engines.<engine>' configuration key.
+					`),
 				},
 				Options: engineNames,
 			},
 			"engines": schematypes.Object{
 				MetaData: schematypes.MetaData{
 					Title: "Engine Configuration",
-					Description: `Mapping from engine name to engine configuration.
+					Description: util.Markdown(`
+						Mapping from engine name to engine configuration.
 						Even-though the worker will only use one engine at any given time,
 						the configuration file can hold configuration for all engines.
 						Hence, you need only update the 'engine' key to change which engine
-						should be used.`,
+						should be used.
+					`),
 				},
 				Properties: engineConfig,
 			},
@@ -198,17 +218,21 @@ func ConfigSchema() schematypes.Object {
 			"temporaryFolder": schematypes.String{
 				MetaData: schematypes.MetaData{
 					Title: "Temporary Folder",
-					Description: `Path to folder that can be used for temporary files and
-							folders, if folder doesn't exist it will be created, otherwise it
-							will be overwritten.`,
+					Description: util.Markdown(`
+						Path to folder that can be used for temporary files and
+						folders, if folder doesn't exist it will be created, otherwise it
+						will be overwritten.
+					`),
 				},
 			},
 			"minimumDiskSpace": schematypes.Integer{
 				MetaData: schematypes.MetaData{
 					Title: "Minimum Disk Space",
-					Description: `The minimum amount of disk space in bytes to have available
+					Description: util.Markdown(`
+						The minimum amount of disk space in bytes to have available
 						before starting on the next task. Garbage collector will do a
-						best-effort attempt at releasing resources to satisfy this limit`,
+						best-effort attempt at releasing resources to satisfy this limit.
+					`),
 				},
 				Minimum: 0,
 				Maximum: math.MaxInt64,
@@ -216,9 +240,11 @@ func ConfigSchema() schematypes.Object {
 			"minimumMemory": schematypes.Integer{
 				MetaData: schematypes.MetaData{
 					Title: "Minimum Memory",
-					Description: `The minimum amount of memory in bytes to have available
+					Description: util.Markdown(`
+						The minimum amount of memory in bytes to have available
 						before starting on the next task. Garbage collector will do a
-						best-effort attempt at releasing resources to satisfy this limit`,
+						best-effort attempt at releasing resources to satisfy this limit.
+					`),
 				},
 				Minimum: 0,
 				Maximum: math.MaxInt64,

--- a/worker/lifecyclecontext.go
+++ b/worker/lifecyclecontext.go
@@ -1,0 +1,33 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+// lifeCycleContext implements context.Context such that it is canceled, when
+// the given life-cycle tracker ends.
+type lifeCycleContext struct {
+	LifeCycle *runtime.LifeCycleTracker
+}
+
+func (c *lifeCycleContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (c *lifeCycleContext) Done() <-chan struct{} {
+	return c.LifeCycle.StoppingGracefully.Done()
+}
+
+func (c *lifeCycleContext) Err() error {
+	if c.LifeCycle.StoppingGracefully.IsDone() {
+		return context.Canceled
+	}
+	return nil
+}
+
+func (c *lifeCycleContext) Value(key interface{}) interface{} {
+	return nil
+}

--- a/worker/taskrun/options.go
+++ b/worker/taskrun/options.go
@@ -9,13 +9,13 @@ import (
 
 // Options required to create a TaskRun
 type Options struct {
-	Environment runtime.Environment
-	Engine      engines.Engine
-	Plugin      plugins.Plugin
-	Monitor     runtime.Monitor
-	TaskInfo    runtime.TaskInfo
-	Payload     map[string]interface{}
-	Queue       client.Queue
+	Environment   runtime.Environment
+	Engine        engines.Engine
+	PluginManager *plugins.PluginManager
+	Monitor       runtime.Monitor
+	TaskInfo      runtime.TaskInfo
+	Payload       map[string]interface{}
+	Queue         client.Queue
 }
 
 // mustBeValid panics if Options contains empty values, this allows us to catch
@@ -36,8 +36,8 @@ func (o *Options) mustBeValid() {
 	if o.Engine == nil {
 		panic("taskrun: Options.Engine is nil")
 	}
-	if o.Plugin == nil {
-		panic("taskrun: Options.Plugin is nil")
+	if o.PluginManager == nil {
+		panic("taskrun: Options.PluginManager is nil")
 	}
 	if o.Monitor == nil {
 		panic("taskrun: Options.Monitor is nil")

--- a/worker/taskrun/taskrun.go
+++ b/worker/taskrun/taskrun.go
@@ -18,12 +18,12 @@ import (
 // SetQueueClient() which are intended to be called from other threads.
 type TaskRun struct {
 	// Constants
-	environment runtime.Environment
-	engine      engines.Engine
-	plugin      plugins.Plugin
-	monitor     runtime.Monitor
-	taskInfo    runtime.TaskInfo
-	payload     map[string]interface{}
+	environment   runtime.Environment
+	engine        engines.Engine
+	pluginManager plugins.Plugin // use Plugin interface so we can mock it in tests
+	monitor       runtime.Monitor
+	taskInfo      runtime.TaskInfo
+	payload       map[string]interface{}
 
 	// TaskContext
 	taskContext *runtime.TaskContext
@@ -55,12 +55,12 @@ func New(options Options) *TaskRun {
 	options.mustBeValid()
 
 	t := &TaskRun{
-		environment: options.Environment,
-		engine:      options.Engine,
-		plugin:      options.Plugin,
-		monitor:     options.Monitor,
-		taskInfo:    options.TaskInfo,
-		payload:     options.Payload,
+		environment:   options.Environment,
+		engine:        options.Engine,
+		pluginManager: options.PluginManager,
+		monitor:       options.Monitor,
+		taskInfo:      options.TaskInfo,
+		payload:       options.Payload,
 	}
 	t.c.L = &t.m
 

--- a/worker/taskrun/taskrun_test.go
+++ b/worker/taskrun/taskrun_test.go
@@ -40,8 +40,8 @@ func TestTaskRun(t *testing.T) {
 			Environment: &env,
 			Monitor:     env.Monitor.WithPrefix("engine"),
 		}),
-		Plugin:  nil, // overwritten in each test case
-		Monitor: env.Monitor.WithPrefix("taskrun"),
+		PluginManager: &plugins.PluginManager{}, // overwritten in each test case, after New
+		Monitor:       env.Monitor.WithPrefix("taskrun"),
 		TaskInfo: runtime.TaskInfo{
 			TaskID: "--test-task-id--",
 			RunID:  0,
@@ -69,7 +69,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Finished", true).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    0,
@@ -78,6 +77,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, _ := run.WaitForResult()
 		assert.True(t, success, "expected success to be true")
 		assert.False(t, exception, "expected exception to be false")
@@ -97,7 +97,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Finished", true).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":   10,
@@ -106,6 +105,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, _ := run.WaitForResult()
 		assert.True(t, success, "expected success to be true")
 		assert.False(t, exception, "expected exception to be false")
@@ -125,7 +125,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Finished", false).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    10,
@@ -134,6 +133,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, _ := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.False(t, exception, "expected exception to be false")
@@ -148,7 +148,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonMalformedPayload).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    10,
@@ -157,6 +156,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")
@@ -174,7 +174,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonMalformedPayload).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    10,
@@ -183,6 +182,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")
@@ -200,7 +200,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonInternalError).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    10,
@@ -209,6 +208,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")
@@ -227,7 +227,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonInternalError).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    10,
@@ -236,6 +235,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")
@@ -254,7 +254,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonInternalError).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    0,
@@ -263,6 +262,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")
@@ -281,7 +281,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonInternalError).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    0,
@@ -290,6 +289,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run := New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")
@@ -320,7 +320,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonWorkerShutdown).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    50,
@@ -329,6 +328,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run = New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")
@@ -358,7 +358,6 @@ func TestTaskRun(t *testing.T) {
 		plugin.On("Exception", runtime.ReasonCanceled).Return(nil)
 		plugin.On("Dispose").Return(nil)
 		defer plugin.AssertExpectations(t)
-		options.Plugin = plugin
 
 		require.NoError(t, json.Unmarshal([]byte(`{
 			"delay":    50,
@@ -367,6 +366,7 @@ func TestTaskRun(t *testing.T) {
 		}`), &options.Payload), "unable to parse payload")
 
 		run = New(options)
+		run.pluginManager = plugin // hack to inject mock for PluginManager
 		success, exception, reason := run.WaitForResult()
 		assert.False(t, success, "expected success to be false")
 		assert.True(t, exception, "expected exception to be true")

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -348,17 +348,15 @@ func TestWorkerStopNow(t *testing.T) {
 		Tasks:       1,
 		WorkerGroup: "test-worker-group",
 		WorkerID:    "test-worker-id",
-	}).Once().Run(func(mock.Arguments) {
-		w.StopNow()
-	}).Return(&queue.ClaimWorkResponse{
+	}).Once().Return(&queue.ClaimWorkResponse{
 		Tasks: append(queue.ClaimWorkResponse{}.Tasks, taskClaim{
 			Status:     queue.TaskStatusStructure{TaskID: "my-task-id-1"},
 			RunID:      0,
 			TakenUntil: tcclient.Time(time.Now().Add(10 * time.Minute)),
 			Task: queue.TaskDefinitionResponse{
 				Payload: json.RawMessage(`{
-					"delay": 200,
-					"function": "true",
+					"delay": 50,
+					"function": "stopNow-sleep",
 					"argument": ""
 				}`),
 			},
@@ -367,11 +365,4 @@ func TestWorkerStopNow(t *testing.T) {
 	q.On("ReportException", "my-task-id-1", "0", &queue.TaskExceptionRequest{
 		Reason: "worker-shutdown",
 	}).Once().Return(&queue.TaskStatusResponse{}, nil)
-
-	// return no tasks forever, and stop gracefully
-	q.On("ClaimWork", "test-provisioner-id", "test-worker-type", mock.Anything).Run(func(mock.Arguments) {
-		w.StopGracefully()
-	}).Return(&queue.ClaimWorkResponse{
-		Tasks: append(queue.ClaimWorkResponse{}.Tasks),
-	}, nil)
 }

--- a/worker/workertest/artifactassertions.go
+++ b/worker/workertest/artifactassertions.go
@@ -1,0 +1,42 @@
+package workertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AnyArtifact creates an assertion that checks matches anything.
+func AnyArtifact() func(t *testing.T, a Artifact) {
+	// This is made a function that returns a function for consistency.
+	return func(t *testing.T, a Artifact) {}
+}
+
+// GrepArtifact creates an assertion that holds if the artifact contains the
+// given substring.
+func GrepArtifact(substring string) func(t *testing.T, a Artifact) {
+	return func(t *testing.T, a Artifact) {
+		assert.Contains(t, string(a.Data), substring, "Expected substring in artifact: %s", a.Name)
+	}
+}
+
+// S3Artifact creates an assertion that holds if the artifact is an S3 artifact
+func S3Artifact() func(t *testing.T, a Artifact) {
+	return func(t *testing.T, a Artifact) {
+		assert.Equal(t, "s3", a.StorageType, "Expected storageType: 's3' for artifact: %s", a.Name)
+	}
+}
+
+// ErrorArtifact creates an assertion that holds if the artifact is an error artifact
+func ErrorArtifact() func(t *testing.T, a Artifact) {
+	return func(t *testing.T, a Artifact) {
+		assert.Equal(t, "error", a.StorageType, "Expected storageType: 'error' for artifact: %s", a.Name)
+	}
+}
+
+// ReferenceArtifact creates an assertion that holds if the artifact is a reference artifact
+func ReferenceArtifact() func(t *testing.T, a Artifact) {
+	return func(t *testing.T, a Artifact) {
+		assert.Equal(t, "reference", a.StorageType, "Expected storageType: 'reference' for artifact: %s", a.Name)
+	}
+}

--- a/worker/workertest/doc.go
+++ b/worker/workertest/doc.go
@@ -1,0 +1,7 @@
+// Package workertest provides a framework for declarative definition of worker
+// integration tests.
+package workertest
+
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
+
+var debug = util.Debug("workertest")

--- a/worker/workertest/fakequeue/doc.go
+++ b/worker/workertest/fakequeue/doc.go
@@ -1,0 +1,13 @@
+// Package fakequeue provides a fake implementation of taskcluster-queue in
+// golang, The FakeQueue server stores tasks in-memory, it doesn't validate
+// authentication, but implements most end-points correctly.
+//
+// The aim of this package is to facilitate integration tests to be executed
+// without dependency on a production deployment of taskcluster-queue. Running
+// integration tests against production is important, but also slow, so being
+// able run them locally without credentials is very nice.
+package fakequeue
+
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
+
+var debug = util.Debug("fakequeue")

--- a/worker/workertest/fakequeue/fakequeue.go
+++ b/worker/workertest/fakequeue/fakequeue.go
@@ -1,0 +1,791 @@
+package fakequeue
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/queue"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+)
+
+// FakeQueue is a taskcluster-queue implementation with certain limitations:
+//  * No validation of authentication or authenorization
+//  * Data stored in-memory
+// The FakeQueue supports the following end-points:
+//  * task
+//  * status
+//  * createTask
+//  * cancelTask
+//  * claimWork
+//  * reclaimTask
+//  * reportCompleted
+//  * reportFailed
+//  * reportException
+//  * createArtifact
+//  * getArtifact
+//  * getLatestArtifact
+//  * listLatestArtifact
+//  * pendingTasks
+type FakeQueue struct {
+	m     sync.Mutex
+	c     sync.Cond
+	tasks map[string]*task
+}
+
+// New returns a new FakeQueue
+func New() *FakeQueue {
+	return &FakeQueue{}
+}
+
+type task struct {
+	status    queue.TaskStatusStructure
+	task      queue.TaskDefinitionResponse
+	artifacts []map[string]artifact
+}
+
+type run struct { // as defined in queue.TaskStatusStructure.Runs
+	ReasonCreated  string        `json:"reasonCreated"`
+	ReasonResolved string        `json:"reasonResolved,omitempty"`
+	Resolved       tcclient.Time `json:"resolved,omitempty"`
+	RunID          int           `json:"runId"`
+	Scheduled      tcclient.Time `json:"scheduled"`
+	Started        tcclient.Time `json:"started,omitempty"`
+	State          string        `json:"state"`
+	TakenUntil     tcclient.Time `json:"takenUntil,omitempty"`
+	WorkerGroup    string        `json:"workerGroup,omitempty"`
+	WorkerID       string        `json:"workerId,omitempty"`
+}
+
+const (
+	storageTypeS3        = "s3"
+	storageTypeAzure     = "azure"
+	storageTypeReference = "reference"
+	storageTypeError     = "error"
+)
+
+type artifact struct {
+	StorageType     string    `json:"storageType"`
+	Expires         time.Time `json:"expires"`
+	ContentType     string    `json:"contentType,omitempty"`
+	URL             string    `json:"url,omitempty"`
+	Reason          string    `json:"reason,omitempty"`
+	Message         string    `json:"message,omitempty"`
+	Data            []byte    `json:"-"`
+	ContentEncoding string    `json:"-"`
+}
+
+func (q *FakeQueue) initAndLock() {
+	q.m.Lock()
+	if q.c.L == nil {
+		q.c.L = &q.m
+		q.tasks = make(map[string]*task)
+	}
+}
+
+var (
+	patternTask                = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})$")
+	patternCreateTask          = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})$")
+	patternStatus              = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/status$")
+	patternCancelTask          = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/cancel$")
+	patternReclaimTask         = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/reclaim$")
+	patternReportCompleted     = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/completed$")
+	patternReportFailed        = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/failed$")
+	patternReportException     = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/exception$")
+	patternCreateArtifact      = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/artifacts/(.*)$")
+	patternGetArtifact         = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/artifacts/(.*)$")
+	patternListArtifacts       = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/artifacts$")
+	patternGetLatestArtifact   = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/artifacts/(.*)$")
+	patternListLatestArtifacts = regexp.MustCompile("^/task/([a-zA-Z0-9_-]{22})/artifacts$")
+	patternClaimWork           = regexp.MustCompile("^/claim-work/([a-zA-Z0-9_-]{1,22})/([a-zA-Z0-9_-]{1,22})$")
+	patternPendingTasks        = regexp.MustCompile("^/pending/([a-zA-Z0-9_-]{1,22})/([a-zA-Z0-9_-]{1,22})$")
+	patternPing                = regexp.MustCompile("^/ping$")
+	patternArtifactPutURL      = regexp.MustCompile("^/internal/task/([a-zA-Z0-9_-]{22})/runs/([0-9]+)/put-artifact/(.*)$")
+)
+
+func (q *FakeQueue) task(taskID string) interface{} {
+	if t, ok := q.tasks[taskID]; ok {
+		return t.task
+	}
+	return resourceNotFoundError
+}
+
+func (q *FakeQueue) status(taskID string) interface{} {
+	if t, ok := q.tasks[taskID]; ok {
+		return queue.TaskStatusResponse{Status: t.status}
+	}
+	return resourceNotFoundError
+}
+
+func (q *FakeQueue) createTask(taskID string, payload *queue.TaskDefinitionRequest) interface{} {
+	def := setTaskDefaults(taskID, payload)
+
+	// check that dependencies have been created
+	for _, dep := range def.Dependencies {
+		if _, ok := q.tasks[dep]; !ok {
+			return restError{
+				StatusCode: http.StatusBadRequest,
+				Code:       "BadPayload",
+				Message:    "Task depends on a task that doesn't exist!",
+			}
+		}
+	}
+
+	// Handle case where the task exists
+	if t, ok := q.tasks[taskID]; ok {
+		if isJSONEqual(t.task, def) {
+			return queue.TaskStatusResponse{Status: t.status}
+		}
+		return restError{
+			StatusCode: http.StatusConflict,
+			Code:       "RequestConflict",
+			Message:    "Task with given taskID already exists with a different definition",
+		}
+	}
+
+	// Insert task in database
+	q.tasks[taskID] = &task{
+		task: def,
+		status: queue.TaskStatusStructure{
+			Deadline:      def.Deadline,
+			Expires:       def.Expires,
+			ProvisionerID: def.ProvisionerID,
+			RetriesLeft:   def.Retries,
+			SchedulerID:   def.SchedulerID,
+			State:         statusUnscheduled,
+			TaskGroupID:   def.TaskGroupID,
+			TaskID:        taskID,
+			WorkerType:    def.WorkerType,
+		},
+	}
+	// Schedule all tasks ready to be scheduled
+	reconcileTasks(q.tasks)
+
+	return queue.TaskStatusResponse{Status: q.tasks[taskID].status}
+}
+
+func (q *FakeQueue) cancelTask(taskID string) interface{} {
+	t, ok := q.tasks[taskID]
+	if !ok {
+		return resourceNotFoundError
+	}
+
+	// Added dummy run, if unscheduled
+	if t.status.State == statusUnscheduled {
+		t.status.Runs = append(t.status.Runs, run{
+			RunID:          0,
+			ReasonCreated:  "exception",
+			ReasonResolved: "canceled",
+			Resolved:       tcclient.Time(time.Now()),
+			Scheduled:      tcclient.Time(time.Now()),
+			State:          statusException,
+		})
+		t.artifacts = append(t.artifacts, make(map[string]artifact))
+		t.status.State = statusException
+	}
+
+	// If pending or running we cancel the run
+	if t.status.State == statusPending || t.status.State == statusRunning {
+		runID := len(t.status.Runs) - 1
+		t.status.Runs[runID].State = statusException
+		t.status.Runs[runID].Resolved = tcclient.Time(time.Now())
+		t.status.Runs[runID].ReasonResolved = "canceled"
+		t.status.State = statusException
+	}
+
+	if t.status.State != statusException || t.status.Runs[len(t.status.Runs)-1].ReasonResolved != "canceled" {
+		return restError{
+			StatusCode: http.StatusConflict,
+			Code:       "RequestConflict",
+			Message:    "Task already resolved something other than canceled",
+		}
+	}
+
+	return queue.TaskStatusResponse{Status: t.status}
+}
+
+func (q *FakeQueue) claimWork(provisionerID, workerType string, payload *queue.ClaimWorkRequest, w http.ResponseWriter) interface{} {
+	var finished atomics.Once
+	var result queue.ClaimWorkResponse
+	go func() {
+		q.m.Lock()
+		defer q.m.Unlock()
+		for !finished.IsDone() {
+			// schedule all tasks that may have expired, etc
+			reconcileTasks(q.tasks)
+
+			// Find tasks
+			for _, t := range q.tasks {
+				// Skip tasks that aren't pending or have wrong provisionerID/workerType
+				if t.status.State != statusPending || t.task.ProvisionerID != provisionerID || t.task.WorkerType != workerType {
+					continue
+				}
+
+				// Take this run
+				runID := len(t.status.Runs) - 1
+				t.status.Runs[runID].Started = tcclient.Time(time.Now())
+				t.status.Runs[runID].WorkerGroup = payload.WorkerGroup
+				t.status.Runs[runID].WorkerID = payload.WorkerID
+				t.status.Runs[runID].TakenUntil = tcclient.Time(time.Now().Add(5 * time.Minute))
+				t.status.Runs[runID].State = statusRunning
+				t.status.State = statusRunning
+
+				// Add claim to result
+				result.Tasks = append(result.Tasks, struct {
+					Credentials struct {
+						AccessToken string `json:"accessToken"`
+						Certificate string `json:"certificate"`
+						ClientID    string `json:"clientId"`
+					} `json:"credentials"`
+					RunID       int                          `json:"runId"`
+					Status      queue.TaskStatusStructure    `json:"status"`
+					TakenUntil  tcclient.Time                `json:"takenUntil"`
+					Task        queue.TaskDefinitionResponse `json:"task"`
+					WorkerGroup string                       `json:"workerGroup"`
+					WorkerID    string                       `json:"workerId"`
+				}{
+					Credentials: fakeCredentials,
+					RunID:       runID,
+					Status:      t.status,
+					TakenUntil:  t.status.Runs[runID].TakenUntil,
+					Task:        t.task,
+					WorkerGroup: payload.WorkerGroup,
+					WorkerID:    payload.WorkerID,
+				})
+
+				// Stop looping through tasks if we have enough
+				if len(result.Tasks) >= payload.Tasks {
+					break
+				}
+			}
+
+			// If we found any pending tasks that we now have a claim for then we'r
+			// done
+			if len(result.Tasks) > 0 {
+				finished.Do(nil)
+				break
+			}
+
+			// Temporarily release lock and wait for signal that something changed
+			q.c.Wait()
+		}
+	}()
+
+	// Wait for canceled, use nil channel if not supported
+	var canceled <-chan bool
+	if notifier, ok := w.(http.CloseNotifier); ok {
+		canceled = notifier.CloseNotify()
+	}
+
+	// Wait for done
+	q.m.Unlock()
+	select {
+	case <-canceled:
+	case <-time.After(5 * time.Second):
+	case <-finished.Done():
+	}
+	q.m.Lock()
+
+	finished.Do(nil)
+	return result
+}
+
+func (q *FakeQueue) reclaimTask(taskID string, runID int) interface{} {
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	// If run is not running we have a conflict
+	if t.status.Runs[runID].State != statusRunning {
+		return restError{
+			StatusCode: http.StatusConflict,
+			Code:       "RequestConflict",
+			Message:    "run not running",
+		}
+	}
+
+	// Update takenUntil
+	t.status.Runs[runID].TakenUntil = tcclient.Time(time.Now().Add(5 * time.Minute))
+
+	return queue.TaskReclaimResponse{
+		Credentials: fakeCredentials,
+		RunID:       runID,
+		Status:      t.status,
+		TakenUntil:  t.status.Runs[runID].TakenUntil,
+		WorkerGroup: t.status.Runs[runID].WorkerGroup,
+		WorkerID:    t.status.Runs[runID].WorkerID,
+	}
+}
+
+func (q *FakeQueue) reportCompleted(taskID string, runID int) interface{} {
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	// If completed we do nothing, idempontent requests allowed
+	if t.status.Runs[runID].State == statusCompleted {
+		return queue.TaskStatusResponse{Status: t.status}
+	}
+
+	// if not running we have a conflict
+	if t.status.Runs[runID].State != statusRunning {
+		return restError{
+			StatusCode: http.StatusConflict,
+			Code:       "RequestConflict",
+			Message:    "run is already resolved or pending",
+		}
+	}
+
+	// Resolve the run
+	t.status.Runs[runID].State = statusCompleted
+	t.status.Runs[runID].ReasonResolved = "completed"
+	t.status.Runs[runID].Resolved = tcclient.Time(time.Now())
+	t.status.State = statusCompleted
+
+	return queue.TaskStatusResponse{Status: t.status}
+}
+
+func (q *FakeQueue) reportFailed(taskID string, runID int) interface{} {
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	// If failed we do nothing, idempontent requests allowed
+	if t.status.Runs[runID].State == statusFailed {
+		return queue.TaskStatusResponse{Status: t.status}
+	}
+
+	// if not running we have a conflict
+	if t.status.Runs[runID].State != statusRunning {
+		return restError{
+			StatusCode: http.StatusConflict,
+			Code:       "RequestConflict",
+			Message:    "run is already resolved or pending",
+		}
+	}
+
+	// Resolve the run
+	t.status.Runs[runID].State = statusFailed
+	t.status.Runs[runID].ReasonResolved = "failed"
+	t.status.Runs[runID].Resolved = tcclient.Time(time.Now())
+	t.status.State = statusFailed
+
+	return queue.TaskStatusResponse{Status: t.status}
+}
+
+func (q *FakeQueue) reportException(taskID string, runID int, payload *queue.TaskExceptionRequest) interface{} {
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	// If completed we do nothing, idempontent requests allowed
+	if t.status.Runs[runID].State == statusException &&
+		t.status.Runs[runID].ReasonResolved == payload.Reason {
+		return queue.TaskStatusResponse{Status: t.status}
+	}
+
+	// if not running we have a conflict
+	if t.status.Runs[runID].State != statusRunning {
+		return restError{
+			StatusCode: http.StatusConflict,
+			Code:       "RequestConflict",
+			Message:    "run is already resolved or pending",
+		}
+	}
+
+	// Resolve the run
+	t.status.Runs[runID].State = statusException
+	t.status.Runs[runID].ReasonResolved = payload.Reason
+	t.status.Runs[runID].Resolved = tcclient.Time(time.Now())
+	t.status.State = statusException
+
+	// Add a retry run
+	if t.status.RetriesLeft > 0 && (payload.Reason == "worker-shutdown" || payload.Reason == "intermittent-task") {
+		t.status.RetriesLeft--
+		reason := "retry"
+		if payload.Reason == "intermittent-task" {
+			reason = "task-retry"
+		}
+		t.status.Runs = append(t.status.Runs, run{
+			ReasonCreated: reason,
+			RunID:         len(t.status.Runs),
+			Scheduled:     tcclient.Time(time.Now()),
+			State:         statusPending,
+		})
+		t.artifacts = append(t.artifacts, make(map[string]artifact))
+		t.status.State = statusPending
+	}
+
+	return queue.TaskStatusResponse{Status: t.status}
+}
+
+func (q *FakeQueue) createArtifact(taskID string, runID int, name string, payload []byte, r *http.Request) interface{} {
+	// Parse payload
+	var a artifact
+	if err := json.Unmarshal(payload, &a); err != nil {
+		return invalidJSONPayloadError
+	}
+
+	// Find task
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	// if artifact already exists, and it doesn't match and it's not a reference
+	if a2, ok := t.artifacts[runID][name]; ok && !isJSONEqual(a, a2) &&
+		!(a.StorageType == storageTypeReference && a2.StorageType == storageTypeReference) {
+		return restError{
+			StatusCode: http.StatusConflict,
+			Code:       "RequestConflict",
+			Message:    "Artifact already exists with different definition",
+		}
+	}
+
+	// Recover data in case there was some stored
+	a.Data = t.artifacts[runID][name].Data
+	t.artifacts[runID][name] = a
+
+	var result struct {
+		StorageType string    `json:"storageType"`
+		Expires     time.Time `json:"expires,omitempty"`
+		ContentType string    `json:"contentType,omitempty"`
+		PutURL      string    `json:"putUrl,omitempty"`
+	}
+	result.StorageType = a.StorageType
+
+	// Set PutURL if s3 or azure
+	if a.StorageType == storageTypeS3 || a.StorageType == storageTypeAzure {
+		proto := "http"
+		if r.TLS != nil {
+			proto = "https"
+		}
+		result.PutURL = fmt.Sprintf(
+			"%s://%s/internal/task/%s/runs/%d/put-artifact/%s",
+			proto, r.Host, taskID, runID, name,
+		)
+		result.Expires = time.Now().Add(5 * time.Minute)
+	}
+
+	return result
+}
+
+func (q *FakeQueue) internalPutArtifact(taskID string, runID int, name string, payload []byte, r *http.Request) interface{} {
+	// Find task
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	// check that the artifact was created first
+	if a, ok := t.artifacts[runID][name]; !ok || (a.StorageType != storageTypeS3 && a.StorageType != storageTypeAzure) {
+		return restError{
+			StatusCode: http.StatusForbidden,
+			Code:       "InvalidPutURL",
+			Message:    "This URL was not returned from createArtifact",
+		}
+	}
+
+	// Store payload
+	a := t.artifacts[runID][name]
+	a.Data = payload
+	a.ContentEncoding = r.Header.Get("Content-Encoding")
+	t.artifacts[runID][name] = a
+
+	return map[string]interface{}{
+		"upload": "OK",
+	}
+}
+
+func (q *FakeQueue) getArtifact(taskID string, runID int, name string) interface{} {
+	// Find task
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	if a, ok := t.artifacts[runID][name]; ok {
+		switch a.StorageType {
+		case storageTypeS3, storageTypeAzure:
+			return rawResponse{
+				StatusCode:      http.StatusOK,
+				ContentType:     a.ContentType,
+				ContentEncoding: a.ContentEncoding,
+				Payload:         a.Data,
+			}
+		case storageTypeReference:
+			return redirectResponse{
+				StatusCode: http.StatusSeeOther,
+				Location:   a.URL,
+			}
+		case storageTypeError:
+		default:
+			panic(fmt.Sprintf("unknown artifact storageType: %s", a.StorageType))
+		}
+	}
+
+	return restError{
+		StatusCode: http.StatusNotFound,
+		Code:       "ResourceNotFound",
+		Message:    "No such artifact found",
+	}
+}
+
+func (q *FakeQueue) getLatestArtifact(taskID, name string) interface{} {
+	// Find task
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) == 0 {
+		return resourceNotFoundError
+	}
+
+	return q.getArtifact(taskID, len(t.status.Runs)-1, name)
+}
+
+func (q *FakeQueue) listArtifacts(taskID string, runID int) interface{} {
+	// Find task
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) <= runID {
+		return resourceNotFoundError
+	}
+
+	var result queue.ListArtifactsResponse
+	for name, a := range t.artifacts[runID] {
+		result.Artifacts = append(result.Artifacts, struct {
+			ContentType string        `json:"contentType"`
+			Expires     tcclient.Time `json:"expires"`
+			Name        string        `json:"name"`
+			StorageType string        `json:"storageType"`
+		}{
+			ContentType: a.ContentType,
+			Expires:     tcclient.Time(a.Expires),
+			Name:        name,
+			StorageType: a.StorageType,
+		})
+	}
+	return result
+}
+
+func (q *FakeQueue) listLatestArtifacts(taskID string) interface{} {
+	// Find task
+	t, ok := q.tasks[taskID]
+	if !ok || len(t.status.Runs) == 0 {
+		return resourceNotFoundError
+	}
+
+	return q.listArtifacts(taskID, len(t.status.Runs)-1)
+}
+
+func (q *FakeQueue) pendingTasks(provisionerID, workerType string) interface{} {
+	count := 0
+	for _, t := range q.tasks {
+		if t.status.State == statusPending && t.status.ProvisionerID == provisionerID && t.status.WorkerType == workerType {
+			count++
+		}
+	}
+
+	return queue.CountPendingTasksResponse{
+		PendingTasks:  count,
+		ProvisionerID: provisionerID,
+		WorkerType:    workerType,
+	}
+}
+
+func (q *FakeQueue) ping() interface{} {
+	return map[string]interface{}{
+		"status": "running",
+	}
+}
+
+func (q *FakeQueue) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	debug("%s %s", r.Method, r.URL.Path)
+
+	// Read body before we lock
+	var data []byte
+	if r.Body != nil {
+		defer r.Body.Close()
+		var rerr error
+		data, rerr = ioutil.ReadAll(r.Body)
+		if rerr != nil {
+			debug("failed to read REST payload, error: %s", rerr)
+			reply(w, r, restError{
+				StatusCode: http.StatusInternalServerError,
+				Code:       "PayloadTransmissionError",
+				Message:    "Some error reading the payload",
+			})
+			return
+		}
+	}
+
+	// Always initialize and lock
+	q.initAndLock()
+	defer q.m.Unlock()
+
+	// Always notify other threads that state may have changed
+	defer q.c.Broadcast()
+
+	// Always reconcileTasks
+	reconcileTasks(q.tasks)
+	defer reconcileTasks(q.tasks)
+
+	// handle URL path
+	p := r.URL.Path
+
+	// GET  /task/<taskId>
+	if m := patternTask.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodGet {
+		debug(" -> queue.task(%s)", m[1])
+		reply(w, r, q.task(m[1]))
+		return
+	}
+
+	// PUT  /task/<taskId>
+	if m := patternCreateTask.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPut {
+		debug(" -> queue.createTask(%s, ...)", m[1])
+		var payload queue.TaskDefinitionRequest
+		if err := json.Unmarshal(data, &payload); err != nil {
+			reply(w, r, invalidJSONPayloadError)
+			return
+		}
+		reply(w, r, q.createTask(m[1], &payload))
+		return
+	}
+
+	// GET  /task/<taskId>/status
+	if m := patternStatus.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodGet {
+		debug(" -> queue.status(%s)", m[1])
+		reply(w, r, q.status(m[1]))
+		return
+	}
+
+	// POST /task/<taskId>/cancel
+	if m := patternCancelTask.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPost {
+		debug(" -> queue.cancelTask(%s)", m[1])
+		reply(w, r, q.cancelTask(m[1]))
+		return
+	}
+
+	// POST /task/<taskId>/runs/<runId>/reclaim
+	if m := patternReclaimTask.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPost {
+		runID, _ := strconv.Atoi(m[2])
+		debug(" -> queue.reclaimTask(%s, %d)", m[1], runID)
+		reply(w, r, q.reclaimTask(m[1], runID))
+		return
+	}
+
+	// POST /task/<taskId>/runs/<runId>/completed
+	if m := patternReportCompleted.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPost {
+		runID, _ := strconv.Atoi(m[2])
+		debug(" -> queue.reportCompleted(%s, %d)", m[1], runID)
+		reply(w, r, q.reportCompleted(m[1], runID))
+		return
+	}
+
+	// POST /task/<taskId>/runs/<runId>/failed
+	if m := patternReportFailed.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPost {
+		runID, _ := strconv.Atoi(m[2])
+		debug(" -> queue.reportFailed(%s, %d)", m[1], runID)
+		reply(w, r, q.reportFailed(m[1], runID))
+		return
+	}
+
+	// POST /task/<taskId>/runs/<runId>/exception
+	if m := patternReportException.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPost {
+		runID, _ := strconv.Atoi(m[2])
+		var payload queue.TaskExceptionRequest
+		if err := json.Unmarshal(data, &payload); err != nil {
+			reply(w, r, invalidJSONPayloadError)
+			return
+		}
+		debug(" -> queue.reportException(%s, %d, {reason: %s})", m[1], runID, payload.Reason)
+		reply(w, r, q.reportException(m[1], runID, &payload))
+		return
+	}
+
+	// POST /task/<taskId>/runs/<runId>/artifacts/<name>
+	if m := patternCreateArtifact.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPost {
+		runID, _ := strconv.Atoi(m[2])
+		debug(" -> queue.createArtifact(%s, %d, %s, ...)", m[1], runID, m[3])
+		reply(w, r, q.createArtifact(m[1], runID, m[3], data, r))
+		return
+	}
+
+	// PUT  /internal/task/<taskId>/runs/<runId>/artifacts/<name>
+	if m := patternArtifactPutURL.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPut {
+		debug(" -> s3/azure")
+		runID, _ := strconv.Atoi(m[2])
+		reply(w, r, q.internalPutArtifact(m[1], runID, m[3], data, r))
+		return
+	}
+
+	// GET  /task/<taskId>/runs/<runId>/artifacts/<name>
+	if m := patternGetArtifact.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodGet {
+		runID, _ := strconv.Atoi(m[2])
+		debug(" -> queue.getArtifact(%s, %d, %s)", m[1], runID, m[3])
+		reply(w, r, q.getArtifact(m[1], runID, m[3]))
+		return
+	}
+
+	// GET  /task/<taskId>/runs/<runId>/artifacts
+	if m := patternListArtifacts.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodGet {
+		runID, _ := strconv.Atoi(m[2])
+		debug(" -> queue.listArtifacts(%s, %d)", m[1], runID)
+		reply(w, r, q.listArtifacts(m[1], runID))
+		return
+	}
+
+	// GET  /task/<taskId>/artifacts/<name>
+	if m := patternGetLatestArtifact.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodGet {
+		debug(" -> queue.getLatestArtifact(%s, %s)", m[1], m[2])
+		reply(w, r, q.getLatestArtifact(m[1], m[2]))
+		return
+	}
+
+	// GET  /task/<taskId>/artifacts
+	if m := patternListLatestArtifacts.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodGet {
+		debug(" -> queue.listLatestArtifacts(%s)", m[1])
+		reply(w, r, q.listLatestArtifacts(m[1]))
+		return
+	}
+
+	// POST /claim-work/<provisionerId>/<workerType>
+	if m := patternClaimWork.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodPost {
+		debug(" -> queue.claimWork(%s, %s, ...)", m[1], m[2])
+		var payload queue.ClaimWorkRequest
+		if err := json.Unmarshal(data, &payload); err != nil {
+			reply(w, r, invalidJSONPayloadError)
+			return
+		}
+		reply(w, r, q.claimWork(m[1], m[2], &payload, w))
+		return
+	}
+
+	// GET  /pending/<provisionerId>/<workerType>
+	if m := patternPendingTasks.FindStringSubmatch(p); len(m) > 0 && r.Method == http.MethodGet {
+		debug(" -> queue.pendingTasks(%s, %s)", m[1], m[2])
+		reply(w, r, q.pendingTasks(m[1], m[2]))
+		return
+	}
+
+	// GET  /ping
+	if patternPing.MatchString(p) && r.Method == http.MethodGet {
+		debug(" -> queue.ping()")
+		reply(w, r, q.ping())
+		return
+	}
+
+	// Reply with generic error
+	reply(w, r, restError{
+		StatusCode: http.StatusNotFound,
+		Code:       "UnknownEndPoint",
+		Message:    "Invalid request URL or method. No matching end-point found!",
+	})
+}

--- a/worker/workertest/fakequeue/fakequeue_test.go
+++ b/worker/workertest/fakequeue/fakequeue_test.go
@@ -1,0 +1,74 @@
+package fakequeue
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/slugid-go/slugid"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/queue"
+)
+
+const (
+	testProvisionerID = "dummy-test-provisioner"
+	testWorkerType    = "dummy-test-worker-317"
+)
+
+func TestFakeQueue(t *testing.T) {
+	s := httptest.NewServer(New())
+	defer s.Close()
+
+	q := queue.New(&tcclient.Credentials{})
+	q.BaseURL = s.URL
+
+	debug("### Creating task")
+	taskID := slugid.Nice()
+	task := queue.TaskDefinitionRequest{
+		ProvisionerID: testProvisionerID,
+		WorkerType:    testWorkerType,
+		Created:       tcclient.Time(time.Now()),
+		Deadline:      tcclient.Time(time.Now().Add(60 * time.Minute)),
+		Payload:       json.RawMessage(`{}`),
+	}
+	task.Metadata.Name = "test task"
+	task.Metadata.Description = "Some test task to see if fake queue works"
+	task.Metadata.Source = "https://github.com/taskcluster/taskcluster-worker/tree/master/worker/workertest/fakequeue/fakequeue_test.go"
+	task.Metadata.Owner = "jonasfj@mozilla.com"
+	_, err := q.CreateTask(taskID, &task)
+	assert.NoError(t, err, "failed to create task")
+
+	debug("### Claim work")
+	claims, err := q.ClaimWork(testProvisionerID, testWorkerType, &queue.ClaimWorkRequest{
+		Tasks:       5,
+		WorkerGroup: "test-worker-group",
+		WorkerID:    "test-worker-42",
+	})
+	assert.NoError(t, err, "failed to claim work")
+	assert.True(t, len(claims.Tasks) == 1, "Expected 1 task")
+	assert.True(t, claims.Tasks[0].Status.TaskID == taskID, "expected taskID")
+	assert.True(t, claims.Tasks[0].RunID == 0, "expected runID = 0")
+
+	debug("### Reclaim Task")
+	_, err = q.ReclaimTask(taskID, "0")
+	assert.NoError(t, err, "failed to reclaim")
+
+	debug("### Reclaim Task (again)")
+	_, err = q.ReclaimTask(taskID, "0")
+	assert.NoError(t, err, "failed to reclaim (again)")
+
+	debug("### Report completed")
+	_, err = q.ReportCompleted(taskID, "0")
+	assert.NoError(t, err, "failed to report completed")
+
+	debug("### Report completed (again)")
+	_, err = q.ReportCompleted(taskID, "0")
+	assert.NoError(t, err, "failed to report completed (again)")
+
+	debug("### Get task status")
+	status, err := q.Status(taskID)
+	assert.NoError(t, err, "failed to get tasks status")
+	assert.True(t, status.Status.State == "completed", "Expected task to be completed")
+}

--- a/worker/workertest/fakequeue/httputil.go
+++ b/worker/workertest/fakequeue/httputil.go
@@ -1,0 +1,59 @@
+package fakequeue
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type restError struct {
+	StatusCode int    `json:"-"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+}
+
+var invalidJSONPayloadError = restError{
+	StatusCode: http.StatusBadRequest,
+	Code:       "InvalidJSONPayload",
+	Message:    "Payload must be valid JSON",
+}
+
+var resourceNotFoundError = restError{
+	StatusCode: http.StatusNotFound,
+	Code:       "ResourceNotFound",
+	Message:    "Check that the taskId and runId is correct",
+}
+
+type redirectResponse struct {
+	StatusCode int
+	Location   string
+}
+
+type rawResponse struct {
+	StatusCode      int
+	ContentType     string
+	ContentEncoding string
+	Payload         []byte
+}
+
+func reply(w http.ResponseWriter, r *http.Request, result interface{}) {
+	if rr, ok := result.(rawResponse); ok {
+		w.Header().Set("Content-Type", rr.ContentType)
+		w.Header().Set("Content-Encoding", rr.ContentEncoding)
+		w.WriteHeader(rr.StatusCode)
+		w.Write(rr.Payload)
+	} else if rd, ok := result.(redirectResponse); ok {
+		http.Redirect(w, r, rd.Location, rd.StatusCode)
+	} else if e, ok := result.(restError); ok {
+		w.WriteHeader(e.StatusCode)
+		data, _ := json.MarshalIndent(e, "", "  ")
+		w.Write(data)
+	} else {
+		w.WriteHeader(http.StatusOK)
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			panic(fmt.Sprintf("internal server error: can't serialize: %T, err: %s", result, err))
+		}
+		w.Write(data)
+	}
+}

--- a/worker/workertest/fakequeue/listener.go
+++ b/worker/workertest/fakequeue/listener.go
@@ -1,0 +1,48 @@
+package fakequeue
+
+// Listener provides and interface that allows waiting for task resolution.
+//
+// This is not intended to be a generic pulse listening interface, it's intended
+// to the minimum subset required to write integration test. This way we can
+// implement it using Pulse/AMQP for integration testing and using FakeQueue for
+// testing without credentials.
+type Listener interface {
+	// WaitForTask returns a channel that gets a nil message when taskID is
+	// resolved, or an error if listening fails.
+	WaitForTask(taskID string) <-chan error
+}
+
+// NewFakeQueueListener returns a Listener implementation that waits for tasks
+// to be resolved in the FakeQueue given.
+func NewFakeQueueListener(q *FakeQueue) Listener {
+	return &fakeQueueListener{queue: q}
+}
+
+type fakeQueueListener struct {
+	queue *FakeQueue
+}
+
+func (l *fakeQueueListener) WaitForTask(taskID string) <-chan error {
+	done := make(chan error)
+
+	go func() {
+		l.queue.initAndLock()
+		defer l.queue.m.Unlock()
+
+		for {
+			t, ok := l.queue.tasks[taskID]
+			if ok && (t.status.State == statusCompleted ||
+				t.status.State == statusFailed ||
+				t.status.State == statusException) {
+				// close done, and return
+				close(done)
+				return
+			}
+
+			// Wait for a change
+			l.queue.c.Wait()
+		}
+	}()
+
+	return done
+}

--- a/worker/workertest/fakequeue/pulselistener.go
+++ b/worker/workertest/fakequeue/pulselistener.go
@@ -1,0 +1,82 @@
+package fakequeue
+
+import (
+	"fmt"
+
+	"github.com/streadway/amqp"
+	"github.com/taskcluster/slugid-go/slugid"
+)
+
+type pulseListener struct {
+	conn     *amqp.Connection
+	username string
+}
+
+// NewPulseListener creates a listener implementation for production queue
+// using pulse.
+func NewPulseListener(username, password string) (Listener, error) {
+	u := fmt.Sprintf("amqps://%s:%s@pulse.mozilla.org:5671", username, password)
+	conn, err := amqp.Dial(u)
+	if err != nil {
+		return nil, err
+	}
+	return &pulseListener{
+		conn:     conn,
+		username: username,
+	}, nil
+}
+
+var taskResolvedExchanges = []string{
+	"exchange/taskcluster-queue/v1/task-completed",
+	"exchange/taskcluster-queue/v1/task-failed",
+	"exchange/taskcluster-queue/v1/task-exception",
+}
+
+func (l *pulseListener) WaitForTask(taskID string) <-chan error {
+	done := make(chan error)
+
+	channel, err := l.conn.Channel()
+	if err != nil {
+		go func() { done <- err }()
+		return done
+	}
+
+	q, err := channel.QueueDeclare(
+		fmt.Sprintf("queue/%s/%s", l.username, slugid.Nice()), false, true, true, false, nil,
+	)
+	if err != nil {
+		go func() { done <- err }()
+		return done
+	}
+
+	for _, ex := range taskResolvedExchanges {
+		err = channel.QueueBind(q.Name, fmt.Sprintf("primary.%s.#", taskID), ex, false, nil)
+		if err != nil {
+			go func() { done <- err }()
+			return done
+		}
+	}
+
+	// require exclusive and autoAck because we don't care in this setting
+	messages, err := channel.Consume(q.Name, "", true, true, false, false, nil)
+	if err != nil {
+		go func() { done <- err }()
+		return done
+	}
+
+	errChan := make(chan *amqp.Error)
+	channel.NotifyClose(errChan)
+	go func() {
+		select {
+		case <-messages:
+			done <- nil
+		case e := <-errChan:
+			done <- e
+		}
+		channel.Close()
+		for range messages {
+			// Ignore messages
+		}
+	}()
+	return done
+}

--- a/worker/workertest/fakequeue/taskutils.go
+++ b/worker/workertest/fakequeue/taskutils.go
@@ -1,0 +1,219 @@
+package fakequeue
+
+import (
+	"encoding/json"
+	"reflect"
+	"time"
+
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/queue"
+)
+
+const (
+	statusUnscheduled = "unscheduled"
+	statusPending     = "pending"
+	statusRunning     = "running"
+	statusCompleted   = "completed"
+	statusFailed      = "failed"
+	statusException   = "exception"
+)
+
+// setTaskDefaults creates a TaskDefinitionResponse from a TaskDefinitionRequest
+// with defaults applies as taskcluster-queue would
+func setTaskDefaults(taskID string, task *queue.TaskDefinitionRequest) queue.TaskDefinitionResponse {
+	expires := task.Expires
+	if expires == (tcclient.Time{}) {
+		expires = tcclient.Time(time.Time(task.Created).Add(365 * 24 * 60 * 60 * time.Second))
+	}
+	extra := json.RawMessage(`{}`)
+	if task.Extra != nil {
+		extra = task.Extra
+	}
+	priority := "normal"
+	if task.Priority != "" {
+		priority = task.Priority
+	}
+	requires := "all-completed"
+	if task.Requires != "" {
+		requires = task.Requires
+	}
+	retries := 5
+	if task.Retries != 0 {
+		retries = task.Retries
+	}
+	schedulerID := "-"
+	if task.SchedulerID != "" {
+		schedulerID = task.SchedulerID
+	}
+	tags := json.RawMessage(`{}`)
+	if task.Tags != nil {
+		tags = task.Tags
+	}
+	taskGroupID := taskID
+	if task.TaskGroupID != "" {
+		taskGroupID = task.TaskGroupID
+	}
+	return queue.TaskDefinitionResponse{
+		Created:       task.Created,
+		Deadline:      task.Deadline,
+		Dependencies:  task.Dependencies,
+		Expires:       expires,
+		Extra:         extra,
+		Metadata:      task.Metadata,
+		Payload:       task.Payload,
+		Priority:      priority,
+		ProvisionerID: task.ProvisionerID,
+		Requires:      requires,
+		Retries:       retries,
+		Routes:        task.Routes,
+		SchedulerID:   schedulerID,
+		Scopes:        task.Scopes,
+		Tags:          tags,
+		TaskGroupID:   taskGroupID,
+		WorkerType:    task.WorkerType,
+	}
+}
+
+func isJSONEqual(val1, val2 interface{}) bool {
+	d1, _ := json.Marshal(val1)
+	d2, _ := json.Marshal(val2)
+	var v1, v2 interface{}
+	_ = json.Unmarshal(d1, &v1)
+	_ = json.Unmarshal(d2, &v2)
+	return reflect.DeepEqual(v1, v2)
+}
+
+// fakeCredentials as defined in queue.ClaimWorkResponse.Tasks[i].Credentials
+var fakeCredentials = struct {
+	AccessToken string `json:"accessToken"`
+	Certificate string `json:"certificate"`
+	ClientID    string `json:"clientId"`
+}{
+	ClientID:    "some-super-fake-client-for-use-in-responses",
+	AccessToken: "some-super-fake-secret-for-use-in-responses",
+}
+
+// reconcileTasks will reconcile task states, expiring claims, enforcing
+// deadlines, deleting expired tasks/artifacts, and scheduling unblocked tasks.
+func reconcileTasks(tasks map[string]*task) {
+	// Delete tasks with expires < now
+	for taskID, t := range tasks {
+		if time.Time(t.task.Expires).Before(time.Now()) {
+			debug("expiring taskId: %s", taskID)
+			delete(tasks, taskID)
+		}
+	}
+
+	// Delete artifacts with expires < now
+	for taskID, t := range tasks {
+		for runID, artifacts := range t.artifacts {
+			for name, artifact := range artifacts {
+				if artifact.Expires.Before(time.Now()) {
+					debug("expiring artifact for taskId: %s, runId: %d, name: %s", taskID, runID, name)
+					delete(artifacts, name)
+				}
+			}
+		}
+	}
+
+	// Resolve tasks with deadline < now
+	for taskID, t := range tasks {
+		// Skip resolved tasks
+		if t.status.State == statusCompleted ||
+			t.status.State == statusFailed ||
+			t.status.State == statusException {
+			continue
+		}
+		// Skip tasks with deadline > now
+		if !time.Time(t.status.Deadline).Before(time.Now()) {
+			continue
+		}
+
+		if t.status.State == statusUnscheduled {
+			// Add new resolved run
+			debug("deadline-exceeded in taskId: %s", t.status.TaskID)
+			t.status.Runs = append(t.status.Runs, run{
+				ReasonCreated:  "exception",
+				ReasonResolved: "deadline-exceeded",
+				Resolved:       tcclient.Time(time.Now()),
+				RunID:          0,
+				Scheduled:      tcclient.Time(time.Now()),
+				State:          statusException,
+			})
+			t.artifacts = append(t.artifacts, make(map[string]artifact))
+			t.status.State = statusException
+		} else {
+			// Resolve latest run
+			runID := len(t.status.Runs) - 1
+			debug("deadline-exceeded in taskId: %s, runId: %d", taskID, runID)
+			t.status.Runs[runID].State = statusException
+			t.status.Runs[runID].ReasonResolved = "deadline-exceeded"
+			t.status.Runs[runID].Resolved = tcclient.Time(time.Now())
+			t.status.State = statusException
+		}
+	}
+
+	// Resolve runs with takenUntil < now
+	for taskID, t := range tasks {
+		// Skip tasks not running
+		if t.status.State != statusRunning {
+			continue
+		}
+
+		// Skip tasks with takenUntil > now
+		runID := len(t.status.Runs) - 1
+		if !time.Time(t.status.Runs[runID].TakenUntil).Before(time.Now()) {
+			continue
+		}
+
+		// Resolve the run
+		debug("takenUntil expired for taskId: %s, runId: %d", taskID, runID)
+		t.status.Runs[runID].ReasonResolved = "claim-expired"
+		t.status.Runs[runID].Resolved = tcclient.Time(time.Now())
+		t.status.Runs[runID].State = statusException
+		t.status.State = statusException
+
+		// Add new run if we have retries left
+		if t.status.RetriesLeft > 0 {
+			t.status.RetriesLeft--
+			debug("scheduling a retry of taskId: %s", taskID)
+			t.status.Runs = append(t.status.Runs, run{
+				ReasonCreated: "retry",
+				RunID:         len(t.status.Runs),
+				Scheduled:     tcclient.Time(time.Now()),
+				State:         statusPending,
+			})
+			t.artifacts = append(t.artifacts, make(map[string]artifact))
+			t.status.State = statusPending
+		}
+	}
+
+	// Schedule all tasks whose dependencies have been resolved
+	for _, t := range tasks {
+		// Skip anything that's already scheduled
+		if t.status.State != statusUnscheduled {
+			continue
+		}
+
+		// Check if all dependencies is completed or resolved
+		isCompleted := true
+		isResolved := true
+		for _, dep := range t.task.Dependencies {
+			s := tasks[dep].status.State
+			isCompleted = isCompleted && s == statusCompleted
+			isResolved = isResolved && (s == statusCompleted || s == statusFailed || s == statusException)
+		}
+		if isCompleted || (t.task.Requires == "all-resolved" && isResolved) {
+			// Schedule task
+			debug("scheduling taskId: %s", t.status.TaskID)
+			t.status.State = statusPending
+			t.status.Runs = append(t.status.Runs, run{
+				ReasonCreated: "scheduled",
+				RunID:         len(t.status.Runs),
+				Scheduled:     tcclient.Time(time.Now()),
+				State:         statusPending,
+			})
+			t.artifacts = append(t.artifacts, make(map[string]artifact))
+		}
+	}
+}

--- a/worker/workertest/taskassertions.go
+++ b/worker/workertest/taskassertions.go
@@ -1,0 +1,128 @@
+package workertest
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	got "github.com/taskcluster/go-got"
+	"github.com/taskcluster/taskcluster-client-go/queue"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
+
+func verifyAssertions(t *testing.T, title, taskID string, task Task, q *queue.Queue) {
+	result, err := q.Status(taskID)
+	assert.NoError(t, err, "Failed to fetch task status for '%s'", title)
+	if err != nil {
+		return
+	}
+	runID := len(result.Status.Runs) - 1
+	debug("task: '%s' was resolved: %s, reason: %s in runId: %d",
+		title, result.Status.State, result.Status.Runs[runID].ReasonResolved, runID)
+
+	// Validate status assertions if we have one
+	if task.Status != nil {
+		task.Status(t, q, result.Status)
+	}
+
+	// check task resolution
+	if task.Exception == runtime.ReasonNoException {
+		if task.Success {
+			assert.Equal(t, "completed", result.Status.State, "Expected task completed")
+		} else {
+			assert.Equal(t, "failed", result.Status.State, "Expected task failed")
+		}
+	} else {
+		assert.Equal(t, "exception", result.Status.State, "Expected task exception")
+		assert.Equal(t, task.Exception.String(), result.Status.Runs[runID].ReasonResolved,
+			"Expected an exception with reason: %s", task.Exception.String())
+	}
+
+	// Create list of artifacts
+	var artifacts []Artifact
+	var continuationToken string
+	for {
+		r, err := q.ListArtifacts(taskID, strconv.Itoa(runID), continuationToken, "")
+		assert.NoError(t, err, "Failed to list artifacts")
+		if err != nil {
+			break
+		}
+
+		// Append artifacts
+		for _, a := range r.Artifacts {
+			debug("task: '%s' has artifact: %s", title, a.Name)
+			artifacts = append(artifacts, Artifact{
+				Name:        a.Name,
+				ContentType: a.ContentType,
+				StorageType: a.StorageType,
+				Expires:     time.Time(a.Expires),
+				Data:        nil,
+			})
+		}
+
+		// Break, if there is no continuationToken
+		continuationToken = r.ContinuationToken
+		if continuationToken == "" {
+			break
+		}
+	}
+
+	g := got.New()
+	util.Spawn(len(artifacts), func(j int) {
+		// Skip anything not s3 or azure
+		if artifacts[j].StorageType != "s3" && artifacts[j].StorageType != "azure" {
+			return
+		}
+		// Build signed URL
+		u, err := q.GetArtifact_SignedURL(taskID, strconv.Itoa(runID), artifacts[j].Name, 15*time.Minute)
+		assert.NoError(t, err, "Failed to create signed artifact URL, for: %s", artifacts[j].Name)
+		if err != nil {
+			return
+		}
+
+		// Get artifact
+		res, err := g.Get(u.String()).Send()
+		if err != nil {
+			assert.NoError(t, err, "Failed to get artifact, for: %s", artifacts[j].Name)
+			return
+		}
+		artifacts[j].ContentEncoding = res.Header.Get("Content-Encoding")
+		if artifacts[j].ContentEncoding == "gzip" {
+			r, err := gzip.NewReader(bytes.NewReader(res.Body))
+			assert.NoError(t, err, "Failed to create gzip decoder for: %s", artifacts[j].Name)
+			artifacts[j].Data, err = ioutil.ReadAll(r)
+			assert.NoError(t, err, "Failed to decode gzip for: %s", artifacts[j].Name)
+			err = r.Close()
+			assert.NoError(t, err, "Failed to close gzip decoder for: %s", artifacts[j].Name)
+		} else {
+			artifacts[j].Data = res.Body
+		}
+	})
+
+	// Validate artifacts
+	if task.Artifacts == nil {
+		assert.True(t, len(artifacts) == 0 || task.AllowAdditional,
+			"task produced artifacts, but no assertions given and AllowAdditional is false")
+	} else {
+		util.Spawn(len(artifacts), func(j int) {
+			a := artifacts[j]
+			assertion, ok := task.Artifacts[a.Name]
+			assert.True(t, ok || task.AllowAdditional, "Task produced artifact %s not allowed", a.Name)
+			if assertion != nil {
+				assertion(t, a)
+			}
+		})
+		for name := range task.Artifacts {
+			found := false
+			for _, a := range artifacts {
+				found = found || a.Name == name
+			}
+			assert.True(t, found, "Task did not produce expected artifact: %s", name)
+		}
+	}
+}

--- a/worker/workertest/workertest.go
+++ b/worker/workertest/workertest.go
@@ -1,0 +1,315 @@
+package workertest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/slugid-go/slugid"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/queue"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+	"github.com/taskcluster/taskcluster-worker/worker"
+	"github.com/taskcluster/taskcluster-worker/worker/workertest/fakequeue"
+)
+
+const defaultTestCaseTimeout = 10 * time.Minute
+
+// Case is a worker test case
+type Case struct {
+	Engine            string        // Engine to be used
+	EngineConfig      string        // Engine configuration as JSON
+	PluginConfig      string        // Configuration of plugins, see plugins.PluginManagerConfigSchema()
+	Tasks             []Task        // Tasks to create and associated assertions
+	Concurrency       int           // Worker concurrency, if zero defaulted to 1 and tasks will sequantially dependent
+	StoppedGracefully bool          // True, if worker is expected to stop gracefully
+	StoppedNow        bool          // True, if worker is expected to stop now
+	Timeout           time.Duration // Test timeout, defaults to 10 min
+}
+
+// A Task to be included in a worker test case
+type Task struct {
+	Title           string                  // Optional title (for debugging)
+	Payload         string                  // Task payload as JSON
+	Success         bool                    // True, if task should be successfully
+	Exception       runtime.ExceptionReason // Reason, if exception is expected
+	Artifacts       ArtifactAssertions      // Mapping from artifact name to assertion
+	AllowAdditional bool                    // True, if additional artifacts is allowed
+	Status          StatusAssertion         // Optional, custom assertion on status and queue
+}
+
+// A StatusAssertion is a function that can make an assertion on a task status
+type StatusAssertion func(t *testing.T, q *queue.Queue, status queue.TaskStatusStructure)
+
+// An ArtifactAssertions is a mapping from artifact name to assertion for the
+// artifact. If mapping to nil value, any artifact will be permitted.
+type ArtifactAssertions map[string]func(t *testing.T, a Artifact)
+
+// Artifact contains artifact meta-data.
+type Artifact struct {
+	ContentType     string
+	Expires         time.Time
+	Name            string
+	StorageType     string
+	Data            []byte
+	ContentEncoding string
+}
+
+// provisionerId/workerType for test cases, access granted by role:
+//   assume:project:taskcluster:worker-test-scopes
+var dummyProvisionerID = "test-dummy-provisioner"
+
+func dummyWorkerType() string {
+	return "dummy-worker-" + slugid.V4()[:9]
+}
+
+// TestWithFakeQueue runs integration tests against FakeQueue
+func (c Case) TestWithFakeQueue(t *testing.T) {
+	// Create FakeQueue
+	fq := fakequeue.New()
+	s := httptest.NewServer(fq)
+	defer s.Close()
+
+	// Create listener
+	l := fakequeue.NewFakeQueueListener(fq)
+
+	// Create queue client
+	q := queue.New(&tcclient.Credentials{
+		// Long enough to pass schema validation
+		ClientID:    "dummy-test-client-id",
+		AccessToken: "non-secret-dummy-test-access-token",
+	})
+	q.BaseURL = s.URL
+
+	c.testWithQueue(t, q, l)
+}
+
+// TestWithRealQueue runs integration tests against production queue
+func (c Case) TestWithRealQueue(t *testing.T) {
+	u := os.Getenv("PULSE_USERNAME")
+	p := os.Getenv("PULSE_PASSWORD")
+	if u == "" || p == "" {
+		t.Skip("Skipping integration tests, because PULSE_USERNAME and PULSE_PASSWORD are not specified")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	// Create listener
+	l, err := fakequeue.NewPulseListener(u, p)
+	require.NoError(t, err, "Failed to create PulseListener")
+
+	// Create queue client
+	q := queue.New(&tcclient.Credentials{
+		ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
+		AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
+		Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
+	})
+	if os.Getenv("QUEUE_BASE_URL") != "" {
+		q.BaseURL = os.Getenv("QUEUE_BASE_URL")
+	}
+
+	c.testWithQueue(t, q, l)
+}
+
+// Test runs the test case
+func (c Case) Test(t *testing.T) {
+	passedFake := t.Run("FakeQueue", c.TestWithFakeQueue)
+	// We don't run real integration tests if the FakeQueue tests fails
+	// This is aimed to avoid polluting the queue and reducing feedback cycle.
+	// You can manually call TestWithRealQueue(t), if you want to debug it.
+	if passedFake {
+		t.Run("RealQueue", c.TestWithRealQueue)
+	} else {
+		t.Run("RealQueue", func(t *testing.T) {
+			t.Skip("Skipping integration tests, because FakeQueue tests failed")
+		})
+	}
+}
+
+func mustUnmarshalJSON(data string) interface{} {
+	var v interface{}
+	err := json.Unmarshal([]byte(data), &v)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse JSON, error: %s, json: '%s'", err, data))
+	}
+	return v
+}
+
+func (c Case) testWithQueue(t *testing.T, q *queue.Queue, l fakequeue.Listener) {
+	// Create config
+	tempFolder := path.Join(os.TempDir(), slugid.Nice())
+	defer os.RemoveAll(tempFolder)
+	concurrency := c.Concurrency
+	if concurrency == 0 {
+		concurrency = 1
+	}
+	creds := map[string]interface{}{
+		"clientId":    q.Credentials.ClientID,
+		"accessToken": q.Credentials.AccessToken,
+	}
+	if q.Credentials.Certificate != "" {
+		creds["certificate"] = q.Credentials.Certificate
+	}
+	workerID := "dummy-worker-" + slugid.V4()[:9]
+	workerType := dummyWorkerType()
+	config := map[string]interface{}{
+		"credentials": creds,
+		"engine":      c.Engine,
+		"engines": map[string]interface{}{
+			c.Engine: mustUnmarshalJSON(c.EngineConfig),
+		},
+		"minimumDiskSpace": 0,
+		"minimumMemory":    0,
+		"monitor":          mustUnmarshalJSON(`{"panicOnError": false, "type": "mock"}`),
+		"plugins":          mustUnmarshalJSON(c.PluginConfig),
+		"queueBaseUrl":     q.BaseURL,
+		"temporaryFolder":  tempFolder,
+		"webHookServer":    mustUnmarshalJSON(`{"provider": "localhost"}`),
+		"worker": map[string]interface{}{
+			"concurrency":         concurrency,
+			"minimumReclaimDelay": 30,
+			"pollingInterval":     1,
+			"reclaimOffset":       30,
+			"workerGroup":         "test-dummy-workers",
+			"workerId":            workerID,
+			"provisionerId":       dummyProvisionerID,
+			"workerType":          workerType,
+		},
+	}
+	err := worker.ConfigSchema().Validate(config)
+	require.NoError(t, err, "Failed to validate worker config against schema")
+
+	// Create worker
+	w, err := worker.New(config)
+	require.NoError(t, err, "Failed to create worker")
+
+	// Create taskIDs
+	taskIDs := make([]string, len(c.Tasks))
+	for i := range taskIDs {
+		taskIDs[i] = slugid.Nice()
+	}
+
+	// Setup event listeners
+	events := make([]<-chan error, len(c.Tasks))
+	util.Spawn(len(c.Tasks), func(i int) {
+		events[i] = l.WaitForTask(taskIDs[i])
+	})
+
+	// Wait for tasks to be resolved
+	var tasksResolved atomics.Once
+	go tasksResolved.Do(func() {
+		// Wait for events
+		debug("Waiting for tasks to be resolved")
+		util.Spawn(len(c.Tasks), func(i int) {
+			err := <-events[i]
+			assert.NoError(t, err, "Failed to listen for task %d", i)
+			debug("Finished waiting for %s", taskIDs[i])
+			if err != nil {
+				debug("Error '%s' waiting for %s", taskIDs[i], err)
+			}
+		})
+	})
+
+	// Create tasks
+	for i, task := range c.Tasks {
+		tdef := queue.TaskDefinitionRequest{
+			ProvisionerID: dummyProvisionerID,
+			WorkerType:    workerType,
+			Created:       tcclient.Time(time.Now()),
+			Deadline:      tcclient.Time(time.Now().Add(60 * time.Minute)),
+			Expires:       tcclient.Time(time.Now().Add(31 * 24 * 60 * time.Minute)),
+			Payload:       json.RawMessage(task.Payload),
+		}
+		// If tasks are to run sequantially, we'll make them dependent
+		if c.Concurrency == 0 && i > 0 {
+			tdef.Dependencies = []string{taskIDs[i-1]}
+			tdef.Requires = "all-resolved"
+		}
+		title := task.Title
+		if title == "" {
+			title = fmt.Sprintf("Task %d", i)
+		}
+		tdef.Metadata.Name = title
+		tdef.Metadata.Description = "Task from taskcluster-worker integration tests"
+		tdef.Metadata.Source = "https://github.com/taskcluster/taskcluster-worker/tree/master/worker/workertest/workertest.go"
+		tdef.Metadata.Owner = "jonasfj@mozilla.com"
+		debug("creating task '%s' as taskId: %s", title, taskIDs[i])
+		_, err := q.CreateTask(taskIDs[i], &tdef)
+		require.NoError(t, err, "Failed to create task: %s", title)
+	}
+
+	// Start worker
+	var serr error
+	var stopped atomics.Once
+	go stopped.Do(func() {
+		debug("starting worker with workerType: %s and workerID: %s", workerType, workerID)
+		serr = w.Start()
+		debug("worker stopped")
+	})
+
+	// Wait for events to have been handled
+	timeout := c.Timeout
+	if timeout == 0 {
+		timeout = defaultTestCaseTimeout
+	}
+	select {
+	case <-tasksResolved.Done():
+	case <-time.After(timeout):
+		assert.Fail(t, "Test case timed out, see workertest.Case.Timeout Property!")
+		debug("worker.StopNow() because of test case timeout")
+		w.StopNow()
+		// We give it 30s to stop now, otherwise we end the test-case
+		select {
+		case <-stopped.Done():
+		case <-time.After(30 * time.Second):
+			debug("worker.StopNow() didn't stop after 30s")
+		}
+		return
+	}
+
+	// if we expect the worker to stop then we don't want to stop it here
+	if !c.StoppedGracefully && !c.StoppedNow {
+		// Stop worker
+		debug("gracefully stopping worker (since test-case isn't stopping the worker)")
+		w.StopGracefully()
+	}
+
+	// Wait for the worker to stop
+	select {
+	case <-stopped.Done():
+	case <-time.After(30 * time.Second):
+		assert.Fail(t, "Expected worker to stop")
+	}
+
+	// Verify assertions
+	// We must do this after the worker has stopped, since tasks resolved
+	// with exception can have artifacts added after resolution.
+	debug("Verifying task assertions")
+	// We could run these in parallel, but debugging is easier if we don't...
+	for i, task := range c.Tasks {
+		title := task.Title
+		if title == "" {
+			title = fmt.Sprintf("Task %d", i)
+		}
+		t.Run(title, func(t *testing.T) {
+			verifyAssertions(t, title, taskIDs[i], task, q)
+		})
+	}
+
+	// Check the stopping condition
+	if c.StoppedNow {
+		assert.Exactly(t, worker.ErrWorkerStoppedNow, serr, "Expected StoppedNow!")
+	} else {
+		assert.NoError(t, serr, "Expected worker to stop gracefully")
+	}
+}

--- a/worker/workertest/workertest_test.go
+++ b/worker/workertest/workertest_test.go
@@ -1,0 +1,120 @@
+package workertest
+
+import (
+	"testing"
+
+	"github.com/taskcluster/taskcluster-worker/runtime"
+
+	_ "github.com/taskcluster/taskcluster-worker/engines/mock"
+	_ "github.com/taskcluster/taskcluster-worker/plugins/env"
+	_ "github.com/taskcluster/taskcluster-worker/plugins/livelog"
+	_ "github.com/taskcluster/taskcluster-worker/plugins/success"
+)
+
+func TestWorkerTest(t *testing.T) {
+	Case{
+		Engine:       "mock",
+		Concurrency:  2,
+		EngineConfig: `{}`,
+		PluginConfig: `{
+      "disabled": [],
+      "success": {}
+    }`,
+		Tasks: []Task{
+			{
+				Title:   "Task Success",
+				Success: true,
+				Payload: `{
+          "delay": 50,
+          "function": "true",
+          "argument": ""
+        }`,
+			}, {
+				Title:   "Task Failure",
+				Success: false,
+				Payload: `{
+					"delay": 50,
+					"function": "false",
+					"argument": ""
+				}`,
+			},
+		},
+	}.Test(t)
+}
+
+func TestWorkerWithEnv(t *testing.T) {
+	Case{
+		Engine:       "mock",
+		Concurrency:  1,
+		EngineConfig: `{}`,
+		PluginConfig: `{
+      "disabled": [],
+      "env": {
+        "extra": {
+          "STATIC_ENV_VAR": "static-value"
+        }
+      },
+      "livelog": {},
+      "success": {}
+    }`,
+		Tasks: []Task{
+			{
+				Title:   "Print Task Env Var",
+				Success: true,
+				Payload: `{
+          "delay": 50,
+          "function": "print-env-var",
+          "argument": "HELLO_WORLD",
+          "env": {
+            "HELLO_WORLD": "hello-world"
+          }
+        }`,
+				Artifacts: ArtifactAssertions{
+					"public/logs/live_backing.log": GrepArtifact("hello-world"),
+					"public/logs/live.log":         AnyArtifact(),
+				},
+			}, {
+				Title:   "Print Static Env Var",
+				Success: true,
+				Payload: `{
+          "delay": 50,
+          "function": "print-env-var",
+          "argument": "STATIC_ENV_VAR"
+        }`,
+				Artifacts: ArtifactAssertions{
+					"public/logs/live_backing.log": GrepArtifact("static-value"),
+					"public/logs/live.log":         AnyArtifact(),
+				},
+			},
+		},
+	}.Test(t)
+}
+
+func TestWorkerMalformedPayload(t *testing.T) {
+	// This is a special test case, because the task.payload doesn't match the
+	// schema. Hence, we can declare malformed-payload before running anything.
+	// However, we still want to PluginManager.NewTaskPlugins to run and create
+	// a livelog TaskPlugin, otherwise no log with an explanation of the schema
+	// error won't be uploaded.
+	Case{
+		Engine:       "mock",
+		Concurrency:  2,
+		EngineConfig: `{}`,
+		PluginConfig: `{
+      "disabled": [],
+      "success": {},
+			"livelog": {}
+    }`,
+		Tasks: []Task{
+			{
+				Title:     "Task Malformed Payload",
+				Exception: runtime.ReasonMalformedPayload,
+				Payload:   `{}`, // Should never create a SandboxBuilder
+				Artifacts: ArtifactAssertions{
+					"public/logs/live_backing.log": GrepArtifact("malformed-payload"),
+				},
+				AllowAdditional: true,
+			},
+		},
+	}.Test(t)
+}


### PR DESCRIPTION
@petemoore, this should be a bit nicer than previous PR...
I've split it into reasonable commits...
First commit is a bit of bug fixes and refactoring to fix some issues. It all got intermingled and interdependent.. Tests covering some of these cases will appear later, probably in a different PR.

The `FakeQueue` commit contains the majority of the changes... Feel free to skim through it, but it's not super important the tests are design to run again **both** the _fake queue_ and the _real queue_. So if we have bugs of significance we'll probably find out when testing against the real thing.

The most important thing to review is the _integration testing_ framework. I've tried to make it as declarative as possible. Meaning you define:
 * engine and engine config,
 * plugin configuration
 * tasks
 * assertions for the tasks
   * success and exception reason if not `NoException` (default)
   * Artifacts expected, and conditions on these artifacts
   * whether additional artifacts are allowed
 * If worker is expected to StopNow or StopGracefully on it's own
 * Concurrency, with the trick that concurrency == 0 means tasks will have `task.dependencies` defined such that run in the order given... This is cool if we want to test caches, etc...

Finally, it's possible to write custom assertions... All the assertions are basically functions on the form `func(t *testing.T, ....)`. I don't imagine we'll use that a lot. I'm thinking we'll have functions like `GrepArtifact(substring)` that returns an assertion (a function) that checks that the artifact contains the given substring.

All this is aimed to let us write super high-level integration, where all we have to do is define our input and expected output, and the test framework will run the tests against both fake queue and real queue :)