### PR TITLE
Moved schemas to use util.Markdown to make descriptions easier to wri…

### DIFF
--- a/engines/native/config.go
+++ b/engines/native/config.go
@@ -1,6 +1,9 @@
 package nativeengine
 
-import schematypes "github.com/taskcluster/go-schematypes"
+import (
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
 
 type config struct {
 	Groups     []string `json:"groups,omitempty"`
@@ -10,16 +13,20 @@ type config struct {
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "Native Engine Config",
-		Description: "Configuration for the native engine, this engines creates " +
-			"a system user-account per task, and deletes user-account when task " +
-			"is completed.",
+		Description: util.Markdown(`
+			Configuration for the native engine, this engines creates
+			a system user-account per task, and deletes user-account when task
+			is completed.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"groups": schematypes.Array{
 			MetaData: schematypes.MetaData{
 				Title: "Group Memberships",
-				Description: "List of system user-groups that the temporary " +
-					"task-users should be be granted membership of.",
+				Description: util.Markdown(`
+					List of system user-groups that the temporary
+					task-users should be be granted membership of.
+				`),
 			},
 			Items: schematypes.String{
 				MetaData: schematypes.MetaData{
@@ -31,10 +38,15 @@ var configSchema = schematypes.Object{
 		},
 		"createUser": schematypes.Boolean{
 			MetaData: schematypes.MetaData{
-				Title: "Tells if a user should be created to run a command",
-				Description: `When set to true, a new user is created on the fly to run
-				the command. It runs the command from whitin the user's home directory.
-				If false, the command runs without changing userid`,
+				Title: "Create User per Task",
+				Description: util.Markdown(`
+					Tells if a system user should be created to run a command.
+
+					When set to 'true', a new user is created on-the-fly to run each task.
+					It runs the command from within the user's home directory.
+					If 'false', the command runs without changing userid, hence, tasks
+					will run with the same user as the worker does.
+				`),
 			},
 		},
 	},

--- a/engines/native/payload.go
+++ b/engines/native/payload.go
@@ -1,6 +1,9 @@
 package nativeengine
 
-import schematypes "github.com/taskcluster/go-schematypes"
+import (
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
 
 type payload struct {
 	Command []string `json:"command"`
@@ -19,8 +22,10 @@ var payloadSchema = schematypes.Object{
 		"context": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Task Context",
-				Description: "Optional URL for a gzipped tar-ball to downloaded " +
-					"and extracted in the HOME directory for running the command.",
+				Description: util.Markdown(`
+					Optional URL for a gzipped tar-ball to downloaded
+					and extracted in the 'HOME' directory for running the command.
+				`),
 			},
 		},
 	},

--- a/engines/qemu/engine.go
+++ b/engines/qemu/engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/engines/qemu/network"
 	"github.com/taskcluster/taskcluster-worker/engines/qemu/vm"
 	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type engine struct {
@@ -42,15 +43,19 @@ var configSchema = schematypes.Object{
 		"imageFolder": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Image Folder",
-				Description: `Path to folder to be used for image storage and cache.
-											Please ensure this has lots of space.`,
+				Description: util.Markdown(`
+					Path to folder to be used for image storage and cache.
+					Please ensure this has lots of space.
+				`),
 			},
 		},
 		"socketFolder": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Socket Folder",
-				Description: `Path to folder to be used for internal unix-domain sockets.
-											Ideally, this shouldn't be readable by anyone else.`,
+				Description: util.Markdown(`
+					Path to folder to be used for internal unix-domain sockets.
+					Ideally, this shouldn't be readable by anyone else.
+				`),
 			},
 		},
 		"machineOptions": vm.MachineOptionsSchema,
@@ -113,10 +118,12 @@ var payloadSchema = schematypes.Object{
 		"image": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Image to download",
-				Description: "URL to an image file. This is a zstd compressed " +
-					"tar-archive containing a raw disk image `disk.img`, a qcow2 " +
-					"overlay `layer.qcow2` and a machine definition file " +
-					"`machine.json`. Refer to engine documentation for more details.",
+				Description: util.Markdown(`
+					URL to an image file. This is a zstd compressed
+					tar-archive containing a raw disk image 'disk.img', a qcow2
+					overlay 'layer.qcow2' and a machine definition file
+					'machine.json'. Refer to engine documentation for more details.
+				`),
 			},
 		},
 		"command": schematypes.Array{

--- a/plugins/artifacts/payloadschema.go
+++ b/plugins/artifacts/payloadschema.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type payloadType struct {
@@ -28,9 +29,11 @@ var payloadSchema = schematypes.Object{
 					"type": schematypes.StringEnum{
 						MetaData: schematypes.MetaData{
 							Title: "Upload type",
-							Description: "Artifacts can be either an individual `file` or " +
-								"a `directory` containing potentially multiple files with " +
-								"recursively included subdirectories",
+							Description: util.Markdown(`
+								Artifacts can be either an individual 'file' or a 'directory'
+								containing potentially multiple files with recursively included
+								subdirectories
+							`),
 						},
 						Options: []string{"file", "directory"},
 					},
@@ -44,11 +47,12 @@ var payloadSchema = schematypes.Object{
 					"name": schematypes.String{
 						MetaData: schematypes.MetaData{
 							Title: "Artifact Name",
-							Description: "" +
-								"This will be the leading path to directories and the full name\n" +
-								"for files that are uploaded to s3. It must not begin or end\n" +
-								"with '/' and must only contain printable ascii characters\n" +
-								"otherwise.",
+							Description: util.Markdown(`
+								This will be the leading path to directories and the full name
+								for files that are uploaded to s3. It must not begin or end
+								with '/' and must only contain printable ascii characters
+								otherwise.
+							`),
 						},
 						Pattern: `^([\x20-\x2e\x30-\x7e][\x20-\x7e]*)[\x20-\x2e\x30-\x7e]$`,
 					},

--- a/plugins/interactive/config.go
+++ b/plugins/interactive/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type config struct {
@@ -19,16 +20,20 @@ type config struct {
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "Interactive Plugin",
-		Description: `Configuration for the 'interactive' plugin that allows user
-      to configure tasks that expose an interactive shell or noVNC sessions.`,
+		Description: util.Markdown(`
+			Configuration for the 'interactive' plugin that allows user
+			to configure tasks that expose an interactive shell or noVNC sessions.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"artifactPrefix": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Artifact Prefix",
-				Description: "Prefix that the `sockets.json`, `display.html` and " +
-					"`shell.html` should be created under. Defaults to " +
-					fmt.Sprintf("`%s`.", defaultArtifactPrefix),
+				Description: util.Markdown(`
+					Prefix that the 'sockets.json', 'display.html' and 'shell.html'
+					should be created under. Defaults to
+					` + fmt.Sprintf("'%s'", defaultArtifactPrefix) + `.
+				`),
 			},
 			Pattern:       `^[\x20-.0-\x7e][\x20-\x7e]*/$`,
 			MaximumLength: 255,
@@ -36,8 +41,10 @@ var configSchema = schematypes.Object{
 		"forbidCustomArtifactPrefix": schematypes.Boolean{
 			MetaData: schematypes.MetaData{
 				Title: "Forbid Custom ArtifactPrefix",
-				Description: "Prevent tasks from specifying a custom `artifactPrefix`" +
-					" , by default tasks are allowed to overwrite the global setting.",
+				Description: util.Markdown(`
+					Prevent tasks from specifying a custom 'artifactPrefix', by default
+					tasks are allowed to overwrite the global setting.
+				`),
 			},
 		},
 		"alwaysEnabled": schematypes.Boolean{
@@ -61,18 +68,22 @@ var configSchema = schematypes.Object{
 		"shellToolUrl": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Shell Tool URL",
-				Description: `URL to a tool that can take shell socket URL and display
+				Description: util.Markdown(`
+					URL to a tool that can take shell socket URL and display
 					an interactive shell session. The URL will be given the querystring
-					options: 'v=2', 'socketUrl', 'taskId', 'runId'.`,
+					options: 'v=2', 'socketUrl', 'taskId', 'runId'.
+				`),
 			},
 		},
 		"displayToolUrl": schematypes.URI{
 			MetaData: schematypes.MetaData{
 				Title: "Display Tool URL",
-				Description: `URL to a tool that can take display socket, list
+				Description: util.Markdown(`
+					URL to a tool that can take display socket, list
 					displays and render noVNC session. The URL will be given the
 					querystring options: 'v=1', 'socketUrl', 'displaysUrl', 'taskId' and
-					'runId'.`,
+					'runId'.
+				`),
 			},
 		},
 	},

--- a/plugins/interactive/interactive.go
+++ b/plugins/interactive/interactive.go
@@ -13,6 +13,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 // defaultArtifactPrefix is the default artifact prefix used if nothing is
@@ -63,23 +64,29 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 	s := schematypes.Object{
 		MetaData: schematypes.MetaData{
 			Title: "Interactive Features",
-			Description: `Settings for interactive features, all options are optional,
+			Description: util.Markdown(`
+				Settings for interactive features, all options are optional,
 				an empty object can be used to enable the interactive features with
-				default options.`,
+				default options.
+			`),
 		},
 		Properties: schematypes.Properties{
 			"disableDisplay": schematypes.Boolean{
 				MetaData: schematypes.MetaData{
 					Title: "Disable Display",
-					Description: "Disable the interactive display, defaults to enabled if " +
-						"any options is given for `interactive`, even an empty object.",
+					Description: util.Markdown(`
+						Disable the interactive display, defaults to enabled if any options
+						is given for 'interactive', even an empty object.
+					`),
 				},
 			},
 			"disableShell": schematypes.Boolean{
 				MetaData: schematypes.MetaData{
 					Title: "Disable Shell",
-					Description: "Disable the interactive shell, defaults to enabled if " +
-						"any options is given for `interactive`, even an empty object.",
+					Description: util.Markdown(`
+						Disable the interactive shell, defaults to enabled if any options
+						is given for 'interactive', even an empty object.
+					`),
 				},
 			},
 		},
@@ -88,10 +95,12 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 		s.Properties["artifactPrefix"] = schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Artifact Prefix",
-				Description: "Prefix for the interactive artifacts will be used to " +
-					"create `<prefix>/shell.html`, `<prefix>/display.html` and " +
-					"`<prefix>/sockets.json`. The prefix defaults to `" +
-					p.config.ArtifactPrefix + "`",
+				Description: util.Markdown(`
+					Prefix for the interactive artifacts will be used to create
+					'<prefix>/shell.html', '<prefix>/display.html' and
+					'<prefix>/sockets.json'. The prefix defaults to
+					'` + p.config.ArtifactPrefix + `'.
+				`),
 			},
 			Pattern:       `^[\x20-.0-\x7e][\x20-\x7e]*/$`,
 			MaximumLength: 255,

--- a/plugins/maxruntime/config.go
+++ b/plugins/maxruntime/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type config struct {
@@ -20,7 +21,7 @@ const (
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "`maxRunTime` Plugin",
-		Description: `
+		Description: util.Markdown(`
 			The maximum runtime plugin kills tasks that have a runtime exceeding the
 			'maxRunTime' specified. This means it kills the sandbox and any interactive
 			shells and display. Once killed the task will be resolved as failed.
@@ -32,26 +33,26 @@ var configSchema = schematypes.Object{
 			A 'maxRunTime' limit is given in the plugin configuration, and the
 			'perTaskLimit' option can be used to allow or require tasks to specify a
 			shorter 'maxRunTime'.
-		`,
+		`),
 	},
 	Properties: schematypes.Properties{
 		"maxRunTime": schematypes.Duration{
 			MetaData: schematypes.MetaData{
 				Title: "Maximum Task Run-Time",
-				Description: `
+				Description: util.Markdown(`
 					Maximum execution time before a task is killed, does not include
 					artifact upload or image download time, etc.
-				`,
+				`),
 			},
 		},
 		"perTaskLimit": schematypes.StringEnum{
 			MetaData: schematypes.MetaData{
 				Title: "Per Task Limits",
-				Description: `
+				Description: util.Markdown(`
 					This plugin can 'forbid', 'allow' or 'require' tasks to specify
 					'task.payload.maxRunTime', which if present must be less than
 					'maxRunTime' as configured at plugin level.
-				`,
+				`),
 			},
 			Options: []string{
 				limitRequire,

--- a/plugins/maxruntime/maxruntime.go
+++ b/plugins/maxruntime/maxruntime.go
@@ -8,6 +8,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	"github.com/taskcluster/taskcluster-worker/runtime"
 	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type provider struct {
@@ -56,7 +57,7 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 			"maxRunTime": schematypes.Duration{
 				MetaData: schematypes.MetaData{
 					Title: "Maximum Task Run-Time",
-					Description: `
+					Description: util.Markdown(`
 						The maximum task run-time before the task is **killed** and resolved
 						as _failed_. Specified as an integer in seconds, or as string on
 						the form: '1 day 2 hours 3 minutes'.
@@ -66,7 +67,7 @@ func (p *plugin) PayloadSchema() schematypes.Object {
 
 						For this worker-type the 'maxRunTime' may not exceed:
 						'` + p.MaxRunTime.String() + `'.
-					`,
+					`),
 				},
 			},
 		}

--- a/plugins/watchdog/config.go
+++ b/plugins/watchdog/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 type config struct {
@@ -14,33 +15,33 @@ type config struct {
 var configSchema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "Watchdog Plugin",
-		Description: `
-      The watchdog plugin resets a timer whenever the worker is reported as
-      idle or processes a step in a task. This ensure that the task-processing
-      loop remains alive. If the timeout is exceeded, the watchdog will report
-      to sentry and shutdown the worker immediately.
+		Description: util.Markdown(`
+			The watchdog plugin resets a timer whenever the worker is reported as
+			idle or processes a step in a task. This ensure that the task-processing
+			loop remains alive. If the timeout is exceeded, the watchdog will report
+			to sentry and shutdown the worker immediately.
 
-      This plugin is mainly useful to avoid stale workers cut in some livelock.
-      Note: This plugin won't cause a timeout between Started() and
-      Stopped(), as this would limit task run time, for this purpose use the
-      'maxruntime' plugin.
-    `,
+			This plugin is mainly useful to avoid stale workers cut in some livelock.
+			Note: This plugin won't cause a timeout between 'Started()' and
+			'Stopped()', as this would limit task run time, for this purpose use the
+			'maxruntime' plugin.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"timeout": schematypes.Duration{
 			MetaData: schematypes.MetaData{
 				Title: "Watchdog Timeout",
-				Description: `
-          Timeout after which to kill the worker, timeout is reset whenever a
-          task progresses, worker is reported idle or task is between Started()
-          and Stopped().
+				Description: util.Markdown(`
+					Timeout after which to kill the worker, timeout is reset whenever a
+					task progresses, worker is reported idle or task is between
+					'Started()' and 'Stopped()'.
 
-          Defaults to ` + strconv.Itoa(defaultTimeout) + ` minutes, if not
-          specified (or zero).
+					Defaults to ` + strconv.Itoa(defaultTimeout) + ` minutes, if not
+					specified (or zero).
 
-          This property is specified in seconds as integer or as string on the
-          form '1 day 2 hours 3 minutes'.
-        `,
+					This property is specified in seconds as integer or as string on the
+					form '1 day 2 hours 3 minutes'.
+				`),
 			},
 			AllowNegative: false,
 		},

--- a/runtime/webhookserver/config.go
+++ b/runtime/webhookserver/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
 var localhostConfigSchema = schematypes.Object{
@@ -32,12 +33,18 @@ var statelessDNSConfigSchema = schematypes.Object{
 		},
 		"networkInterface": schematypes.String{
 			MetaData: schematypes.MetaData{
-				Description: "Network device webhookserver should listen on. If not supplied, it binds to the interface from serverIp address",
+				Description: util.Markdown(`
+					Network device webhookserver should listen on. If not supplied, it
+					binds to the interface from 'serverIp' address
+				`),
 			},
 		},
 		"exposedPort": schematypes.Integer{
 			MetaData: schematypes.MetaData{
-				Description: "Port webhookserver should listen on. If not supplied, it uses the serverPort value.",
+				Description: util.Markdown(`
+					Port webhookserver should listen on. If not supplied, it uses the
+					'serverPort' value.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 65535,
@@ -48,8 +55,11 @@ var statelessDNSConfigSchema = schematypes.Object{
 		"statelessDNSDomain": schematypes.String{},
 		"maxLifeCycle": schematypes.Integer{
 			MetaData: schematypes.MetaData{
-				Title:       "Maximum lifetime of the worker in seconds",
-				Description: "Used to limit the time period for which the DNS server will return an IP for the given worker hostname",
+				Title: "Maximum lifetime of the worker in seconds",
+				Description: util.Markdown(`
+					Used to limit the time period for which the DNS server will return
+					an IP for the given worker hostname.
+				`),
 			},
 			Minimum: 5 * 60,
 			Maximum: 31 * 24 * 60 * 60,

--- a/worker/config.go
+++ b/worker/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/plugins"
 	"github.com/taskcluster/taskcluster-worker/runtime/monitoring"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
 	"github.com/taskcluster/taskcluster-worker/runtime/webhookserver"
 )
 
@@ -47,42 +48,50 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 		"provisionerId": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "ProvisionerId",
-				Description: `ProvisionerId for workerType that tasks should be claimed
-				from. Note, a 'workerType' is only unique given the 'provisionerId'.`,
+				Description: util.Markdown(`
+					ProvisionerId for workerType that tasks should be claimed
+					from. Note, a 'workerType' is only unique given the 'provisionerId'.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"workerType": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "WorkerType",
-				Description: `WorkerType to claim tasks for, combined with
-				'provisionerId' this identifies the pool of workers the machine
-				belongs to.`,
+				Description: util.Markdown(`
+					WorkerType to claim tasks for, combined with 'provisionerId' this
+					identifies the pool of workers the machine belongs to.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"workerGroup": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "WorkerGroup",
-				Description: `Group of workers this machine belongs to. This is any
-				identifier such that workerGroup and workerId uniquely identifies this
-				machine.`,
+				Description: util.Markdown(`
+					Group of workers this machine belongs to. This is any identifier such
+					that workerGroup and workerId uniquely identifies this machine.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"workerId": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "WorkerId",
-				Description: `Identifier for this machine. This is any identifier such
-				that workerGroup and workerId uniquely identifies this machine.`,
+				Description: util.Markdown(`
+					Identifier for this machine. This is any identifier such
+					that workerGroup and workerId uniquely identifies this machine.
+				`),
 			},
 			Pattern: `^[a-zA-Z0-9_-]{1,22}$`,
 		},
 		"pollingInterval": schematypes.Integer{
 			MetaData: schematypes.MetaData{
 				Title: "Task Polling Interval",
-				Description: `The amount of time to wait between task polling
-				iterations in seconds.`,
+				Description: util.Markdown(`
+					The amount of time to wait between task polling
+					iterations in seconds.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 10 * 60,
@@ -90,8 +99,10 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 		"reclaimOffset": schematypes.Integer{
 			MetaData: schematypes.MetaData{
 				Title: "Reclaim Offset",
-				Description: `The number of seconds priorty task claim expiration the
-				claim should be reclamed.`,
+				Description: util.Markdown(`
+					The number of seconds priorty task claim expiration the
+					claim should be reclamed.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 10 * 60,
@@ -99,9 +110,11 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 		"minimumReclaimDelay": schematypes.Integer{
 			MetaData: schematypes.MetaData{
 				Title: "Minimum Reclaim Delay",
-				Description: `Minimum number of seconds to wait before reclaiming a task.
+				Description: util.Markdown(`
+					Minimum number of seconds to wait before reclaiming a task.
 					it is important that this is some reasonable non-zero minimum to avoid
-					overloading servers if there is some error.`,
+					overloading servers if there is some error.
+				`),
 			},
 			Minimum: 0,
 			Maximum: 10 * 60,
@@ -130,9 +143,11 @@ var optionsSchema schematypes.Schema = schematypes.Object{
 var credentialsSchema schematypes.Schema = schematypes.Object{
 	MetaData: schematypes.MetaData{
 		Title: "TaskCluster Credentials",
-		Description: `The set of credentials that should be used by the worker
-		when authenticating against taskcluster endpoints. This needs scopes
-		for claiming tasks for the given workerType.`,
+		Description: util.Markdown(`
+			The set of credentials that should be used by the worker
+			when authenticating against taskcluster endpoints. This needs scopes
+			for claiming tasks for the given workerType.
+		`),
 	},
 	Properties: schematypes.Properties{
 		"clientId": schematypes.String{
@@ -152,8 +167,9 @@ var credentialsSchema schematypes.Schema = schematypes.Object{
 		"certificate": schematypes.String{
 			MetaData: schematypes.MetaData{
 				Title: "Certificate",
-				Description: `The certificate for the client, if using temporary
-				credentials.`,
+				Description: util.Markdown(`
+					The certificate for the client, if using temporary credentials.
+				`),
 			},
 		},
 		"authorizedScopes": schematypes.Array{
@@ -176,20 +192,24 @@ func ConfigSchema() schematypes.Object {
 			"engine": schematypes.StringEnum{
 				MetaData: schematypes.MetaData{
 					Title: "Worker Engine",
-					Description: `Selected worker engine to use, notice that the
+					Description: util.Markdown(`
+						Selected worker engine to use, notice that the
 						configuration for this engine **must** be present under the
-						'engines.<engine>' configuration key.`,
+						'engines.<engine>' configuration key.
+					`),
 				},
 				Options: engineNames,
 			},
 			"engines": schematypes.Object{
 				MetaData: schematypes.MetaData{
 					Title: "Engine Configuration",
-					Description: `Mapping from engine name to engine configuration.
+					Description: util.Markdown(`
+						Mapping from engine name to engine configuration.
 						Even-though the worker will only use one engine at any given time,
 						the configuration file can hold configuration for all engines.
 						Hence, you need only update the 'engine' key to change which engine
-						should be used.`,
+						should be used.
+					`),
 				},
 				Properties: engineConfig,
 			},
@@ -198,17 +218,21 @@ func ConfigSchema() schematypes.Object {
 			"temporaryFolder": schematypes.String{
 				MetaData: schematypes.MetaData{
 					Title: "Temporary Folder",
-					Description: `Path to folder that can be used for temporary files and
-							folders, if folder doesn't exist it will be created, otherwise it
-							will be overwritten.`,
+					Description: util.Markdown(`
+						Path to folder that can be used for temporary files and
+						folders, if folder doesn't exist it will be created, otherwise it
+						will be overwritten.
+					`),
 				},
 			},
 			"minimumDiskSpace": schematypes.Integer{
 				MetaData: schematypes.MetaData{
 					Title: "Minimum Disk Space",
-					Description: `The minimum amount of disk space in bytes to have available
+					Description: util.Markdown(`
+						The minimum amount of disk space in bytes to have available
 						before starting on the next task. Garbage collector will do a
-						best-effort attempt at releasing resources to satisfy this limit`,
+						best-effort attempt at releasing resources to satisfy this limit.
+					`),
 				},
 				Minimum: 0,
 				Maximum: math.MaxInt64,
@@ -216,9 +240,11 @@ func ConfigSchema() schematypes.Object {
 			"minimumMemory": schematypes.Integer{
 				MetaData: schematypes.MetaData{
 					Title: "Minimum Memory",
-					Description: `The minimum amount of memory in bytes to have available
+					Description: util.Markdown(`
+						The minimum amount of memory in bytes to have available
 						before starting on the next task. Garbage collector will do a
-						best-effort attempt at releasing resources to satisfy this limit`,
+						best-effort attempt at releasing resources to satisfy this limit.
+					`),
 				},
 				Minimum: 0,
 				Maximum: math.MaxInt64,


### PR DESCRIPTION
This is an easy review... just hit merge if you agree with what I'm doing here...

The `util.Markdown` function removes indentation and converts `'` to `, otherwise can't make inline code snippets... It basically makes it easy to write markdown...