### PR TITLE
Improved schema validation error log

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -300,10 +300,10 @@
 			"revisionTime": "2017-02-24T22:20:36Z"
 		},
 		{
-			"checksumSHA1": "yGGqDZjev+9RMQwccdCGPqgFFWw=",
+			"checksumSHA1": "1fAiVyAoRtg2GvtUskVSPQZ56dg=",
 			"path": "github.com/taskcluster/go-schematypes",
-			"revision": "3b23dab837ab6c46f375c713408a00dc1cf2ea3e",
-			"revisionTime": "2017-04-04T17:32:08Z"
+			"revision": "728bd96e3e4cf5a433e1bb42a955b59759290c7b",
+			"revisionTime": "2017-04-18T14:56:21Z"
 		},
 		{
 			"checksumSHA1": "Y3FCWxJ8fakDsn6T3RxfRf+GQn4=",

--- a/worker/taskrun/taskrun.go
+++ b/worker/taskrun/taskrun.go
@@ -167,7 +167,9 @@ func (t *TaskRun) RunToStage(targetStage Stage) {
 		if err != nil || incidentID != "" {
 			reason := runtime.ReasonInternalError
 			if e, ok := runtime.IsMalformedPayloadError(err); ok {
-				t.controller.LogError(e.Error())
+				for _, m := range e.Messages() {
+					t.controller.LogError(m)
+				}
 				reason = runtime.ReasonMalformedPayload
 			} else if err == runtime.ErrNonFatalInternalError {
 				t.nonFatalErr.Set(true)

--- a/worker/workertest/workertest_test.go
+++ b/worker/workertest/workertest_test.go
@@ -111,7 +111,8 @@ func TestWorkerMalformedPayload(t *testing.T) {
 				Exception: runtime.ReasonMalformedPayload,
 				Payload:   `{}`, // Should never create a SandboxBuilder
 				Artifacts: ArtifactAssertions{
-					"public/logs/live_backing.log": GrepArtifact("malformed-payload"),
+					// We expect an error message that says something about task.payload
+					"public/logs/live_backing.log": GrepArtifact("task.payload"),
 				},
 				AllowAdditional: true,
 			},


### PR DESCRIPTION
Example task log:

> [taskcluster:error]  Required property 'delay' is missing at task.payload.delay
[taskcluster:error]  Required property 'function' is missing at task.payload.function
[taskcluster:error]  Required property 'argument' is missing at task.payload.argument


Hopefully this will make it easier to figure out what is wrong with the `task.payload` property.
I haven't tried it with complex paths, but it should also work things like `task.payload.artifacts[2].name`