### PR TITLE
 System support groups

### DIFF
--- a/engines/native/system/process_posix.go
+++ b/engines/native/system/process_posix.go
@@ -150,7 +150,7 @@ func StartProcess(options ProcessOptions) (*Process, error) {
 		// accounts unable to execute process.
 		// If the passed owner matches the current user, we set owner to
 		// nil to allow non-root accounts to succeed.
-		if currentUser.uid == options.Owner.uid {
+		if currentUser.uid == options.Owner.uid && len(options.Groups) == 0 {
 			options.Owner = nil
 		}
 	}

--- a/engines/native/system/process_posix.go
+++ b/engines/native/system/process_posix.go
@@ -173,10 +173,15 @@ func StartProcess(options ProcessOptions) (*Process, error) {
 
 	// Set owner for the process
 	if options.Owner != nil {
+		var groups []uint32
+		for _, g := range options.Groups {
+			groups = append(groups, uint32(g.gid))
+		}
 		p.cmd.SysProcAttr = &syscall.SysProcAttr{
 			Credential: &syscall.Credential{
-				Uid: options.Owner.uid,
-				Gid: options.Owner.gid,
+				Uid:    options.Owner.uid,
+				Gid:    options.Owner.gid,
+				Groups: groups,
 			},
 		}
 	}

--- a/engines/native/system/process_windows.go
+++ b/engines/native/system/process_windows.go
@@ -85,6 +85,9 @@ func StartProcess(options ProcessOptions) (*Process, error) {
 	if options.Owner != nil {
 		panic("Not implemented: Support for creating processes under a different user is not yet implemented on windows")
 	}
+	if len(options.Groups) > 0 {
+		panic("Not implemented: Support for setting groups on windows is not implemented yet")
+	}
 
 	// Start the process
 	p.cmd.Stdin = options.Stdin

--- a/engines/native/system/system.go
+++ b/engines/native/system/system.go
@@ -9,6 +9,7 @@ type ProcessOptions struct {
 	Environment   map[string]string // Environment variables
 	WorkingFolder string            // Working directory, if not HOME
 	Owner         *User             // User to run process as, nil to use current
+	Groups        []*Group          // Groups to run the process with, only if user is set
 	Stdin         io.ReadCloser     // Stream with stdin, or nil if nothing
 	Stdout        io.WriteCloser    // Stream for stdout
 	Stderr        io.WriteCloser    // Stream for stderr, or nil if using stdout

--- a/engines/native/system/user_darwin.go
+++ b/engines/native/system/user_darwin.go
@@ -238,3 +238,8 @@ func isDuplicateID(d dscl, name string, id int) (bool, error) {
 
 	return n > 1, nil
 }
+
+// Groups returns a list of user groups
+func (u *User) Groups() []*Group {
+	panic("user.Groups() is not implemented on OS X yet")
+}

--- a/engines/native/system/user_linux.go
+++ b/engines/native/system/user_linux.go
@@ -171,3 +171,24 @@ func (u *User) Name() string {
 func (u *User) Home() string {
 	return u.homeFolder
 }
+
+// Groups returns a list of user groups
+func (u *User) Groups() []*Group {
+	usr, err := user.LookupId(strconv.Itoa(int(u.uid)))
+	if err != nil {
+		panic(errors.Wrap(err, "failed to find user when looking up groups"))
+	}
+	grps, err := usr.GroupIds()
+	if err != nil {
+		panic(errors.Wrap(err, "failed to list groups from user"))
+	}
+	var groups []*Group
+	for _, gid := range grps {
+		g, err := strconv.Atoi(gid)
+		if err != nil {
+			panic("expected group ids to be integers on linux")
+		}
+		groups = append(groups, &Group{gid: g})
+	}
+	return groups
+}

--- a/engines/native/system/user_windows.go
+++ b/engines/native/system/user_windows.go
@@ -52,3 +52,8 @@ func (u *User) Name() string {
 func (u *User) Home() string {
 	return u.homeFolder
 }
+
+// Groups returns a list of user groups
+func (u *User) Groups() []*Group {
+	panic("user.Groups() is not implemented on Windows yet")
+}


### PR DESCRIPTION
@walac, what are your thoughts here?

Should we allow specification of user groups as this PR suggests?

Or should we just embed the listing of user-groups into the `system.StartProcess` call and always set user groups to whatever groups the provider `owner` has.. I'm tempted to do this instead, as I don't see us wanting to configure user-groups here... If we really care we just give the given user what ever groups it should have in system level configuration.

What is your thoughts?

I need this fixed as right now my `worker` user has group `worker` and no other groups... Hence, it can't user docker... in system config my worker user is member of a lot of groups, but when the task is run under `system.StartProcess` it only gets the `worker` group (which is the primary group).

Given that we don't make it optional specify what group is the primary group now.. maybe we should just always pass whatever groups a user is configured to have in system config... I'm not even sure you can do per-process groups on Windows anyways...