### PR TITLE
Fix 243 - Make webhookserver config optional with a provider: none, o…

### DIFF
--- a/runtime/taskcontext.go
+++ b/runtime/taskcontext.go
@@ -284,6 +284,11 @@ func (c *TaskContext) ExtractLog() (ioext.ReadSeekCloser, error) {
 //  - engines that send an email and await user confirmation
 //  ...
 //
+// If mechanics to expose the webhook is permanently or temporarily off-line,
+// this function may return empty-string instead of a URL. This shouldn't crash
+// worker, rather it should be handled as feature unavailable without
+// interrupting tasks.
+//
 // Implementors attaching a hook should take care to ensure that the handler
 // is able to respond with a non-2xx response, if the data it is accessing isn't
 // available anymore. All webhooks will be detached at the end of the

--- a/runtime/webhookserver/config.go
+++ b/runtime/webhookserver/config.go
@@ -8,6 +8,13 @@ import (
 	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
+var noneConfigSchema = schematypes.Object{
+	Properties: schematypes.Properties{
+		"provider": schematypes.StringEnum{Options: []string{"none"}},
+	},
+	Required: []string{"provider"},
+}
+
 var localhostConfigSchema = schematypes.Object{
 	Properties: schematypes.Properties{
 		"provider": schematypes.StringEnum{Options: []string{"localhost"}},
@@ -69,6 +76,7 @@ var statelessDNSConfigSchema = schematypes.Object{
 
 // ConfigSchema specifies schema for configuration passed to NewServer.
 var ConfigSchema schematypes.Schema = schematypes.OneOf{
+	noneConfigSchema,
 	localhostConfigSchema,
 	localtunnelConfigSchema,
 	statelessDNSConfigSchema,
@@ -99,6 +107,9 @@ func NewServer(config interface{}) (Server, error) {
 		BaseURL            string        `json:"baseUrl"`
 	}
 	schematypes.MustValidate(ConfigSchema, config)
+	if schematypes.MustMap(noneConfigSchema, config, &c) == nil {
+		return noneServer{}, nil
+	}
 	if schematypes.MustMap(localhostConfigSchema, config, &c) == nil {
 		return NewTestServer()
 	}

--- a/runtime/webhookserver/noneserver.go
+++ b/runtime/webhookserver/noneserver.go
@@ -1,0 +1,14 @@
+package webhookserver
+
+import "net/http"
+
+// noneServer is a stupid implementation that does nothing.
+type noneServer struct{}
+
+func (noneServer) AttachHook(handler http.Handler) (url string, detach func()) {
+	return "", func() {}
+}
+
+func (noneServer) Stop() {
+
+}

--- a/runtime/webhookserver/webhookserver.go
+++ b/runtime/webhookserver/webhookserver.go
@@ -15,6 +15,10 @@ import "net/http"
 // "http://localhost:8080/test/<suffix>" will be given to the handler as a
 // request for "/<suffix>".
 //
+// The AttachHook(handler) function may return empty string, if it's unable to
+// expose the webhook. This may happen intermittently, or permanent. Generally,
+// we don't want to crash the worker just because livelogs don't work.
+//
 // This is useful for interactive web hooks like livelog, interactive shell and
 // display.
 type WebHookServer interface {


### PR DESCRIPTION
…ption

Hmm, I'm not sure this is the most elegant solution... Maybe it would be better to allow `AttachWebHook` to return an error, like `ErrFeatureNotSupported` and `ErrNonFatalError`... So we can make a payload error if people try to create interactive when not supported...

Granted I do love the simplicity of not returning errors...