### PR TITLE
use webhooktunnel [DO NOT MERGE]

### DIFF
--- a/examples/packet-config.yml
+++ b/examples/packet-config.yml
@@ -59,24 +59,7 @@ config:
     success:        {}
   temporaryFolder:  /mnt/tmp
   webHookServer:
-    provider:           stateless-dns
-    expiration:         '1 day'
-    serverIp:           {$packet: public-ipv4}
-    serverPort:         {$env: PORT, type: number}
-    networkInterface:   eth0
-    exposedPort:        {$env: PORT, type: number}
-    tlsCertificate:
-      $secret:  project/taskcluster/taskcluster-worker/stateless-dns
-      key:      certificate
-    tlsKey:
-      $secret:  project/taskcluster/taskcluster-worker/stateless-dns
-      key:      tlsKey
-    statelessDNSSecret:
-      $secret:  project/taskcluster/taskcluster-worker/stateless-dns
-      key:      secret
-    statelessDNSDomain:
-      $secret:  project/taskcluster/taskcluster-worker/stateless-dns
-      key:      domain
+    provider:       webhooktunnel
   worker:
     concurrency:          2
     minimumReclaimDelay:  30


### PR DESCRIPTION
This is deployed as: "test-dummy-provisioner/dummy-worker-packet"

Example task: https://github.com/taskcluster/taskcluster-worker/blob/0c1b2150688f12c9f8234abbc2f159de1ded45b5/.taskcluster.yml#L176-L197

Adding: `task.payload.interactive = {}` will enable interactive features.

@ckousik, let's figure out why this doesn't work...
Server logs are in papertrail under "tc-worker-ci".

It's probably easiest to test this with `taskcluster-worker shell-server` locally, and just tweak it to use webhooktunnel.. Note that `taskcluster-worker shell wss://...` works with `taskcluster-worker shell-server`