### PR TITLE
Refactor worker to use webhooktunnel

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,57 @@
+nsforms:
+  - env
+  - hostcredentials
+  - secrets
+config:
+  credentials:
+    clientId: 'email/chinmaykousik1@gmail.com/test-worker'
+    accessToken: 'sQtg16XeQm67brCkRvGcEQC5V6F1QOT3So4fFSZV97Ow'
+  engine:           native
+  engines:
+    native:
+      createUser: false
+  plugins:
+    disabled: []
+    artifacts: {}
+    livelog: {}
+    success: {}
+    reboot:
+      maxLifeCycle: '96 hours'
+      allowTaskReboots: true
+    # tasks can never take more than 96 hours (but typically are limited by their own maxRunTime)
+    maxruntime:
+      maxRunTime: '96 hours'
+      perTaskLimit: allow
+    watchdog: {}
+    logprefix:
+      hostname: dummy-worker-*
+      workerType: dummy-worker-*
+      workerGroup: dummy-worker-*
+    env:
+      extra:
+        PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        # we probably don't need the remainder
+        TMPDIR: ./tmp
+        SHELL: '/bin/bash'
+        LANG: 'en_US.UTF-8'
+        LC_ALL: 'en_US.UTF-8'
+        XPC_FLAGS: '0x0'
+        XPC_SERVICE_NAME: '0'
+  queueBaseUrl:     https://queue.taskcluster.net/v1
+  worker:
+    provisionerId:    test-dummy-provisioner
+    workerType :      dummy-worker-50
+    workerGroup:      test-dummy-workers
+    workerId:         dummy-worker-50
+    pollingInterval:  10
+    reclaimOffset:    120
+    minimumReclaimDelay: 30
+    concurrency: 1
+  temporaryFolder:  /var/tmp/tc-worker-tmp
+  webHookServer:
+    provider: webhooktunnel
+  minimumDiskSpace:   10000000  # 10 GB
+  minimumMemory:      1000000   # 1 GB
+  monitor:
+    project: test-dummy-worker
+    logLevel: info

--- a/examples/webhooktunnel-example-config.yml
+++ b/examples/webhooktunnel-example-config.yml
@@ -50,8 +50,6 @@ config:
   temporaryFolder:  /var/tmp/tc-worker-tmp
   webHookServer:
     provider: webhooktunnel
-    proxyUrl: 'ws://...'
-    webhooktunnelSecret: test-secret
   minimumDiskSpace:   10000000  # 10 GB
   minimumMemory:      1000000   # 1 GB
   monitor:

--- a/examples/webhooktunnel-example-config.yml
+++ b/examples/webhooktunnel-example-config.yml
@@ -1,0 +1,59 @@
+nsforms:
+  - env
+  - hostcredentials
+  - secrets
+config:
+  credentials:
+    clientId: '...'
+    accessToken: '...'
+  engine:           native
+  engines:
+    native:
+      createUser: false
+  plugins:
+    disabled: []
+    artifacts: {}
+    livelog: {}
+    success: {}
+    reboot:
+      maxLifeCycle: '96 hours'
+      allowTaskReboots: true
+    # tasks can never take more than 96 hours (but typically are limited by their own maxRunTime)
+    maxruntime:
+      maxRunTime: '96 hours'
+      perTaskLimit: allow
+    watchdog: {}
+    logprefix:
+      hostname: dummy-worker-*
+      workerType: dummy-worker-*
+      workerGroup: dummy-worker-*
+    env:
+      extra:
+        PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        # we probably don't need the remainder
+        TMPDIR: ./tmp
+        SHELL: '/bin/bash'
+        LANG: 'en_US.UTF-8'
+        LC_ALL: 'en_US.UTF-8'
+        XPC_FLAGS: '0x0'
+        XPC_SERVICE_NAME: '0'
+  queueBaseUrl:     https://queue.taskcluster.net/v1
+  worker:
+    provisionerId:    test-dummy-provisioner
+    workerType :      dummy-worker-50
+    workerGroup:      test-dummy-workers
+    workerId:         dummy-worker-50
+    pollingInterval:  10
+    reclaimOffset:    120
+    minimumReclaimDelay: 30
+    concurrency: 1
+  temporaryFolder:  /var/tmp/tc-worker-tmp
+  webHookServer:
+    provider: webhooktunnel
+    proxyUrl: 'ws://...'
+    webhooktunnelSecret: test-secret
+  minimumDiskSpace:   10000000  # 10 GB
+  minimumMemory:      1000000   # 1 GB
+  monitor:
+    project: test-dummy-worker
+    logLevel: info

--- a/runtime/webhookserver/config.go
+++ b/runtime/webhookserver/config.go
@@ -6,7 +6,6 @@ import (
 
 	schematypes "github.com/taskcluster/go-schematypes"
 	"github.com/taskcluster/taskcluster-client-go"
-	"github.com/taskcluster/taskcluster-client-go/auth"
 	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
@@ -120,12 +119,7 @@ func NewServer(config interface{}, credentials *tcclient.Credentials) (Server, e
 		return NewLocalTunnel(c.BaseURL)
 	}
 	if schematypes.MustMap(webhooktunnelConfigSchema, config, &c) == nil {
-		authCl := auth.New(credentials)
-		whresp, err := authCl.WebhooktunnelToken()
-		if err != nil {
-			return nil, err
-		}
-		s, err := NewWebhookTunnel(whresp)
+		s, err := NewWebhookTunnel(credentials)
 		return s, err
 	}
 	if schematypes.MustMap(statelessDNSConfigSchema, config, &c) == nil {

--- a/runtime/webhookserver/webhooktunnel.go
+++ b/runtime/webhookserver/webhooktunnel.go
@@ -1,0 +1,93 @@
+package webhookserver
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/taskcluster/slugid-go/slugid"
+	"github.com/taskcluster/webhooktunnel/whclient"
+)
+
+func genWebhooktunnelAuthorizer(secret string) whclient.Authorizer {
+	return func(id string) (string, error) {
+		now := time.Now()
+		expires := now.Add(30 * 24 * time.Hour)
+		token := jwt.New(jwt.SigningMethodHS256)
+		token.Claims.(jwt.MapClaims)["iat"] = now.Unix() - 300
+		token.Claims.(jwt.MapClaims)["exp"] = expires.Unix()
+		token.Claims.(jwt.MapClaims)["nbf"] = now.Unix() - 300
+
+		token.Claims.(jwt.MapClaims)["tid"] = id
+		tokenString, err := token.SignedString([]byte(secret))
+		return tokenString, err
+	}
+}
+
+// WebhookTunnel
+type WebhookTunnel struct {
+	m        sync.RWMutex
+	handlers map[string]http.Handler
+	// url is assigned when the client connects to the proxy
+	client *whclient.Client
+}
+
+// NewWebhookTunnel returns a pointer to a new WebhookTunnel instance
+func NewWebhookTunnel(workerID string, proxyAddr string, authorizer whclient.Authorizer) (*WebhookTunnel, error) {
+	client, err := whclient.New(whclient.Config{
+		ID:        workerID,
+		ProxyAddr: proxyAddr,
+		Authorize: authorizer,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	wt := &WebhookTunnel{
+		handlers: make(map[string]http.Handler),
+		client:   client,
+	}
+
+	go http.Serve(wt.client, http.HandlerFunc(wt.handle))
+	return wt, nil
+}
+
+// AttachHook adds a new webhook to the server
+func (wt *WebhookTunnel) AttachHook(handler http.Handler) (string, func()) {
+	id := slugid.Nice()
+	wt.m.Lock()
+	wt.handlers[id] = handler
+	wt.m.Unlock()
+
+	url := wt.client.URL() + "/" + id + "/"
+	detach := func() {
+		wt.m.Lock()
+		defer wt.m.Unlock()
+		delete(wt.handlers, id)
+	}
+
+	return url, detach
+}
+
+// Stop will close the webhooktunnel client
+func (wt *WebhookTunnel) Stop() {
+	_ = wt.client.Close()
+}
+
+func (wt *WebhookTunnel) handle(w http.ResponseWriter, r *http.Request) {
+	id, path := r.URL.Path[1:23], r.URL.Path[23:]
+
+	wt.m.RLock()
+	handler, ok := wt.handlers[id]
+	wt.m.RUnlock()
+
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	r.URL.Path = path
+	handler.ServeHTTP(w, r)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -360,16 +360,16 @@
 			"revisionTime": "2017-02-22T01:37:00Z"
 		},
 		{
-			"checksumSHA1": "/D5Zh31yiQafcHoXxdfU8FErLM4=",
+			"checksumSHA1": "dK3vEsrwRHwQbmlEmIIGzlZm29I=",
 			"path": "github.com/taskcluster/taskcluster-client-go",
-			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
-			"revisionTime": "2017-04-13T22:51:09Z"
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
-			"checksumSHA1": "mUzvuAzVrPU0206K5ti5q/sURck=",
+			"checksumSHA1": "DA5jpMoJqpZr+pBnZpZtG+FYSzo=",
 			"path": "github.com/taskcluster/taskcluster-client-go/auth",
-			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
-			"revisionTime": "2017-04-13T22:51:09Z"
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
 			"checksumSHA1": "R32NrZ6Q3DDlu+LNdi4AnnjTsAg=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -396,16 +396,16 @@
 			"revisionTime": "2017-06-29T16:13:10Z"
 		},
 		{
-			"checksumSHA1": "IHlE4TYdfJIcOye/j5pAT3Ud8ho=",
+			"checksumSHA1": "NorQF5CSKrkTGPq34EsRI44xCXI=",
 			"path": "github.com/taskcluster/webhooktunnel/whclient",
-			"revision": "6af62b541931c916b61ca5649f49a78579d3cc7f",
-			"revisionTime": "2017-06-29T16:13:10Z"
+			"revision": "049796898bd756a92141522d21356d9fba42eb19",
+			"revisionTime": "2017-07-05T22:51:22Z"
 		},
 		{
-			"checksumSHA1": "s7KvYNX1JQgYMeuz6h8wAxenWMs=",
+			"checksumSHA1": "pgfTziE0vPP0YiySU+ZAqIFJSQ0=",
 			"path": "github.com/taskcluster/webhooktunnel/wsmux",
-			"revision": "6af62b541931c916b61ca5649f49a78579d3cc7f",
-			"revisionTime": "2017-06-29T16:13:10Z"
+			"revision": "049796898bd756a92141522d21356d9fba42eb19",
+			"revisionTime": "2017-07-05T22:51:22Z"
 		},
 		{
 			"checksumSHA1": "Jggs+SsefVhBtVaWOqlFnsXICkk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -390,22 +390,34 @@
 			"revisionTime": "2017-04-13T22:51:09Z"
 		},
 		{
-			"checksumSHA1": "t6eOsjNEsMwHWPfZIuMAx3A+DFU=",
-			"path": "github.com/taskcluster/webhooktunnel/util",
-			"revision": "6af62b541931c916b61ca5649f49a78579d3cc7f",
-			"revisionTime": "2017-06-29T16:13:10Z"
+			"checksumSHA1": "Ovethd0h0S1L+6k28lqJyYXTmuY=",
+			"path": "github.com/taskcluster/webhooktunnel",
+			"revision": "8a82e7eea9a1b31168147c69a82b649ae3d90728",
+			"revisionTime": "2017-07-21T18:25:03Z"
 		},
 		{
-			"checksumSHA1": "NorQF5CSKrkTGPq34EsRI44xCXI=",
+			"checksumSHA1": "t6eOsjNEsMwHWPfZIuMAx3A+DFU=",
+			"path": "github.com/taskcluster/webhooktunnel/util",
+			"revision": "8a82e7eea9a1b31168147c69a82b649ae3d90728",
+			"revisionTime": "2017-07-21T18:25:03Z"
+		},
+		{
+			"checksumSHA1": "HqyG247A/t1I3lD/VVlZ5AjtPaA=",
 			"path": "github.com/taskcluster/webhooktunnel/whclient",
-			"revision": "049796898bd756a92141522d21356d9fba42eb19",
-			"revisionTime": "2017-07-05T22:51:22Z"
+			"revision": "8a82e7eea9a1b31168147c69a82b649ae3d90728",
+			"revisionTime": "2017-07-21T18:25:03Z"
+		},
+		{
+			"checksumSHA1": "O3NRnHZlxNw02ofW+ZtY3KPzakM=",
+			"path": "github.com/taskcluster/webhooktunnel/whproxy",
+			"revision": "8a82e7eea9a1b31168147c69a82b649ae3d90728",
+			"revisionTime": "2017-07-21T18:25:03Z"
 		},
 		{
 			"checksumSHA1": "pgfTziE0vPP0YiySU+ZAqIFJSQ0=",
 			"path": "github.com/taskcluster/webhooktunnel/wsmux",
-			"revision": "049796898bd756a92141522d21356d9fba42eb19",
-			"revisionTime": "2017-07-05T22:51:22Z"
+			"revision": "8a82e7eea9a1b31168147c69a82b649ae3d90728",
+			"revisionTime": "2017-07-21T18:25:03Z"
 		},
 		{
 			"checksumSHA1": "Jggs+SsefVhBtVaWOqlFnsXICkk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -154,10 +154,10 @@
 			"revisionTime": "2016-07-29T03:38:29Z"
 		},
 		{
-			"checksumSHA1": "klfNfdEPsrWYLps2qBkLgfJsNYI=",
+			"checksumSHA1": "hEnH6sgR83Qfx7UNnphNNlelmj0=",
 			"path": "github.com/gorilla/websocket",
-			"revision": "2d1e4548da234d9cb742cc3628556fef86aafbac",
-			"revisionTime": "2016-09-12T15:30:41Z"
+			"revision": "ea4d1f681babbce9545c9c5f3d5194a789c89f5b",
+			"revisionTime": "2017-06-20T19:01:03Z"
 		},
 		{
 			"checksumSHA1": "IyHKjCdrqRRLTAKBHEh6wUhkgiI=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -64,6 +64,12 @@
 			"revisionTime": "2015-08-27T20:02:57Z"
 		},
 		{
+			"checksumSHA1": "2Fy1Y6Z3lRRX1891WF/+HT4XS2I=",
+			"path": "github.com/dgrijalva/jwt-go",
+			"revision": "2268707a8f0843315e2004ee4f1d021dc08baedf",
+			"revisionTime": "2017-02-01T22:58:49Z"
+		},
+		{
 			"checksumSHA1": "vMyAhiOqLvwMPXNaRrSfSvJp1dA=",
 			"path": "github.com/digitalocean/go-libvirt",
 			"revision": "754c709cd3e8b44df38586b87d3bb13366380047",
@@ -382,6 +388,24 @@
 			"path": "github.com/taskcluster/taskcluster-client-go/secrets",
 			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
 			"revisionTime": "2017-04-13T22:51:09Z"
+		},
+		{
+			"checksumSHA1": "t6eOsjNEsMwHWPfZIuMAx3A+DFU=",
+			"path": "github.com/taskcluster/webhooktunnel/util",
+			"revision": "6af62b541931c916b61ca5649f49a78579d3cc7f",
+			"revisionTime": "2017-06-29T16:13:10Z"
+		},
+		{
+			"checksumSHA1": "IHlE4TYdfJIcOye/j5pAT3Ud8ho=",
+			"path": "github.com/taskcluster/webhooktunnel/whclient",
+			"revision": "6af62b541931c916b61ca5649f49a78579d3cc7f",
+			"revisionTime": "2017-06-29T16:13:10Z"
+		},
+		{
+			"checksumSHA1": "s7KvYNX1JQgYMeuz6h8wAxenWMs=",
+			"path": "github.com/taskcluster/webhooktunnel/wsmux",
+			"revision": "6af62b541931c916b61ca5649f49a78579d3cc7f",
+			"revisionTime": "2017-06-29T16:13:10Z"
 		},
 		{
 			"checksumSHA1": "Jggs+SsefVhBtVaWOqlFnsXICkk=",

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -81,7 +81,7 @@ func New(config interface{}) (w *Worker, err error) {
 
 	// Create webhookserver
 	if c.WebHookServer != nil {
-		w.webhookserver, err = webhookserver.NewServer(c.WebHookServer)
+		w.webhookserver, err = webhookserver.NewServer(c.WebHookServer, &c.Credentials)
 		if err != nil {
 			w.monitor.ReportError(err, "worker.New() failed to setup webhookserver")
 			err = runtime.ErrFatalInternalError


### PR DESCRIPTION
The worker can use `webhooktunnelToken` auth endpoint to authenticate and create a tunnel using webhooktunnel proxy.