### PR TITLE
CI for qemu-engine running under tc-worker w. qemu-engine on packet...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage.out
 /qemu-config.yml
 /vendor/*/
 /config.env
+/examples/ubuntu-image/cache/

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -170,6 +170,33 @@ tasks:
           format: tar.gz
 
   ##########################################################
+  #################### linux QEMU tests ####################
+  ##########################################################
+
+  - provisionerId:  test-dummy-provisioner
+    workerType:     dummy-worker-packet
+    metadata:
+      name: "Test taskcluster-worker QEMU engine on QEMU engine"
+      description: "Builds and tests tc-worker with QEMU engine..."
+      owner: "{{ event.head.user.email }}" # the user who sent the pr/push e-mail will be inserted here
+      source: "{{ event.head.repo.url }}"  # the repo where the pr came from will be inserted here
+    extra:
+      github:
+        # Events that will trigger this task
+        events:
+          - push
+    payload:
+      image: 'https://s3-us-west-2.amazonaws.com/public-qemu-images/repository/github.com/taskcluster/taskcluster-worker/ubuntu-worker.tar.zst'
+      command:
+        - clone-and-exec.sh
+        - make
+        - tc-worker-env-tests
+      maxRunTime: '30 min'
+      env:
+        REPOSITORY: '{{ event.head.repo.url }}'
+        REVISION: '{{ event.head.sha }}'
+
+  ##########################################################
   ##################### upload-docs #####################
   ##########################################################
 

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -27,7 +27,7 @@ tasks:
           - push
     scopes:
       - secrets:get:repo:github.com/taskcluster/taskcluster-worker
-      - docker-worker:cache:taskcluster-worker-checkout
+      - docker-worker:cache:taskcluster-worker-checkout-1
     payload:
       features:
         taskclusterProxy: true
@@ -56,7 +56,7 @@ tasks:
           expires: "{{ '2 weeks' | $fromNow }}"
           type: file
       cache:
-        taskcluster-worker-checkout: /go/src
+        taskcluster-worker-checkout-1: /go/src
 
 
   ##########################################################
@@ -76,7 +76,7 @@ tasks:
         events:
           - push
     scopes:
-      - generic-worker:cache:taskcluster-worker-checkout
+      - generic-worker:cache:taskcluster-worker-checkout-1
     payload:
       maxRunTime: 3600
       artifacts:
@@ -103,7 +103,7 @@ tasks:
         - 'C:\taskcluster-worker-test-creds.cmd'
         - '"C:\mozilla-build\msys\bin\bash.exe" --login -c "cd ${GOPATH}/src/github.com/taskcluster/taskcluster-worker && make rebuild check"'
       mounts:
-        - cacheName: taskcluster-worker-checkout
+        - cacheName: taskcluster-worker-checkout-1
           directory: gopath/src
         - content:
             url: https://storage.googleapis.com/golang/go1.8.windows-amd64.zip
@@ -132,7 +132,7 @@ tasks:
         events:
           - push
     scopes:
-      - generic-worker:cache:taskcluster-worker-checkout
+      - generic-worker:cache:taskcluster-worker-checkout-1
     payload:
       maxRunTime: 3600
       artifacts:
@@ -162,7 +162,7 @@ tasks:
             mkdir -p public/build
             mv "${GOPATH}/bin/taskcluster-worker" public/build/taskcluster-worker-darwin-amd64
       mounts:
-        - cacheName: taskcluster-worker-checkout
+        - cacheName: taskcluster-worker-checkout-1
           directory: gopath/src
         - content:
             url: https://storage.googleapis.com/golang/go1.8.darwin-amd64.tar.gz
@@ -216,7 +216,7 @@ tasks:
           - master
     scopes:
       - auth:aws-s3:read-write:taskcluster-raw-docs/taskcluster-worker/
-      - docker-worker:cache:taskcluster-worker-checkout
+      - docker-worker:cache:taskcluster-worker-checkout-1
     payload:
       features:
         taskclusterProxy: true
@@ -250,4 +250,4 @@ tasks:
           # See: https://github.com/taskcluster/taskcluster-lib-docs/pull/26
           nodejs `which upload-project-docs`
       cache:
-        taskcluster-worker-checkout: /go/src
+        taskcluster-worker-checkout-1: /go/src

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ tc-worker:
 	docker build -t taskcluster/tc-worker -f tc-worker.Dockerfile .
 
 tc-worker-env-tests:
-	@if [ `whoami` != 'root' ]; then \
+	@if [ -z "$TASKID" ]; then \
 		echo "This command should only be used in the CI environment"; \
 		exit 1 ; \
 	fi
@@ -58,7 +58,7 @@ tc-worker-env-tests:
 	@echo '### Running govendor sync'
 	@docker run \
 		--tty --rm --privileged \
-		-e DEBUG -e GOARCH -e CGO_ENABLED=$(CGO_ENABLED) \
+		-e DEBUG -e GOARCH=$(GOARCH) -e CGO_ENABLED=$(CGO_ENABLED) \
 		-v $$(pwd):/go/src/github.com/taskcluster/taskcluster-worker/ \
 		taskcluster/tc-worker-env \
 		govendor sync
@@ -67,7 +67,7 @@ tc-worker-env-tests:
 	@echo '### Running tests'
 	@docker run \
 		--tty --rm --privileged \
-		-e DEBUG -e GOARCH -e CGO_ENABLED=$(CGO_ENABLED) \
+		-e DEBUG -e GOARCH=$(GOARCH) -e CGO_ENABLED=$(CGO_ENABLED) \
 		-v $$(pwd):/go/src/github.com/taskcluster/taskcluster-worker/ \
 		taskcluster/tc-worker-env \
 		go test -timeout 20m -race -tags 'qemu network system native' -p 1 -v \

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,11 @@ rebuild: prechecks build test lint
 
 check: test
 	# tests should fail if go fmt results in uncommitted code
-	git status --porcelain
-	/bin/bash -c 'test $$(git status --porcelain | wc -l) == 0'
+	@if [ $$(git status --porcelain | wc -l) -ne 0 ]; then \
+		echo "go fmt results in changes"; \
+		git diff; \
+		exit 1; \
+	fi
 test:
 	# should run with -tags=system at some point..... i.e.:
 	# go test -tags=system -v -race $$(go list ./... | grep -v /vendor/)

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ tc-worker-env-tests:
 		-e DEBUG -e GOARCH -e CGO_ENABLED=$(CGO_ENABLED) \
 		-v $$(pwd):/go/src/github.com/taskcluster/taskcluster-worker/ \
 		taskcluster/tc-worker-env \
-		go test -race -tags 'qemu network system native' -p 1 -v \
-		$$(find  -name '*_test.go' | xargs dirname | sort | uniq)
+		go test -timeout 20m -race -tags 'qemu network system native' -p 1 -v \
+		$$(find -name '*_test.go' | xargs dirname | sort | uniq)
 
 lint:
 	go get github.com/alecthomas/gometalinter

--- a/Makefile
+++ b/Makefile
@@ -53,17 +53,19 @@ tc-worker-env-tests:
 		echo "This command should only be used in the CI environment"; \
 		exit 1 ; \
 	fi
+	@echo '### Pulling tc-worker-env'
+	@docker pull taskcluster/tc-worker-env > /dev/null
 	@echo '### Running govendor sync'
-	docker run \
+	@docker run \
 		--tty --rm --privileged \
 		-e DEBUG -e GOARCH -e CGO_ENABLED=$(CGO_ENABLED) \
 		-v $$(pwd):/go/src/github.com/taskcluster/taskcluster-worker/ \
 		taskcluster/tc-worker-env \
 		govendor sync
 	@echo '### Downloading test images'
-	./engines/qemu/test-image/download.sh
+	@./engines/qemu/test-image/download.sh
 	@echo '### Running tests'
-	docker run \
+	@docker run \
 		--tty --rm --privileged \
 		-e DEBUG -e GOARCH -e CGO_ENABLED=$(CGO_ENABLED) \
 		-v $$(pwd):/go/src/github.com/taskcluster/taskcluster-worker/ \

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -12,17 +12,17 @@ ARGS="$ARGS taskcluster/tc-worker-env";
 TAGS='qemu network system native';
 
 if [[ "$@" == go\ * ]]; then
-  docker run $ARGS $@;
+  docker run $ARGS "$@";
 elif [[ "$1" == -- ]]; then
   shift;
-  docker run $ARGS $@;
+  docker run $ARGS "$@";
 elif [[ "$@" == bash ]]; then
   docker run $ARGS bash --login;
 elif [[ "$@" == "" ]]; then
   docker run $ARGS go test -race -tags "$TAGS" -p 1 -v \
   `go list ./... | grep -v ^github.com/taskcluster/taskcluster-worker/vendor/`;
 else
-  docker run $ARGS go test -v -race -tags "$TAGS" -p 1 $@;
+  docker run $ARGS go test -v -race -tags "$TAGS" -p 1 "$@";
 fi;
 
 if [[ "$?" != "0" ]]; then

--- a/engines/enginetest/artifacts.go
+++ b/engines/enginetest/artifacts.go
@@ -158,12 +158,9 @@ func (c *ArtifactTestCase) TestExtractFolderHandlerInterrupt() {
 
 // Test runs all test cases in parallel
 func (c *ArtifactTestCase) Test() {
-	wg := sync.WaitGroup{}
-	wg.Add(5)
-	go func() { c.TestExtractTextFile(); wg.Done() }()
-	go func() { c.TestExtractFileNotFound(); wg.Done() }()
-	go func() { c.TestExtractFolderNotFound(); wg.Done() }()
-	go func() { c.TestExtractNestedFolderPath(); wg.Done() }()
-	go func() { c.TestExtractFolderHandlerInterrupt(); wg.Done() }()
-	wg.Wait()
+	c.TestExtractTextFile()
+	c.TestExtractFileNotFound()
+	c.TestExtractFolderNotFound()
+	c.TestExtractNestedFolderPath()
+	c.TestExtractFolderHandlerInterrupt()
 }

--- a/engines/enginetest/attachproxy.go
+++ b/engines/enginetest/attachproxy.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"net/http"
 	"strings"
-	"sync"
 )
 
 // PingPath is the path that PingProxyPayload should hit on the proxy.
@@ -150,11 +149,8 @@ func (c *ProxyTestCase) TestParallelPings() {
 
 // Test runs all tests for the ProxyTestCase is parallel
 func (c *ProxyTestCase) Test() {
-	wg := sync.WaitGroup{}
-	wg.Add(4)
-	go func() { c.TestPingProxyPayload(); wg.Done() }()
-	go func() { c.TestPing404IsUnsuccessful(); wg.Done() }()
-	go func() { c.TestLiveLogging(); wg.Done() }()
-	go func() { c.TestParallelPings(); wg.Done() }()
-	wg.Wait()
+	c.TestPingProxyPayload()
+	c.TestPing404IsUnsuccessful()
+	c.TestLiveLogging()
+	c.TestParallelPings()
 }

--- a/engines/enginetest/attachvolume.go
+++ b/engines/enginetest/attachvolume.go
@@ -4,7 +4,6 @@ package enginetest
 
 import (
 	"log"
-	"sync"
 
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/runtime/mocks"
@@ -114,11 +113,8 @@ func (c *VolumeTestCase) TestReadToReadOnlyVolume() {
 
 // Test runs all tests on the test case.
 func (c *VolumeTestCase) Test() {
-	wg := sync.WaitGroup{}
-	wg.Add(4)
-	go func() { c.TestWriteReadVolume(); wg.Done() }()
-	go func() { c.TestReadEmptyVolume(); wg.Done() }()
-	go func() { c.TestWriteToReadOnlyVolume(); wg.Done() }()
-	go func() { c.TestReadToReadOnlyVolume(); wg.Done() }()
-	wg.Wait()
+	c.TestWriteReadVolume()
+	c.TestReadEmptyVolume()
+	c.TestWriteToReadOnlyVolume()
+	c.TestReadToReadOnlyVolume()
 }

--- a/engines/enginetest/display.go
+++ b/engines/enginetest/display.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"sync"
 	"time"
 
 	vnc "github.com/mitchellh/go-vnc"
@@ -169,13 +168,10 @@ func (c *DisplayTestCase) TestInvalidDisplayName() {
 
 // Test runs all tests in parallel
 func (c *DisplayTestCase) Test() {
-	wg := sync.WaitGroup{}
-	wg.Add(4)
-	go func() { c.TestListDisplays(); wg.Done() }()
-	go func() { c.TestDisplays(); wg.Done() }()
-	go func() { c.TestInvalidDisplayName(); wg.Done() }()
-	go func() { c.TestKillDisplay(); wg.Done() }()
-	wg.Wait()
+	c.TestListDisplays()
+	c.TestDisplays()
+	c.TestInvalidDisplayName()
+	c.TestKillDisplay()
 }
 
 type resolution struct {

--- a/engines/enginetest/environmentvariable.go
+++ b/engines/enginetest/environmentvariable.go
@@ -2,7 +2,6 @@ package enginetest
 
 import (
 	"log"
-	"sync"
 
 	"github.com/taskcluster/taskcluster-worker/engines"
 	"github.com/taskcluster/taskcluster-worker/runtime"
@@ -65,10 +64,7 @@ func (c *EnvVarTestCase) TestInvalidVariableNames() {
 
 // Test runs all tests in parallel
 func (c *EnvVarTestCase) Test() {
-	wg := sync.WaitGroup{}
-	wg.Add(3)
-	go func() { c.TestPrintVariable(); wg.Done() }()
-	go func() { c.TestVariableNameConflict(); wg.Done() }()
-	go func() { c.TestInvalidVariableNames(); wg.Done() }()
-	wg.Wait()
+	c.TestPrintVariable()
+	c.TestVariableNameConflict()
+	c.TestInvalidVariableNames()
 }

--- a/engines/enginetest/logging.go
+++ b/engines/enginetest/logging.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 )
 
 // A LoggingTestCase holds information necessary to run tests that an engine
@@ -70,10 +69,7 @@ func (c *LoggingTestCase) TestSilentTask() {
 
 // Test will run all logging tests
 func (c *LoggingTestCase) Test() {
-	wg := sync.WaitGroup{}
-	wg.Add(3)
-	go func() { c.TestLogTarget(); wg.Done() }()
-	go func() { c.TestLogTargetWhenFailing(); wg.Done() }()
-	go func() { c.TestSilentTask(); wg.Done() }()
-	wg.Wait()
+	c.TestLogTarget()
+	c.TestLogTargetWhenFailing()
+	c.TestSilentTask()
 }

--- a/engines/enginetest/shell.go
+++ b/engines/enginetest/shell.go
@@ -190,11 +190,8 @@ func (c *ShellTestCase) TestKillSleepCommand() {
 
 // Test runs all tests in parallel
 func (c *ShellTestCase) Test() {
-	wg := sync.WaitGroup{}
-	wg.Add(4)
-	go func() { c.TestCommand(); wg.Done() }()
-	go func() { c.TestBadCommand(); wg.Done() }()
-	go func() { c.TestAbortSleepCommand(); wg.Done() }()
-	go func() { c.TestKillSleepCommand(); wg.Done() }()
-	wg.Wait()
+	c.TestCommand()
+	c.TestBadCommand()
+	c.TestAbortSleepCommand()
+	c.TestKillSleepCommand()
 }

--- a/engines/qemu/qemuengine_test.go
+++ b/engines/qemu/qemuengine_test.go
@@ -61,9 +61,10 @@ var provider = &enginetest.EngineProvider{
 		"imageFolder":      "/tmp/images/",
 		"socketFolder":     "/tmp/",
 		"machineOptions": {
-			"maxMemory": 256
+			"maxMemory": 256,
+			"maxCores": 1
 		}
-  }`,
+	}`,
 }
 
 func TestLogging(t *testing.T) {

--- a/engines/qemu/qemuengine_test.go
+++ b/engines/qemu/qemuengine_test.go
@@ -61,7 +61,7 @@ var provider = &enginetest.EngineProvider{
 		"imageFolder":      "/tmp/images/",
 		"socketFolder":     "/tmp/",
 		"machineOptions": {
-			"maxMemory": 512
+			"maxMemory": 256
 		}
   }`,
 }

--- a/engines/qemu/qemuengine_test.go
+++ b/engines/qemu/qemuengine_test.go
@@ -146,7 +146,6 @@ func TestArtifacts(t *testing.T) {
 			"command": ["sh", "-ec", "mkdir -p /home/tc/folder/sub-folder; echo '[hello-world]' > /home/tc/folder/hello.txt; echo '[hello-world]' > /home/tc/folder/sub-folder/hello2.txt"]
 		}`,
 	}
-
 	c.TestExtractTextFile()
 	c.TestExtractFileNotFound()
 	c.TestExtractFolderNotFound()

--- a/engines/qemu/vm/options.go
+++ b/engines/qemu/vm/options.go
@@ -9,6 +9,7 @@ import (
 // values and options.
 type MachineOptions struct {
 	MaxMemory int `json:"maxMemory"`
+	MaxCores  int `json:"maxCores"`
 }
 
 // MachineOptionsSchema is the schema for MachineOptions.
@@ -31,8 +32,22 @@ var MachineOptionsSchema = schematypes.Object{
 			Minimum: 0,
 			Maximum: 1024 * 1024, // 1 TiB
 		},
+		"maxCores": schematypes.Integer{
+			Title: "Max CPU Cores",
+			Description: util.Markdown(`
+				Maximum number of CPUs a virtual machine can use.
+
+				This is the product of 'threads', 'cores' and 'sockets' as specified
+				in the machine definition 'machine.json'. If the virtual machine image
+				does not specify CPU requires it will be given 'maxCores' number of
+				cores in a single socket.
+			`),
+			Minimum: 1,
+			Maximum: 255, // Maximum allowed by QEMU
+		},
 	},
 	Required: []string{
 		"maxMemory",
+		"maxCores",
 	},
 }

--- a/engines/qemu/vm/vm.go
+++ b/engines/qemu/vm/vm.go
@@ -93,7 +93,11 @@ func NewVirtualMachine(
 		for i, k := range keys {
 			pairs[i] = fmt.Sprintf("%s=%s", k, opts[k])
 		}
-		return kind + strings.Join(pairs, ",")
+		// Preprend with kind, if it's non-empty
+		if kind != "" {
+			pairs = append([]string{kind}, pairs...)
+		}
+		return strings.Join(pairs, ",")
 	}
 	options := []string{
 		"-S", // Wait for QMP command "continue" before starting execution
@@ -108,10 +112,10 @@ func NewVirtualMachine(
 		// TODO: fit to system HT, see: https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
 		// TODO: Configure CPU instruction sets: http://forum.ipfire.org/viewtopic.php?t=12642
 		"-smp", arg("", opts{
-			"cpus":    "1", // cpus = threads * cores * sockets
-			"threads": "1", // threads per core
-			"cores":   "1", // cores per socket
-			"sockets": "1", // sockets in the machine
+			"cpus":    strconv.Itoa(machine.CPU.Threads * machine.CPU.Cores * machine.CPU.Sockets),
+			"threads": strconv.Itoa(machine.CPU.Threads), // threads per core
+			"cores":   strconv.Itoa(machine.CPU.Cores),   // cores per socket
+			"sockets": strconv.Itoa(machine.CPU.Sockets), // sockets in the machine
 		}),
 		"-uuid", machine.UUID,
 		"-no-user-config", "-nodefaults",

--- a/engines/qemu/vm/vm.go
+++ b/engines/qemu/vm/vm.go
@@ -107,7 +107,12 @@ func NewVirtualMachine(
 		"-realtime", "mlock=off", // TODO: Enable for things like talos
 		// TODO: fit to system HT, see: https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
 		// TODO: Configure CPU instruction sets: http://forum.ipfire.org/viewtopic.php?t=12642
-		"-smp", "cpus=2,sockets=2,cores=1,threads=1",
+		"-smp", arg("", opts{
+			"cpus":    "1", // cpus = threads * cores * sockets
+			"threads": "1", // threads per core
+			"cores":   "1", // cores per socket
+			"sockets": "1", // sockets in the machine
+		}),
 		"-uuid", machine.UUID,
 		"-no-user-config", "-nodefaults",
 		"-rtc", "base=utc", // TODO: Allow clock=vm for loadvm with windows

--- a/examples/packet-cloud-init.yml
+++ b/examples/packet-cloud-init.yml
@@ -1,0 +1,96 @@
+#cloud-config
+
+# The following variables must be filled out:
+#   papertrail log destination: <log-host> <log-port>
+#   taskcluster credentials: <client-id> <access-token>
+# Then this is ready to go!
+coreos:
+  units:
+    # Disable SSH
+    - name:    sshd.socket
+      mask:    true
+      command: stop
+    - name:    sshd.service
+      mask:    true
+      command: stop
+    # Stop updates of coreos
+    - name:    locksmithd.service
+      mask:    true
+      command: stop
+    # Disable fleet socket activation
+    - name:    fleet.socket
+      mask:    true
+      command: stop
+    # Disable etcd2
+    - name:    etcd2.service
+      mask:    true
+      command: stop
+    # Enable debug-level logging
+    - name:    systemd-journald.service
+      command: restart
+      drop-ins:
+        - name: 10-debug.conf
+          content: |
+            [Service]
+            Environment=SYSTEMD_LOG_LEVEL=debug
+    # Setup logging to papertrail
+    - name:    papertrail.service
+      command: start
+      content: |
+        [Unit]
+        Description=forward syslog to papertrail
+        After=systemd-journald.service
+        Before=docker.service
+        Requires=systemd-journald.service
+
+        [Service]
+        ExecStart=/bin/sh -c "journalctl -f | ncat --ssl <log-host> <log-port>"
+        TimeoutStartSec=0
+        Restart=on-failure
+        RestartSec=5s
+    # Reload kvm_intel with nested virtualization allowed
+    - name:    kvm_intel_nested.service
+      command: start
+      content: |
+        [Unit]
+        Description=Reload kvm_intel to allow nested virtualization.
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/bin/sh -c 'modprobe -r kvm_intel && modprobe kvm_intel nested=1'
+        ExecStop=/bin/sh -c 'modprobe -r kvm_intel && modprobe kvm_intel'
+    # Setup taskcluster-worker
+    - name:    taskcluster-worker.service
+      command: start
+      content: |
+        [Unit]
+        Description=taskcluster worker process
+        Requires=papertrail.service docker.service kvm_intel_nested.service
+
+        [Service]
+        Restart=always
+        ExecStart=/usr/bin/docker \
+          run -p 443:443 --rm --privileged \
+          --env-file /etc/taskcluster-worker-env.list \
+          --name taskcluster-worker \
+          taskcluster/tc-worker@sha256:8703d969a75e6cebe693d5415b4590c721ecf861fff072d932ecf5384ec73d1c
+        ExecStop=/usr/bin/docker kill taskcluster-worker
+
+        [Install]
+        WantedBy=multi-user.target
+# Add file with environment variables for taskcluster-worker
+write_files:
+  - path:         /etc/taskcluster-worker-env.list
+    permissions:  '0400'
+    owner:        root
+    content: |
+      ENGINE=qemu
+      TASKCLUSTER_CLIENT_ID=<client-id>
+      TASKCLUSTER_ACCESS_TOKEN=<access-token>
+      PORT=443
+      PROVISIONER_ID=test-dummy-provisioner
+      WORKER_TYPE=dummy-worker-packet
+      WORKER_GROUP=test-dummy-workers
+      WORKER_ID=dummy-worker-type2
+      DEBUG=*

--- a/examples/ubuntu-image/README.md
+++ b/examples/ubuntu-image/README.md
@@ -1,0 +1,36 @@
+Ubuntu QEMU Image
+=================
+
+This folder contains scripts and logic for building a QEMU image with ubuntu
+for taskcluster-worker running QEMU engine.
+
+This generally involves:
+ 1) Installing Ubuntu
+ 2) Setting up `taskcluster-worker qemu-guest-tools` to run after start-up
+
+We do this in two steps, first we create an `ubuntu-setup.tar.zst` image that
+when booted will mount `/dev/cdrom` and execute `setup.sh` from the CD drive.
+This way we can tweak the contents of the ISO mounted as `/dev/cdrom`, and
+derive a new image without having to install ubuntu from scratch.
+
+Creating `ubuntu-setup.tar.zst`
+-------------------------------
+First run the `download.sh` to download images, then run `build-ubuntu-setup.sh`
+and install ubuntu, mount `/dev/sr1` and run `install-customize-image.sh` from
+the CD drive. This installs a service that will run after start-up, mount
+`/dev/cdrom` and execute `setup.sh`.
+
+Note. **this involves manually steps**, installation of ubuntu isn't automated.
+For consistency we enter username/password as:
+
+```
+username: ubuntu
+password: ubuntu
+```
+
+Creating `ubuntu-worker.tar.zst`
+-------------------------------
+Once we have the `ubuntu-setup.tar.zst` building an image we can use with the
+worker is as easy as running `build-ubuntu-setup.sh`.
+
+Note: there's currently no automated testing that image building is successful.

--- a/examples/ubuntu-image/build-ubuntu-setup.sh
+++ b/examples/ubuntu-image/build-ubuntu-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# Load constants
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/constants.sh"
+
+# Create temporary files
+DATA=`mktemp -d`;
+ISO=`mktemp`;
+TCWORKER=`mktemp`;
+
+echo '### Building taskcluster-worker for host (for building image)'
+go build -o "$TCWORKER" github.com/taskcluster/taskcluster-worker
+
+echo '### Packaging data.iso'
+cp "$DIR/data"/* "$DATA/"
+genisoimage -vJrV DATA_VOLUME -input-charset utf-8 -o "$ISO" "$DATA"
+
+echo "### Building $SETUP_IMAGE_NAME"
+echo 'This step opens a VNC sessions and requires you to:'
+echo ' 1. Install operating system'
+echo ' 2. Mount cdrom'
+echo ' 3. Execute install-customize-image.sh'
+"$TCWORKER" qemu-build --boot "$INSTALLER_ISO" --cdrom "$ISO" --size "$DISKSIZE" \
+  from-new "$DIR/machine.json" "$DIR/cache/$SETUP_IMAGE_NAME"
+
+echo '### Removing temporary files'
+rm -rf "$DATA"
+rm -f "$ISO" "$TCWORKER"

--- a/examples/ubuntu-image/build-ubuntu-worker.sh
+++ b/examples/ubuntu-image/build-ubuntu-worker.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# Load constants
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/constants.sh"
+
+# Create temporary files
+DATA=`mktemp -d`;
+ISO=`mktemp`;
+TCWORKER=`mktemp`;
+
+echo '### Building taskcluster-worker for host (for building image)'
+go build -o "$TCWORKER" github.com/taskcluster/taskcluster-worker
+
+echo '### Building taskcluster-worker for image (for use inside image)'
+CGO_ENABLED=1 GOARCH="$IMAGE_GOARCH" go build -o "$DATA/taskcluster-worker" \
+  github.com/taskcluster/taskcluster-worker
+
+echo '### Packaging data.iso'
+cp "$DIR/data"/* "$DATA/"
+genisoimage -vJrV DATA_VOLUME -input-charset utf-8 -o "$ISO" "$DATA"
+
+echo "### Building $SETUP_IMAGE_NAME"
+"$TCWORKER" qemu-build --no-vnc --cdrom "$ISO" \
+  from-image "$DIR/cache/$SETUP_IMAGE_NAME" "$DIR/cache/$WORKER_IMAGE_NAME"
+
+echo '### Removing temporary files'
+rm -rf "$DATA"
+rm -f "$ISO" "$TCWORKER"

--- a/examples/ubuntu-image/constants.sh
+++ b/examples/ubuntu-image/constants.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+# Find location of the script no matter where it's located
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+#
+INSTALLER_URL='http://releases.ubuntu.com/16.04.2/ubuntu-16.04.2-server-amd64.iso'
+INSTALLER_ISO="$DIR/cache/ubuntu-16.04.2-server-amd64.iso"
+INSTALLER_SHA256='737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535'
+
+DISKSIZE='10' # GB
+IMAGE_GOARCH='amd64'
+
+SETUP_IMAGE_NAME='ubuntu-setup.tar.zst'
+WORKER_IMAGE_NAME='ubuntu-worker.tar.zst'
+
+S3_BUCKET='public-qemu-images'
+S3_PREFIX='repository/github.com/taskcluster/taskcluster-worker'

--- a/examples/ubuntu-image/data/clone-and-exec.sh
+++ b/examples/ubuntu-image/data/clone-and-exec.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+if [ -z "$REPOSITORY" ]; then
+  echo '$REPOSITORY must be a git repository'
+  exit 1
+fi
+
+if [ -z "$REVISION" ]; then
+  echo '$REVISION must be a revision or branch'
+  exit 1
+fi
+
+mkdir -p '/src';
+cd '/src';
+git clone -q "$REPOSITORY" '/src';
+git checkout "$REVISION";
+
+exec "$@"

--- a/examples/ubuntu-image/data/customize-image.service
+++ b/examples/ubuntu-image/data/customize-image.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run setup.sh from cdrom to customize image.
+After=network-online.target,dev-cdrom.device
+
+[Service]
+Type=simple
+ExecStart=/opt/customize-image.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/ubuntu-image/data/customize-image.sh
+++ b/examples/ubuntu-image/data/customize-image.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Disable customize-image.service
+systemctl disable customize-image.service
+rm /etc/systemd/system/customize-image.service
+rm /opt/customize-image.sh
+
+# Mount cdrom
+mount /dev/cdrom /mnt
+
+sh /mnt/setup.sh
+
+# Unmount cdrom
+umount /dev/cdrom

--- a/examples/ubuntu-image/data/install-customize-image.sh
+++ b/examples/ubuntu-image/data/install-customize-image.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -e
+
+# Find location of the script no matter where it's located
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Disable auto-updates of any kind
+apt-get purge -y unattended-upgrades
+rm /etc/apt/apt.conf.d/10periodic
+
+# Copy in customize-image.service
+cp "$DIR/customize-image.service" /etc/systemd/system/
+chmod 644 /etc/systemd/system/customize-image.service
+
+cp "$DIR/customize-image.sh" /opt/
+chmod +x /opt/customize-image.sh
+
+# Enable customize-image.service
+systemctl enable customize-image.service
+echo 'customize-image.service installed'

--- a/examples/ubuntu-image/data/install.sh
+++ b/examples/ubuntu-image/data/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+# Find location of the script no matter where it's located
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo '### Installing taskcluster-worker qemu-guest-tools'
+cp "$DIR"/taskcluster-worker /usr/local/bin/
+chmod +x /usr/local/bin/taskcluster-worker
+
+echo '### Update packages'
+apt-get update -y
+apt-get upgrade -y
+
+echo '### Installing docker'
+apt-get install -y apt-transport-https ca-certificates
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+echo 'deb https://apt.dockerproject.org/repo ubuntu-xenial main' > /etc/apt/sources.list.d/docker.list
+apt-get update -y
+apt-get install -y docker-engine
+
+echo '### Installing build dependencies'
+apt-get install -y git curl screen nano build-essential
+
+echo '### Installing test script'
+cp "$DIR/clone-and-exec.sh" /usr/local/bin/clone-and-exec.sh;
+chmod +x /usr/local/bin/clone-and-exec.sh;
+
+echo '### Installing systemd service'
+cp "$DIR/taskcluster-worker.service" /etc/systemd/system/
+chmod 644 /etc/systemd/system/taskcluster-worker.service
+systemctl enable taskcluster-worker.service
+
+echo '### Setup done'

--- a/examples/ubuntu-image/data/setup.sh
+++ b/examples/ubuntu-image/data/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Find location of the script no matter where it's located
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+# Wait for metadata service to be available
+until curl -m 1 'http://169.254.169.254/engine/v1/ping'; do
+  echo "Pinging..."
+done
+
+# Run install.sh sending logs to metadata service
+bash "$DIR/install.sh" 2>&1 | "$DIR/taskcluster-worker" qemu-guest-tools post-log -
+
+# Shutdown the system image is now customized
+sleep 1
+poweroff

--- a/examples/ubuntu-image/data/taskcluster-worker.service
+++ b/examples/ubuntu-image/data/taskcluster-worker.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=QEMU guest tools for taskcluster-worker
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/taskcluster-worker qemu-guest-tools
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/ubuntu-image/download.sh
+++ b/examples/ubuntu-image/download.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# Load constants
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/constants.sh"
+
+if ! [ -f "$INSTALLER_ISO" ]; then
+  echo '### Downloading Installer ISO'
+  curl -L "$INSTALLER_URL" > "$INSTALLER_ISO"
+fi
+
+echo '### Checking sha256sum'
+echo "$INSTALLER_SHA256 $INSTALLER_ISO" | sha256sum -c -
+
+if ! [ -f "$DIR/cache/$SETUP_IMAGE_NAME" ]; then
+  echo "### Downloading $SETUP_IMAGE_NAME"
+  curl -L "https://s3-us-west-2.amazonaws.com/$S3_BUCKET/$S3_PREFIX/$SETUP_IMAGE_NAME" > "$DIR/cache/$SETUP_IMAGE_NAME"
+fi
+
+echo "Not downloading $WORKER_IMAGE_NAME as it is easy to rebuild"

--- a/examples/ubuntu-image/machine.json
+++ b/examples/ubuntu-image/machine.json
@@ -1,0 +1,10 @@
+{
+  "uuid": "52bab607-10f1-4049-a0f8-ee4725cb715b",
+  "network": {
+    "device": "e1000",
+    "mac": "aa:54:1a:30:5c:de"
+  },
+  "keyboard": {
+    "layout": "en-us"
+  }
+}

--- a/examples/ubuntu-image/upload.sh
+++ b/examples/ubuntu-image/upload.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# Load constants
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/constants.sh"
+
+# We don't upload $SETUP_IMAGE_NAME as this file is the result of manually
+# constructing the image and following the install instructions in the README.md
+# So we'll rarely need to update this, it's mostly if there is breaking image
+# format changes that we might have to.
+echo "Skipping $SETUP_IMAGE_NAME as we don't change it"
+#aws s3 cp "$DIR/cache/$SETUP_IMAGE_NAME" "s3://$S3_BUCKET/$S3_PREFIX/$SETUP_IMAGE_NAME"
+
+aws s3 cp "$DIR/cache/$WORKER_IMAGE_NAME" "s3://$S3_BUCKET/$S3_PREFIX/$WORKER_IMAGE_NAME"

--- a/tc-worker-env.Dockerfile
+++ b/tc-worker-env.Dockerfile
@@ -19,10 +19,15 @@ RUN curl -L https://github.com/facebook/zstd/archive/v1.1.4.tar.gz > /tmp/zstd.t
  && make -j -C /tmp/zstd-1.1.4/programs install \
  && rm -rf /tmp/zstd-1.1.4/ /tmp/zstd.tar.gz
 
+RUN mkdir -p /go
+
 ENV GOPATH      /go
 ENV PATH        /usr/local/go/bin:$GOPATH/bin:$PATH
 ENV APP_PATH    github.com/taskcluster/taskcluster-worker
 ENV SHELL       bash
+
+# Install govendor
+RUN go get github.com/kardianos/govendor
 
 RUN mkdir -p /go/src/$APP_PATH
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,7 +15,7 @@
 			"revisionTime": "2016-08-29T20:23:21Z"
 		},
 		{
-			"checksumSHA1": "9NR0rrcAT5J76C5xMS4AVksS9o0=",
+			"checksumSHA1": "1r7G/GU4FYrPSc7tUfByThJRoG8=",
 			"path": "github.com/StackExchange/wmi",
 			"revision": "e54cbda6595d7293a7a468ccf9525f6bc8887f99",
 			"revisionTime": "2016-08-11T21:45:55Z"
@@ -124,7 +124,7 @@
 			"revisionTime": "2016-03-18T18:15:35Z"
 		},
 		{
-			"checksumSHA1": "xgjI2W3RGiQwNlxsOW2V9fJ9kaM=",
+			"checksumSHA1": "UVj9Q7XWOZTZXLlvTs1hCtNCMAU=",
 			"path": "github.com/fsnotify/fsnotify",
 			"revision": "f12c6236fe7b5cf6bcf30e5935d08cb079d78334",
 			"revisionTime": "2016-08-16T05:15:41Z"
@@ -136,7 +136,7 @@
 			"revisionTime": "2016-09-08T23:20:54Z"
 		},
 		{
-			"checksumSHA1": "wDZdTaY9JiqqqnF4c3pHP71nWmk=",
+			"checksumSHA1": "sWH0TuEMLkXhWPwuUBZrJz4KmXA=",
 			"path": "github.com/go-ole/go-ole",
 			"revision": "7dfdcf409020452e29b4babcbb22f984d2aa308a",
 			"revisionTime": "2016-07-29T03:38:29Z"
@@ -166,7 +166,7 @@
 			"revisionTime": "2017-03-19T06:52:38Z"
 		},
 		{
-			"checksumSHA1": "eIjJhEqZZmQwt++0jlQhbIhAcH4=",
+			"checksumSHA1": "Cdsm9pkjn7WC0TP2KKPDSApiQKQ=",
 			"path": "github.com/kr/pty",
 			"revision": "ce7fa45920dc37a92de8377972e52bc55ffa8d57",
 			"revisionTime": "2016-07-16T20:46:20Z"
@@ -221,13 +221,13 @@
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "NOh16yOqf+hH+0XMJp3uV1Kb9FA=",
+			"checksumSHA1": "NQJSFdm1lm0/tcsw98mYxzAEk5U=",
 			"path": "github.com/shirou/gopsutil/disk",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "NuQpBEPzjTLUqDW2zxChEBpDAkk=",
+			"checksumSHA1": "zRMBNyrCnaXJuFhqmPc8WM7euSA=",
 			"path": "github.com/shirou/gopsutil/host",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
@@ -239,25 +239,25 @@
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "5HYtuEgPkRvE6I8VFQMAN0rbYRU=",
+			"checksumSHA1": "6d1VOR0P7u/IfmGfxybFn43d7y4=",
 			"path": "github.com/shirou/gopsutil/mem",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "Fa7lUUadHW9402ifjheuSFDkufo=",
+			"checksumSHA1": "Zdy4CSBVZ7R4RlLQR/lXPZRy+DI=",
 			"path": "github.com/shirou/gopsutil/net",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "k1ug9JDvES8wNqxaQcO7qxgpOKc=",
+			"checksumSHA1": "jVtT/LU7guv16DnxQpT/NDycsIc=",
 			"path": "github.com/shirou/gopsutil/process",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "Om0cn0L5ewCIBcORQAXD8guTa9M=",
+			"checksumSHA1": "tzAvLYmiZZMIt4hWuTyS5DHZBUg=",
 			"path": "github.com/streadway/amqp",
 			"revision": "afe8eee29a74d213b1f3fb2586058157c397da60",
 			"revisionTime": "2017-03-13T17:48:48Z"
@@ -372,7 +372,7 @@
 			"revisionTime": "2016-08-05T02:05:43Z"
 		},
 		{
-			"checksumSHA1": "HN3pLd5cC+QXkX8j8FsCCB3FzSI=",
+			"checksumSHA1": "D9cJqFRTfAfngaiE56L1MVJZ2cw=",
 			"path": "github.com/tinylib/msgp/msgp",
 			"revision": "362bfb3384d53ae4d5dd745983a4d70b6d23628c",
 			"revisionTime": "2017-01-01T02:31:10Z"
@@ -396,25 +396,25 @@
 			"revisionTime": "2016-09-14T00:16:04Z"
 		},
 		{
-			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
+			"checksumSHA1": "lM/FuUOHl1AFdGZRafbWikLXciA=",
 			"path": "golang.org/x/net/context",
 			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
 			"revisionTime": "2016-09-11T09:39:33Z"
 		},
 		{
-			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
+			"checksumSHA1": "LolXS3+kS96mT/9wLQVhVmeIDCU=",
 			"path": "golang.org/x/net/context/ctxhttp",
 			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
 			"revisionTime": "2016-09-11T09:39:33Z"
 		},
 		{
-			"checksumSHA1": "vu7njn8O4vhFtmgGWntwjA2NAbk=",
+			"checksumSHA1": "d3c/KT4KEacDbwLcahIo85ASNXk=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9",
 			"revisionTime": "2016-09-14T20:33:16Z"
 		},
 		{
-			"checksumSHA1": "BoDMXJFal8LyM35n5LKhZGIxLyk=",
+			"checksumSHA1": "cWqyArVQwBXxiF9gW8/vraYWi0E=",
 			"path": "gopkg.in/dgrijalva/jwt-go.v2",
 			"revision": "268038b363c7a8d7306b8e35bf77a1fde4b0c402",
 			"revisionTime": "2016-06-16T19:14:24Z"
@@ -438,7 +438,7 @@
 			"revisionTime": "2016-07-24T20:26:31Z"
 		},
 		{
-			"checksumSHA1": "hiOUviIMDKo7y918uBiEhfJyOkk=",
+			"checksumSHA1": "luytxTQqgWwsF63SQ/RuJ9EJqes=",
 			"path": "gopkg.in/tylerb/graceful.v1",
 			"revision": "50a48b6e73fcc75b45e22c05b79629a67c79e938",
 			"revisionTime": "2016-08-29T01:00:30Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,7 +15,7 @@
 			"revisionTime": "2016-08-29T20:23:21Z"
 		},
 		{
-			"checksumSHA1": "1r7G/GU4FYrPSc7tUfByThJRoG8=",
+			"checksumSHA1": "9NR0rrcAT5J76C5xMS4AVksS9o0=",
 			"path": "github.com/StackExchange/wmi",
 			"revision": "e54cbda6595d7293a7a468ccf9525f6bc8887f99",
 			"revisionTime": "2016-08-11T21:45:55Z"
@@ -124,7 +124,7 @@
 			"revisionTime": "2016-03-18T18:15:35Z"
 		},
 		{
-			"checksumSHA1": "UVj9Q7XWOZTZXLlvTs1hCtNCMAU=",
+			"checksumSHA1": "xgjI2W3RGiQwNlxsOW2V9fJ9kaM=",
 			"path": "github.com/fsnotify/fsnotify",
 			"revision": "f12c6236fe7b5cf6bcf30e5935d08cb079d78334",
 			"revisionTime": "2016-08-16T05:15:41Z"
@@ -136,7 +136,7 @@
 			"revisionTime": "2016-09-08T23:20:54Z"
 		},
 		{
-			"checksumSHA1": "sWH0TuEMLkXhWPwuUBZrJz4KmXA=",
+			"checksumSHA1": "wDZdTaY9JiqqqnF4c3pHP71nWmk=",
 			"path": "github.com/go-ole/go-ole",
 			"revision": "7dfdcf409020452e29b4babcbb22f984d2aa308a",
 			"revisionTime": "2016-07-29T03:38:29Z"
@@ -227,7 +227,7 @@
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "zRMBNyrCnaXJuFhqmPc8WM7euSA=",
+			"checksumSHA1": "zYGrRrVEnsZoxkbiqB5Lj7ojBLg=",
 			"path": "github.com/shirou/gopsutil/host",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
@@ -239,25 +239,25 @@
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "6d1VOR0P7u/IfmGfxybFn43d7y4=",
+			"checksumSHA1": "5HYtuEgPkRvE6I8VFQMAN0rbYRU=",
 			"path": "github.com/shirou/gopsutil/mem",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "Zdy4CSBVZ7R4RlLQR/lXPZRy+DI=",
+			"checksumSHA1": "Fa7lUUadHW9402ifjheuSFDkufo=",
 			"path": "github.com/shirou/gopsutil/net",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "jVtT/LU7guv16DnxQpT/NDycsIc=",
+			"checksumSHA1": "u9VGaCX/DyCDmWtg5Jt6yBH0pPk=",
 			"path": "github.com/shirou/gopsutil/process",
 			"revision": "53322384071180140b2a4f33f161fc5898685da5",
 			"revisionTime": "2016-09-19T13:31:52Z"
 		},
 		{
-			"checksumSHA1": "tzAvLYmiZZMIt4hWuTyS5DHZBUg=",
+			"checksumSHA1": "Om0cn0L5ewCIBcORQAXD8guTa9M=",
 			"path": "github.com/streadway/amqp",
 			"revision": "afe8eee29a74d213b1f3fb2586058157c397da60",
 			"revisionTime": "2017-03-13T17:48:48Z"
@@ -372,7 +372,7 @@
 			"revisionTime": "2016-08-05T02:05:43Z"
 		},
 		{
-			"checksumSHA1": "D9cJqFRTfAfngaiE56L1MVJZ2cw=",
+			"checksumSHA1": "HN3pLd5cC+QXkX8j8FsCCB3FzSI=",
 			"path": "github.com/tinylib/msgp/msgp",
 			"revision": "362bfb3384d53ae4d5dd745983a4d70b6d23628c",
 			"revisionTime": "2017-01-01T02:31:10Z"
@@ -396,25 +396,25 @@
 			"revisionTime": "2016-09-14T00:16:04Z"
 		},
 		{
-			"checksumSHA1": "lM/FuUOHl1AFdGZRafbWikLXciA=",
+			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
 			"path": "golang.org/x/net/context",
 			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
 			"revisionTime": "2016-09-11T09:39:33Z"
 		},
 		{
-			"checksumSHA1": "LolXS3+kS96mT/9wLQVhVmeIDCU=",
+			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"path": "golang.org/x/net/context/ctxhttp",
 			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
 			"revisionTime": "2016-09-11T09:39:33Z"
 		},
 		{
-			"checksumSHA1": "d3c/KT4KEacDbwLcahIo85ASNXk=",
+			"checksumSHA1": "noiZtKqeCoHgwUw9PQz4O3w3CnU=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9",
 			"revisionTime": "2016-09-14T20:33:16Z"
 		},
 		{
-			"checksumSHA1": "cWqyArVQwBXxiF9gW8/vraYWi0E=",
+			"checksumSHA1": "BoDMXJFal8LyM35n5LKhZGIxLyk=",
 			"path": "gopkg.in/dgrijalva/jwt-go.v2",
 			"revision": "268038b363c7a8d7306b8e35bf77a1fde4b0c402",
 			"revisionTime": "2016-06-16T19:14:24Z"
@@ -438,7 +438,7 @@
 			"revisionTime": "2016-07-24T20:26:31Z"
 		},
 		{
-			"checksumSHA1": "luytxTQqgWwsF63SQ/RuJ9EJqes=",
+			"checksumSHA1": "hiOUviIMDKo7y918uBiEhfJyOkk=",
 			"path": "gopkg.in/tylerb/graceful.v1",
 			"revision": "50a48b6e73fcc75b45e22c05b79629a67c79e938",
 			"revisionTime": "2016-08-29T01:00:30Z"


### PR DESCRIPTION
On packet I deploy using coreos/docker, and I reuse docker inside the ubuntu VM, so we have:
 `coreos > docker > qemu > ubuntu > docker > qemu > tinycorelinux`

Haha :)

For anyone thinking this is crazy it's:
 1. coreos stable on packet.net
 2. docker running `taskcluster/tc-worker`
 3. taskcluster-worker running a QEMU VM per-task
 4. The per-task VM we run tests in is Ubuntu
 5. Inside the ubuntu VM we run `make tc-worker-env-tests`, which pulls `taskcluster/tc-worker-env`
 6. Inside the docker container we run taskcluster-worker tests w. `go test`
 7. Tests runs QEMU w. tincorelinux as the test image