### PR TITLE
Added Webhooktunnel Support

### DIFF
--- a/runtime/webhookserver/config.go
+++ b/runtime/webhookserver/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-worker/runtime/util"
 )
 
@@ -19,6 +20,13 @@ var localtunnelConfigSchema = schematypes.Object{
 	Properties: schematypes.Properties{
 		"provider": schematypes.StringEnum{Options: []string{"localtunnel"}},
 		"baseUrl":  schematypes.URI{},
+	},
+	Required: []string{"provider"},
+}
+
+var webhooktunnelConfigSchema = schematypes.Object{
+	Properties: schematypes.Properties{
+		"provider": schematypes.StringEnum{Options: []string{"webhooktunnel"}},
 	},
 	Required: []string{"provider"},
 }
@@ -74,6 +82,7 @@ var ConfigSchema schematypes.Schema = schematypes.OneOf{
 	localhostConfigSchema,
 	localtunnelConfigSchema,
 	statelessDNSConfigSchema,
+	webhooktunnelConfigSchema,
 }
 
 // Server abstracts various WebHookServer implementations
@@ -84,9 +93,9 @@ type Server interface {
 
 // NewServer returns a Server implementing WebHookServer, choosing the
 // implemetation based on the configuration passed in.
-//
 // Config passed must match ConfigSchema.
-func NewServer(config interface{}) (Server, error) {
+// Credentials are required if the WebhookServer is Webhooktunnel.
+func NewServer(config interface{}, credentials *tcclient.Credentials) (Server, error) {
 	var c struct {
 		Provider           string        `json:"provider"`
 		ServerIP           string        `json:"serverIp"`
@@ -99,6 +108,7 @@ func NewServer(config interface{}) (Server, error) {
 		StatelessDNSDomain string        `json:"statelessDNSDomain"`
 		Expiration         time.Duration `json:"expiration"`
 		BaseURL            string        `json:"baseUrl"`
+		ProxyURL           string        `json:"proxyUrl"`
 	}
 	schematypes.MustValidate(ConfigSchema, config)
 	if schematypes.MustMap(localhostConfigSchema, config, &c) == nil {
@@ -106,6 +116,10 @@ func NewServer(config interface{}) (Server, error) {
 	}
 	if schematypes.MustMap(localtunnelConfigSchema, config, &c) == nil {
 		return NewLocalTunnel(c.BaseURL)
+	}
+	if schematypes.MustMap(webhooktunnelConfigSchema, config, &c) == nil {
+		s, err := NewWebhookTunnel(credentials)
+		return s, err
 	}
 	if schematypes.MustMap(statelessDNSConfigSchema, config, &c) == nil {
 		s, err := NewLocalServer(

--- a/runtime/webhookserver/doc.go
+++ b/runtime/webhookserver/doc.go
@@ -2,9 +2,16 @@
 // interface. Which allows attachment and detachment for web-hooks to an
 // internet exposed server.
 //
-// The simpliest implementation is to listen on a public port and forward
+// The simplest implementation is to listen on a public port and forward
 // request from there. But abstracting this as an interface allows us to
 // implement different approaches like to ngrok, if we ever need to run the
 // worker in an environment where machines can't be exposed to the internet.
 // Old windows machines in a data center seems like a plausible use-case.
+//
+// Webhooktunnel is an implementation of webhookserver which allows exposing
+// endpoints without having to open any ports, public or otherwise. It uses
+// webhookclient to connect to the proxy and multiplexes streams over websocket,
+// and exposes a net.Listener interface which can be used by http.Server. This
+// results in a more secure worker.
+// Webhooktunnel requires TC credentials.
 package webhookserver

--- a/runtime/webhookserver/webhooktunnel.go
+++ b/runtime/webhookserver/webhooktunnel.go
@@ -1,0 +1,94 @@
+package webhookserver
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/taskcluster/slugid-go/slugid"
+	"github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/auth"
+	"github.com/taskcluster/webhooktunnel/whclient"
+)
+
+// WebhookTunnel wraps a whclient instance as a WebHookServer
+type WebhookTunnel struct {
+	m        sync.RWMutex
+	handlers map[string]http.Handler
+	// url is assigned when the client connects to the proxy
+	client *whclient.Client
+}
+
+// NewWebhookTunnel returns a pointer to a new WebhookTunnel instance
+func NewWebhookTunnel(credentials *tcclient.Credentials) (*WebhookTunnel, error) {
+	configurer := func() (whclient.Config, error) {
+		authClient := auth.New(credentials)
+		whresp, err := authClient.WebhooktunnelToken()
+		if err != nil {
+			return whclient.Config{}, errors.New("could not get token from tc-auth")
+		}
+
+		return whclient.Config{
+			ID:        whresp.TunnelID,
+			ProxyAddr: whresp.ProxyURL,
+			Token:     whresp.Token,
+		}, nil
+	}
+
+	client, err := whclient.New(configurer)
+	if err == whclient.ErrAuthFailed {
+		client, err = whclient.New(configurer)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	wt := &WebhookTunnel{
+		handlers: make(map[string]http.Handler),
+		client:   client,
+	}
+
+	go func() {
+		_ = http.Serve(wt.client, http.HandlerFunc(wt.handle))
+	}()
+	return wt, nil
+}
+
+// AttachHook adds a new webhook to the server
+func (wt *WebhookTunnel) AttachHook(handler http.Handler) (string, func()) {
+	id := slugid.Nice()
+	wt.m.Lock()
+	wt.handlers[id] = handler
+	wt.m.Unlock()
+
+	url := wt.client.URL() + "/" + id + "/"
+	detach := func() {
+		wt.m.Lock()
+		defer wt.m.Unlock()
+		delete(wt.handlers, id)
+	}
+
+	return url, detach
+}
+
+// Stop will close the webhooktunnel client
+func (wt *WebhookTunnel) Stop() {
+	_ = wt.client.Close()
+}
+
+func (wt *WebhookTunnel) handle(w http.ResponseWriter, r *http.Request) {
+	id, path := r.URL.Path[1:23], r.URL.Path[23:]
+
+	wt.m.RLock()
+	handler, ok := wt.handlers[id]
+	wt.m.RUnlock()
+
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	r.URL.Path = path
+	handler.ServeHTTP(w, r)
+}

--- a/runtime/webhookserver/webhooktunnel.go
+++ b/runtime/webhookserver/webhooktunnel.go
@@ -78,6 +78,12 @@ func (wt *WebhookTunnel) Stop() {
 }
 
 func (wt *WebhookTunnel) handle(w http.ResponseWriter, r *http.Request) {
+	// URL Path format: "/" + slugid(22 characters) + <endpoint>
+	if len(r.URL.Path) < 24 || r.URL.Path[23] != '/' {
+		http.NotFound(w, r)
+		return
+	}
+
 	id, path := r.URL.Path[1:23], r.URL.Path[23:]
 
 	wt.m.RLock()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -386,32 +386,32 @@
 		{
 			"checksumSHA1": "SeU/g0O6sCj2Ce+hdBHMDWlL3oc=",
 			"path": "github.com/taskcluster/webhooktunnel",
-			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
-			"revisionTime": "2017-08-08T17:31:32Z"
+			"revision": "c59d83491f27810c1dedaebf2aaa2ddf0a48f8e6",
+			"revisionTime": "2017-08-08T17:22:17Z"
 		},
 		{
 			"checksumSHA1": "FKwSb/1dCkSpzF2Q/ZZa+Pxm4Zk=",
 			"path": "github.com/taskcluster/webhooktunnel/util",
-			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
-			"revisionTime": "2017-08-08T17:31:32Z"
+			"revision": "c59d83491f27810c1dedaebf2aaa2ddf0a48f8e6",
+			"revisionTime": "2017-08-08T17:22:17Z"
 		},
 		{
 			"checksumSHA1": "FrNIn7iR5eAQYfQcGhkJX0NxIn4=",
 			"path": "github.com/taskcluster/webhooktunnel/whclient",
-			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
-			"revisionTime": "2017-08-08T17:31:32Z"
+			"revision": "c59d83491f27810c1dedaebf2aaa2ddf0a48f8e6",
+			"revisionTime": "2017-08-08T17:22:17Z"
 		},
 		{
 			"checksumSHA1": "47dVYIJIu0cxwRU4RaS3dvxZ/Ew=",
 			"path": "github.com/taskcluster/webhooktunnel/whproxy",
-			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
-			"revisionTime": "2017-08-08T17:31:32Z"
+			"revision": "c59d83491f27810c1dedaebf2aaa2ddf0a48f8e6",
+			"revisionTime": "2017-08-08T17:22:17Z"
 		},
 		{
 			"checksumSHA1": "2FPvdPnWvqICT2OVgyu8HIXvE90=",
 			"path": "github.com/taskcluster/webhooktunnel/wsmux",
-			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
-			"revisionTime": "2017-08-08T17:31:32Z"
+			"revision": "c59d83491f27810c1dedaebf2aaa2ddf0a48f8e6",
+			"revisionTime": "2017-08-08T17:22:17Z"
 		},
 		{
 			"checksumSHA1": "Jggs+SsefVhBtVaWOqlFnsXICkk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -384,6 +384,37 @@
 			"revisionTime": "2017-04-13T22:51:09Z"
 		},
 		{
+			"checksumSHA1": "SeU/g0O6sCj2Ce+hdBHMDWlL3oc=",
+			"path": "github.com/taskcluster/webhooktunnel",
+			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
+			"revisionTime": "2017-08-08T17:31:32Z"
+		},
+		{
+			"checksumSHA1": "FKwSb/1dCkSpzF2Q/ZZa+Pxm4Zk=",
+			"origin": "github.com/taskcluster/taskcluster-worker/vendor/github.com/taskcluster/webhooktunnel/util",
+			"path": "github.com/taskcluster/webhooktunnel/util",
+			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
+			"revisionTime": "2017-08-08T17:31:32Z"
+		},
+		{
+			"checksumSHA1": "FrNIn7iR5eAQYfQcGhkJX0NxIn4=",
+			"path": "github.com/taskcluster/webhooktunnel/whclient",
+			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
+			"revisionTime": "2017-08-08T17:31:32Z"
+		},
+		{
+			"checksumSHA1": "47dVYIJIu0cxwRU4RaS3dvxZ/Ew=",
+			"path": "github.com/taskcluster/webhooktunnel/whproxy",
+			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
+			"revisionTime": "2017-08-08T17:31:32Z"
+		},
+		{
+			"checksumSHA1": "2FPvdPnWvqICT2OVgyu8HIXvE90=",
+			"path": "github.com/taskcluster/webhooktunnel/wsmux",
+			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
+			"revisionTime": "2017-08-08T17:31:32Z"
+		},
+		{
 			"checksumSHA1": "Jggs+SsefVhBtVaWOqlFnsXICkk=",
 			"path": "github.com/tent/hawk-go",
 			"revision": "d4fa08268f573f25df477fedc813f26bfb833761",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -148,10 +148,10 @@
 			"revisionTime": "2016-07-29T03:38:29Z"
 		},
 		{
-			"checksumSHA1": "klfNfdEPsrWYLps2qBkLgfJsNYI=",
+			"checksumSHA1": "hEnH6sgR83Qfx7UNnphNNlelmj0=",
 			"path": "github.com/gorilla/websocket",
-			"revision": "2d1e4548da234d9cb742cc3628556fef86aafbac",
-			"revisionTime": "2016-09-12T15:30:41Z"
+			"revision": "a91eba7f97777409bc2c443f5534d41dd20c5720",
+			"revisionTime": "2017-03-19T17:27:27Z"
 		},
 		{
 			"checksumSHA1": "IyHKjCdrqRRLTAKBHEh6wUhkgiI=",
@@ -391,7 +391,6 @@
 		},
 		{
 			"checksumSHA1": "FKwSb/1dCkSpzF2Q/ZZa+Pxm4Zk=",
-			"origin": "github.com/taskcluster/taskcluster-worker/vendor/github.com/taskcluster/webhooktunnel/util",
 			"path": "github.com/taskcluster/webhooktunnel/util",
 			"revision": "dbd8372cc9a8c79f52401456748e3c7f8e78688b",
 			"revisionTime": "2017-08-08T17:31:32Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -64,6 +64,13 @@
 			"revisionTime": "2015-08-27T20:02:57Z"
 		},
 		{
+			"checksumSHA1": "2Fy1Y6Z3lRRX1891WF/+HT4XS2I=",
+			"origin": "github.com/taskcluster/taskcluster-worker/vendor/github.com/dgrijalva/jwt-go",
+			"path": "github.com/dgrijalva/jwt-go",
+			"revision": "2268707a8f0843315e2004ee4f1d021dc08baedf",
+			"revisionTime": "2017-02-01T22:58:49Z"
+		},
+		{
 			"checksumSHA1": "vMyAhiOqLvwMPXNaRrSfSvJp1dA=",
 			"path": "github.com/digitalocean/go-libvirt",
 			"revision": "754c709cd3e8b44df38586b87d3bb13366380047",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -65,7 +65,6 @@
 		},
 		{
 			"checksumSHA1": "2Fy1Y6Z3lRRX1891WF/+HT4XS2I=",
-			"origin": "github.com/taskcluster/taskcluster-worker/vendor/github.com/dgrijalva/jwt-go",
 			"path": "github.com/dgrijalva/jwt-go",
 			"revision": "2268707a8f0843315e2004ee4f1d021dc08baedf",
 			"revisionTime": "2017-02-01T22:58:49Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -354,16 +354,16 @@
 			"revisionTime": "2017-02-22T01:37:00Z"
 		},
 		{
-			"checksumSHA1": "/D5Zh31yiQafcHoXxdfU8FErLM4=",
+			"checksumSHA1": "dK3vEsrwRHwQbmlEmIIGzlZm29I=",
 			"path": "github.com/taskcluster/taskcluster-client-go",
-			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
-			"revisionTime": "2017-04-13T22:51:09Z"
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
-			"checksumSHA1": "mUzvuAzVrPU0206K5ti5q/sURck=",
+			"checksumSHA1": "DA5jpMoJqpZr+pBnZpZtG+FYSzo=",
 			"path": "github.com/taskcluster/taskcluster-client-go/auth",
-			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
-			"revisionTime": "2017-04-13T22:51:09Z"
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
 			"checksumSHA1": "R32NrZ6Q3DDlu+LNdi4AnnjTsAg=",

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -81,7 +81,7 @@ func New(config interface{}) (w *Worker, err error) {
 
 	// Create webhookserver
 	if c.WebHookServer != nil {
-		w.webhookserver, err = webhookserver.NewServer(c.WebHookServer)
+		w.webhookserver, err = webhookserver.NewServer(c.WebHookServer, &c.Credentials)
 		if err != nil {
 			w.monitor.ReportError(err, "worker.New() failed to setup webhookserver")
 			err = runtime.ErrFatalInternalError


### PR DESCRIPTION
This patch allows the worker to use webhooktunnel to
serve proxy endpoints instead of opening public ports
on the worker.

Webhooktunnel allows http to be served over multiplexed
streams over a websocket. This is exposed as a net.Listener
interface by whclient, and can be used by an http.Server.

Webhooktunnel requires TC credentials for getting an ID and
Token from tc-auth. These can be used to connect to the proxy.