### PR TITLE
Fix issue #280 - Add count of TasksSinceBoot to logprefix

### DIFF
--- a/plugins/logprefix/logprefix.go
+++ b/plugins/logprefix/logprefix.go
@@ -61,10 +61,10 @@ func (p *plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskP
 	taskCount := atomic.AddInt64(&p.taskCount, 1) - 1
 
 	keys := map[string]string{
-		"TaskId":         options.TaskContext.TaskID,
-		"RunId":          strconv.Itoa(options.TaskContext.RunID),
-		"HostBootTime":   p.bootTime,
-		"TasksSinceBoot": strconv.FormatInt(taskCount, 10),
+		"TaskId":            options.TaskContext.TaskID,
+		"RunId":             strconv.Itoa(options.TaskContext.RunID),
+		"HostBootTime":      p.bootTime,
+		"TasksSinceStartup": strconv.FormatInt(taskCount, 10),
 	}
 
 	// Construct list of all keys (so we can sort it)

--- a/plugins/logprefix/logprefix_test.go
+++ b/plugins/logprefix/logprefix_test.go
@@ -22,6 +22,22 @@ func TestLogPrefixAddTaskID(*testing.T) {
 	}.Test()
 }
 
+func TestLogPrefixAddTaskCount(*testing.T) {
+	plugintest.Case{
+		Payload: `{
+			"delay": 0,
+			"function": "true",
+			"argument": ""
+		}`,
+		TaskID:        "Ghv98GSxQL2dR7eD8hXbMw",
+		PluginConfig:  `{}`,
+		Plugin:        "logprefix",
+		PluginSuccess: true,
+		EngineSuccess: true,
+		MatchLog:      "TasksSinceBoot",
+	}.Test()
+}
+
 func TestLogPrefixConfiguredKeys(*testing.T) {
 	plugintest.Case{
 		Payload: `{


### PR DESCRIPTION
I'm sure you and gps will find this useful...

Ps. if you have a prettier or more obvious name that `TasksSinceBoot` I'm very interested, I'm not entirely happy with the name...