### PR TITLE
Fix 262 - Prefix logs with a simple header

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	_ "github.com/taskcluster/taskcluster-worker/plugins/env"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/interactive"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/livelog"
+	_ "github.com/taskcluster/taskcluster-worker/plugins/logprefix"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/maxruntime"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/plugintest"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/reboot"

--- a/plugins/logprefix/config.go
+++ b/plugins/logprefix/config.go
@@ -1,0 +1,16 @@
+package logprefix
+
+import (
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
+
+var configSchema = schematypes.Map{
+	Values: schematypes.String{},
+	Title:  "Log Prefix",
+	Description: util.Markdown(`
+		Set of key-value pairs to be printed at the top of all tasks logs.
+
+		Note. values given here can overwrite built-in key-value pairs.
+	`),
+}

--- a/plugins/logprefix/doc.go
+++ b/plugins/logprefix/doc.go
@@ -1,0 +1,8 @@
+// Package logprefix provides a taskcluster-worker plugin that prefixes all
+// task logs with useful debug information such as taskId, workerType, as well
+// as configurable constants.
+package logprefix
+
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
+
+var debug = util.Debug("logprefix")

--- a/plugins/logprefix/logprefix.go
+++ b/plugins/logprefix/logprefix.go
@@ -1,0 +1,86 @@
+package logprefix
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/plugins"
+)
+
+type provider struct {
+	plugins.PluginProviderBase
+}
+
+type plugin struct {
+	plugins.PluginBase
+	keys map[string]string
+}
+
+func init() {
+	plugins.Register("logprefix", provider{})
+}
+
+func (provider) ConfigSchema() schematypes.Schema {
+	return configSchema
+}
+
+func (provider) NewPlugin(options plugins.PluginOptions) (plugins.Plugin, error) {
+	keys := make(map[string]string)
+	schematypes.MustValidateAndMap(configSchema, options.Config, &keys)
+
+	// Print a neat message to make debugging config easier.
+	// Presumably, config files inject stuff into this section using
+	// transforms, so it's nice to have some log.
+	for k, v := range keys {
+		options.Monitor.Infof("Prefixing task logs: '%s' = '%s'", k, v)
+	}
+
+	return &plugin{
+		keys: keys,
+	}, nil
+}
+
+func (p *plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
+	keys := map[string]string{
+		"TaskId": options.TaskContext.TaskID,
+		"RunId":  strconv.Itoa(options.TaskContext.RunID),
+	}
+	// Construct list of all keys (so we can sort it)
+	var allKeys []string
+	for k := range keys {
+		allKeys = append(allKeys, k)
+	}
+	for k := range p.keys {
+		if !stringContains(allKeys, k) {
+			allKeys = append(allKeys, k)
+		} else {
+			debug("overwriting: %s", k)
+		}
+	}
+	// Sort list of allKeys (to ensure consistency)
+	sort.Strings(allKeys)
+
+	// Print keys to task log
+	for _, k := range allKeys {
+		v, ok := p.keys[k]
+		if !ok {
+			v = keys[k]
+		}
+
+		options.TaskContext.Log(fmt.Sprintf("%s: %s", k, v))
+	}
+
+	// Return a plugin that does nothing
+	return plugins.TaskPluginBase{}, nil
+}
+
+func stringContains(list []string, element string) bool {
+	for _, e := range list {
+		if e == element {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/logprefix/logprefix_test.go
+++ b/plugins/logprefix/logprefix_test.go
@@ -1,0 +1,78 @@
+package logprefix
+
+import (
+	"testing"
+
+	"github.com/taskcluster/taskcluster-worker/plugins/plugintest"
+)
+
+func TestLogPrefixAddTaskID(*testing.T) {
+	plugintest.Case{
+		Payload: `{
+			"delay": 0,
+			"function": "true",
+			"argument": ""
+		}`,
+		TaskID:        "Ghv98GSxQL2dR7eD8hXbMw",
+		PluginConfig:  `{}`,
+		Plugin:        "logprefix",
+		PluginSuccess: true,
+		EngineSuccess: true,
+		MatchLog:      "Ghv98GSxQL2dR7eD8hXbMw",
+	}.Test()
+}
+
+func TestLogPrefixConfiguredKeys(*testing.T) {
+	plugintest.Case{
+		Payload: `{
+			"delay": 0,
+			"function": "true",
+			"argument": ""
+		}`,
+		TaskID: "Ghv98GSxQL2dR7eD8hXbMw",
+		PluginConfig: `{
+			"CPU": "intel"
+		}`,
+		Plugin:        "logprefix",
+		PluginSuccess: true,
+		EngineSuccess: true,
+		MatchLog:      "CPU",
+	}.Test()
+}
+
+func TestLogPrefixConfiguredValues(*testing.T) {
+	plugintest.Case{
+		Payload: `{
+			"delay": 0,
+			"function": "true",
+			"argument": ""
+		}`,
+		TaskID: "Ghv98GSxQL2dR7eD8hXbMw",
+		PluginConfig: `{
+			"CPU": "intel"
+		}`,
+		Plugin:        "logprefix",
+		PluginSuccess: true,
+		EngineSuccess: true,
+		MatchLog:      "intel",
+	}.Test()
+}
+
+func TestLogPrefixOverwriteBuiltin(*testing.T) {
+	plugintest.Case{
+		Payload: `{
+			"delay": 0,
+			"function": "true",
+			"argument": ""
+		}`,
+		TaskID: "Ghv98GSxQL2dR7eD8hXbMw",
+		PluginConfig: `{
+			"TaskId": "fakeTaskId"
+		}`,
+		Plugin:        "logprefix",
+		PluginSuccess: true,
+		EngineSuccess: true,
+		MatchLog:      "fakeTaskId",
+		NotMatchLog:   "Ghv98GSxQL2dR7eD8hXbMw",
+	}.Test()
+}


### PR DESCRIPTION
It's possible to inject additional things through configuration....

We can work on adding more built-ins, but since not all workers have a public IPs, etc. I don't know how much makes sense...

Maybe it makes sense to add things like worker: taskcluster-worker, and engine: ...
Perhaps even git revision of taskcluster-worker, but so far we don't have this easily available in the source...

Note: config makes it easy to add dynamic things like publicIP using the transforms... we already use them for things like public IP on packet.net.

As for log footers I suggest these are added by the engines.. and that they aren't exactly footers... but more like a message showing the exit code...