### PR TITLE
Abstractions to let plugins and engines export end-user documentation

### DIFF
--- a/engines/engine.go
+++ b/engines/engine.go
@@ -40,6 +40,12 @@ type SandboxOptions struct {
 // can be implemented on all platforms. See individual methods to see which are
 // required and which can be implemented by returning ErrFeatureNotSupported.
 type Engine interface {
+	// Documentation returns a list of sections with end-user documentation.
+	//
+	// These sections will be combined with documentation sections from all
+	// enabled plugins in-order to form end-user documentation.
+	Documentation() []runtime.Section
+
 	// PayloadSchema returns a JSON schema description of the payload options,
 	// accepted by this engine.
 	PayloadSchema() schematypes.Object
@@ -129,6 +135,11 @@ type Capabilities struct {
 // Implementors of Engine should embed this struct to ensure source
 // compatibility when we add more optional methods to Engine.
 type EngineBase struct{}
+
+// Documentation returns no documentation.
+func (EngineBase) Documentation() []runtime.Section {
+	return nil
+}
 
 // PayloadSchema returns an empty schematypes.Object indicating no contraints
 // on keys of the payload object.

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -30,6 +30,12 @@ type TaskPluginOptions struct {
 //
 // All methods on this interface must be thread-safe.
 type Plugin interface {
+	// Documentation returns a list of sections with end-user documentation.
+	//
+	// These sections will be combined with documentation sections from all
+	// enabled plugins in-order to form end-user documentation.
+	Documentation() []runtime.Section
+
 	// PayloadSchema returns a schematypes.Object with the properties for
 	// for the TaskPluginOptions.Payload property.
 	//
@@ -173,6 +179,11 @@ type TaskPlugin interface {
 // Implementors should embed this to ensure forward compatibility when we add
 // new optional methods.
 type PluginBase struct{}
+
+// Documentation returns no documentation.
+func (PluginBase) Documentation() []runtime.Section {
+	return nil
+}
 
 // PayloadSchema returns a schema for an empty object for plugins that doesn't
 // take any payload.

--- a/runtime/docs.go
+++ b/runtime/docs.go
@@ -1,0 +1,27 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+)
+
+// A Section represents a section of markdown documentation.
+type Section struct {
+	Title   string // Title of section rendered as headline level 2
+	Content string // Section contents, maybe contains headline level 3 and higher
+}
+
+// RenderDocument creates a markdown document with given title from a list of
+// sections. Ordering sections alphabetically.
+func RenderDocument(title string, sections []Section) string {
+	sections = append([]Section{}, sections...)
+	sort.Slice(sections, func(i int, j int) bool {
+		return sections[i].Title < sections[j].Title
+	})
+
+	docs := fmt.Sprintf("# %s\n", title)
+	for _, section := range sections {
+		docs += fmt.Sprintf("\n\n## %s\n%s\n", section.Title, section.Content)
+	}
+	return docs
+}


### PR DESCRIPTION
The idea is that each plugin/engine will expose:
 * A list of markdown sections `{title, content}`
 * A payload schema object

Once combined we get:
 * A single payload schema
 * A single markdown document consisting of a list of sections...

Example:
 * Artifact plugin describes how to extra artifacts, for example it states that if an artifact is missing the task will fail.
 * The native engine describes how the execute environment looks, what form paths are on, and what they are relative to...

This won't end up as complete examples... But it will give fairly feature complete reference style documentation for workerTypes... I suspect we'll manually write some example for most common tc-worker configurations. Maybe we have a plugin that allows for injecting markdown documentation from the configuration file...

----
I haven't figured out exactly where this documentation will be shipped, probably to the queue along with payload schema... The motivation for defining the abstractions for extracting it is that we can start writing docs... And we can write tests that covers the things we document :)