### PR TITLE
Cache support, plugin done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       env:
         - MY_GOOS=darwin
         - MY_GOARCH=amd64
+        - DEBUG=*
     - os: linux
       env:
         - MY_GOOS=windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
       env:
         - MY_GOOS=darwin
         - MY_GOARCH=amd64
-        - DEBUG=*
     - os: linux
       env:
         - MY_GOOS=windows

--- a/commands/qemu-guest-tools/actions_test.go
+++ b/commands/qemu-guest-tools/actions_test.go
@@ -41,6 +41,10 @@ func TestGuestToolsProcessingActions(t *testing.T) {
 	}
 	environment := &runtime.Environment{
 		TemporaryStorage: storage,
+		ProvisionerID:    "dummy-provisioner",
+		WorkerType:       "dummy-worker",
+		WorkerGroup:      "dummy-tests",
+		WorkerID:         "localhost",
 	}
 
 	logTask := bytes.NewBuffer(nil)

--- a/commands/qemu-guest-tools/guesttools_test.go
+++ b/commands/qemu-guest-tools/guesttools_test.go
@@ -29,6 +29,10 @@ func TestGuestToolsSuccess(t *testing.T) {
 	environment := &runtime.Environment{
 		TemporaryStorage: storage,
 		Monitor:          mocks.NewMockMonitor(true),
+		ProvisionerID:    "dummy-provisioner",
+		WorkerType:       "dummy-worker",
+		WorkerGroup:      "dummy-tests",
+		WorkerID:         "localhost",
 	}
 
 	// platform specific hello world command
@@ -81,6 +85,10 @@ func TestGuestToolsFailed(t *testing.T) {
 	environment := &runtime.Environment{
 		TemporaryStorage: storage,
 		Monitor:          mocks.NewMockMonitor(true),
+		ProvisionerID:    "dummy-provisioner",
+		WorkerType:       "dummy-worker",
+		WorkerGroup:      "dummy-tests",
+		WorkerID:         "localhost",
 	}
 
 	// platform specific hello world command
@@ -142,6 +150,10 @@ func TestGuestToolsLiveLog(t *testing.T) {
 	}
 	environment := &runtime.Environment{
 		TemporaryStorage: storage,
+		ProvisionerID:    "dummy-provisioner",
+		WorkerType:       "dummy-worker",
+		WorkerGroup:      "dummy-tests",
+		WorkerID:         "localhost",
 	}
 
 	// platform specific hello world command
@@ -216,6 +228,10 @@ func TestGuestToolsKill(t *testing.T) {
 	environment := &runtime.Environment{
 		TemporaryStorage: storage,
 		Monitor:          mocks.NewMockMonitor(true),
+		ProvisionerID:    "dummy-provisioner",
+		WorkerType:       "dummy-worker",
+		WorkerGroup:      "dummy-tests",
+		WorkerID:         "localhost",
 	}
 
 	// platform specific hello world command

--- a/config/secrets/transform.go
+++ b/config/secrets/transform.go
@@ -10,9 +10,8 @@ package configsecrets
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/secrets"
 	"github.com/taskcluster/taskcluster-worker/config"
@@ -67,7 +66,7 @@ func (provider) Transform(cfg map[string]interface{}, monitor runtime.Monitor) e
 			value := map[string]interface{}{}
 			err = json.Unmarshal(secret.Secret, &value)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to parse response from secret, error: %s", err)
+				return nil, errors.Wrap(err, "failed to parse response from secret")
 			}
 			cache[name] = value
 		}

--- a/engines/engine.go
+++ b/engines/engine.go
@@ -89,9 +89,8 @@ type Engine interface {
 	// NewVolumeBuilder returns a VolumeBuilder for constructing a volume for this
 	// engine, the options must match the VolumeSchema() defined by this engine.
 	//
-	// This method may return ErrFeatureNotSupported, because volumes are not
-	// supported, or because it only supports building empty volumes using
-	// NewVolume().
+	// This method may return ErrFeatureNotSupported, if volumes are not supported,
+	// or if the engine only supports building empty volumes using NewVolume().
 	//
 	// Non-fatal errors: ErrFeatureNotSupported
 	NewVolumeBuilder(options interface{}) (VolumeBuilder, error)

--- a/engines/engine.go
+++ b/engines/engine.go
@@ -82,18 +82,25 @@ type Engine interface {
 	// Non-fatal errors: MalformedPayloadError, ErrMaxConcurrencyExceeded.
 	NewSandboxBuilder(options SandboxOptions) (SandboxBuilder, error)
 
-	// NewCacheFolder returns a new Volume backed by a file system folder
-	// if cache-folders folders are supported, otherwise it must return
-	// ErrFeatureNotSupported.
-	//
-	// Non-fatal errors: ErrFeatureNotSupported
-	NewCacheFolder() (Volume, error)
+	// VolumeSchema returns a JSON schema description of the volume options,
+	// accepted by this engine.
+	VolumeSchema() schematypes.Schema
 
-	// NewMemoryDisk returns a new Volume backed by a ramdisk, if ramdisks are
-	// supported, otherwise it must return ErrFeatureNotSupported.
+	// NewVolumeBuilder returns a VolumeBuilder for constructing a volume for this
+	// engine, the options must match the VolumeSchema() defined by this engine.
+	//
+	// This method may return ErrFeatureNotSupported, because volumes are not
+	// supported, or because it only supports building empty volumes using
+	// NewVolume().
 	//
 	// Non-fatal errors: ErrFeatureNotSupported
-	NewMemoryDisk() (Volume, error)
+	NewVolumeBuilder(options interface{}) (VolumeBuilder, error)
+
+	// NewVolume returns a new empty Volume, may return
+	// ErrFeatureNotSupported, if not supported.
+	//
+	// Non-fatal errors: ErrFeatureNotSupported
+	NewVolume(options interface{}) (Volume, error)
 
 	// Dispose cleans up any resources held by the engine. The engine object
 	// cannot be used after Dispose() has been called.
@@ -153,15 +160,21 @@ func (EngineBase) Capabilities() Capabilities {
 	return Capabilities{}
 }
 
-// NewCacheFolder returns ErrFeatureNotSupported indicating that the feature
+// VolumeSchema returns an empty schematypes.Object indicating no options for
+// volume creation
+func (EngineBase) VolumeSchema() schematypes.Schema {
+	return schematypes.Object{}
+}
+
+// NewVolumeBuilder returns ErrFeatureNotSupported indicating that the feature
 // isn't supported.
-func (EngineBase) NewCacheFolder() (Volume, error) {
+func (EngineBase) NewVolumeBuilder(options interface{}) (VolumeBuilder, error) {
 	return nil, ErrFeatureNotSupported
 }
 
-// NewMemoryDisk returns ErrFeatureNotSupported indicating that the feature
+// NewVolume returns ErrFeatureNotSupported indicating that the feature
 // isn't supported.
-func (EngineBase) NewMemoryDisk() (Volume, error) {
+func (EngineBase) NewVolume(options interface{}) (Volume, error) {
 	return nil, ErrFeatureNotSupported
 }
 

--- a/engines/enginetest/attachvolume.go
+++ b/engines/enginetest/attachvolume.go
@@ -53,7 +53,7 @@ func (c *VolumeTestCase) readVolume(volume engines.Volume, readOnly bool) bool {
 // TestWriteReadVolume tests that we can write and read from a volume
 func (c *VolumeTestCase) TestWriteReadVolume() {
 	c.ensureEngine()
-	volume, err := c.engine.NewCacheFolder()
+	volume, err := c.engine.NewVolume(map[string]interface{}{})
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	if !c.writeVolume(volume, false) {
@@ -70,7 +70,7 @@ func (c *VolumeTestCase) TestWriteReadVolume() {
 // TestReadEmptyVolume tests that read from empty volume doesn't work
 func (c *VolumeTestCase) TestReadEmptyVolume() {
 	c.ensureEngine()
-	volume, err := c.engine.NewCacheFolder()
+	volume, err := c.engine.NewVolume(map[string]interface{}{})
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	if c.readVolume(volume, false) {
@@ -84,7 +84,7 @@ func (c *VolumeTestCase) TestReadEmptyVolume() {
 // TestWriteToReadOnlyVolume tests that write doesn't work to a read-only volume
 func (c *VolumeTestCase) TestWriteToReadOnlyVolume() {
 	c.ensureEngine()
-	volume, err := c.engine.NewCacheFolder()
+	volume, err := c.engine.NewVolume(map[string]interface{}{})
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	c.writeVolume(volume, true)
@@ -96,7 +96,7 @@ func (c *VolumeTestCase) TestWriteToReadOnlyVolume() {
 // TestReadToReadOnlyVolume tests that we can read from a read-only volume
 func (c *VolumeTestCase) TestReadToReadOnlyVolume() {
 	c.ensureEngine()
-	volume, err := c.engine.NewCacheFolder()
+	volume, err := c.engine.NewVolume(map[string]interface{}{})
 	nilOrPanic(err, "Failed to create a new cache folder")
 	defer evalNilOrPanic(volume.Dispose, "Failed to dispose cache folder")
 	if !c.writeVolume(volume, false) {

--- a/engines/enginetest/testutils.go
+++ b/engines/enginetest/testutils.go
@@ -143,6 +143,10 @@ func newTestEnvironment() *runtime.Environment {
 		GarbageCollector: &gc.GarbageCollector{},
 		TemporaryStorage: folder,
 		Monitor:          mocks.NewMockMonitor(true),
+		ProvisionerID:    "enginetest-provisioner",
+		WorkerType:       "enginetest-worker",
+		WorkerGroup:      "enginetest-tests",
+		WorkerID:         "localhost",
 	}
 }
 

--- a/engines/mock/mockengine.go
+++ b/engines/mock/mockengine.go
@@ -34,6 +34,18 @@ func (e engineProvider) NewEngine(options engines.EngineOptions) (engines.Engine
 	if options.Environment.Monitor == nil {
 		panic("EngineOptions.Environment.Monitor is nil, this is a contract violation")
 	}
+	if options.Environment.ProvisionerID == "" {
+		panic("EngineOptions.Environment.ProvisionerID is empty string, this is a contract violation")
+	}
+	if options.Environment.WorkerType == "" {
+		panic("EngineOptions.Environment.WorkerType is empty string, this is a contract violation")
+	}
+	if options.Environment.WorkerGroup == "" {
+		panic("EngineOptions.Environment.WorkerGroup is empty string, this is a contract violation")
+	}
+	if options.Environment.WorkerID == "" {
+		panic("EngineOptions.Environment.WorkerID is empty string, this is a contract violation")
+	}
 	if options.Monitor == nil {
 		panic("EngineOptions.Monitor is nil, this is a contract violation")
 	}

--- a/engines/mock/mockengine.go
+++ b/engines/mock/mockengine.go
@@ -80,7 +80,20 @@ func (e engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.Sandb
 	}, nil
 }
 
-func (engine) NewCacheFolder() (engines.Volume, error) {
+func (engine) VolumeSchema() schematypes.Schema {
+	return schematypes.Object{}
+}
+
+func (engine) NewVolumeBuilder(options interface{}) (engines.VolumeBuilder, error) {
 	// Create a new cache folder
-	return &volume{}, nil
+	return &volume{
+		files: make(map[string]string),
+	}, nil
+}
+
+func (engine) NewVolume(options interface{}) (engines.Volume, error) {
+	// Create a new cache folder
+	return &volume{
+		files: make(map[string]string),
+	}, nil
 }

--- a/engines/mock/mockengine_test.go
+++ b/engines/mock/mockengine_test.go
@@ -14,16 +14,16 @@ var provider = &enginetest.EngineProvider{
 
 var volumeTestCase = enginetest.VolumeTestCase{
 	EngineProvider: provider,
-	Mountpoint:     "/mock/volume",
+	Mountpoint:     "mock-volume",
 	WriteVolumePayload: `{
     "delay": 0,
-    "function": "set-volume",
-    "argument": "/mock/volume"
+    "function": "write-volume",
+    "argument": "mock-volume/my-folder/my-file.txt:hello world"
   }`,
 	CheckVolumePayload: `{
     "delay": 0,
-    "function": "get-volume",
-    "argument": "/mock/volume"
+    "function": "read-volume",
+    "argument": "mock-volume/my-folder/my-file.txt"
   }`,
 }
 

--- a/engines/mock/mocksandbox.go
+++ b/engines/mock/mocksandbox.go
@@ -179,6 +179,16 @@ var functions = map[string]func(*sandbox, string) (bool, error){
 		s.context.Log(mount.volume.files[fileName])
 		return mount.volume.files[fileName] != "", nil
 	},
+	"get-url": func(s *sandbox, arg string) (bool, error) {
+		res, err := http.Get(arg)
+		if err != nil {
+			s.context.Log("Failed to get url: ", arg, " err: ", err)
+			return false, nil
+		}
+		defer res.Body.Close()
+		io.Copy(s.context.LogDrain(), res.Body)
+		return res.StatusCode == http.StatusOK, nil
+	},
 	"ping-proxy": func(s *sandbox, arg string) (bool, error) {
 		u, err := url.Parse(arg)
 		if err != nil {

--- a/engines/mock/mocksandbox.go
+++ b/engines/mock/mocksandbox.go
@@ -153,31 +153,31 @@ var functions = map[string]func(*sandbox, string) (bool, error){
 	"true":  func(s *sandbox, arg string) (bool, error) { return true, nil },
 	"false": func(s *sandbox, arg string) (bool, error) { return false, nil },
 	"write-volume": func(s *sandbox, arg string) (bool, error) {
-		// Parse arg as: <mountPoint>/<file_name>:<file_data>
+		// Parse arg as: <mountPoint>/<file_name>:<fileData>
 		args := strings.SplitN(arg, "/", 2)
-		volume_name := args[0]
+		volumeName := args[0]
 		args = strings.SplitN(args[1], ":", 2)
-		file_name := args[0]
-		file_data := args[1]
-		mount := s.mounts[volume_name]
+		fileName := args[0]
+		fileData := args[1]
+		mount := s.mounts[volumeName]
 		if mount == nil || mount.readOnly {
 			return false, nil
 		}
-		mount.volume.files[file_name] = file_data
+		mount.volume.files[fileName] = fileData
 		return true, nil
 	},
 	"read-volume": func(s *sandbox, arg string) (bool, error) {
-		// Parse arg as: <mountPoint>/<file_name>
+		// Parse arg as: <mountPoint>/<fileName>
 		args := strings.SplitN(arg, "/", 2)
-		volume_name := args[0]
-		file_name := args[1]
+		volumeName := args[0]
+		fileName := args[1]
 
-		mount := s.mounts[volume_name]
+		mount := s.mounts[volumeName]
 		if mount == nil {
 			return false, nil
 		}
-		s.context.Log(mount.volume.files[file_name])
-		return mount.volume.files[file_name] != "", nil
+		s.context.Log(mount.volume.files[fileName])
+		return mount.volume.files[fileName] != "", nil
 	},
 	"ping-proxy": func(s *sandbox, arg string) (bool, error) {
 		u, err := url.Parse(arg)

--- a/engines/mock/mockvolume.go
+++ b/engines/mock/mockvolume.go
@@ -26,7 +26,7 @@ func (w *fileWriter) Close() error {
 	w.Volume.m.Lock()
 	defer w.Volume.m.Unlock()
 
-	w.Volume.files[w.Name] = string(w.Bytes())
+	w.Volume.files[w.Name] = w.String()
 	return nil
 }
 

--- a/engines/mock/mockvolume.go
+++ b/engines/mock/mockvolume.go
@@ -1,9 +1,23 @@
 package mockengine
 
-import "github.com/taskcluster/taskcluster-worker/engines"
+import (
+	"io"
+	"os"
+
+	"github.com/taskcluster/taskcluster-worker/engines"
+)
 
 // A mock volume basically hold a bit value that can be set or cleared
 type volume struct {
 	engines.VolumeBase
-	value bool
+	engines.VolumeBuilderBase
+	files map[string]string
+}
+
+func (v *volume) BuildVolume() (engines.Volume, error) {
+	return v, nil
+}
+
+func (v *volume) WriteEntry(info os.FileInfo) (io.WriteCloser, error) {
+	return nil, nil
 }

--- a/engines/mock/mockvolume.go
+++ b/engines/mock/mockvolume.go
@@ -1,8 +1,9 @@
 package mockengine
 
 import (
+	"bytes"
 	"io"
-	"os"
+	"sync"
 
 	"github.com/taskcluster/taskcluster-worker/engines"
 )
@@ -11,13 +12,36 @@ import (
 type volume struct {
 	engines.VolumeBase
 	engines.VolumeBuilderBase
+	m     sync.Mutex
 	files map[string]string
+}
+
+type fileWriter struct {
+	*bytes.Buffer
+	Name   string
+	Volume *volume
+}
+
+func (w *fileWriter) Close() error {
+	w.Volume.m.Lock()
+	defer w.Volume.m.Unlock()
+
+	w.Volume.files[w.Name] = string(w.Bytes())
+	return nil
 }
 
 func (v *volume) BuildVolume() (engines.Volume, error) {
 	return v, nil
 }
 
-func (v *volume) WriteEntry(info os.FileInfo) (io.WriteCloser, error) {
-	return nil, nil
+func (v *volume) WriteFile(name string) io.WriteCloser {
+	return &fileWriter{
+		Buffer: bytes.NewBuffer(nil),
+		Name:   name,
+		Volume: v,
+	}
+}
+
+func (v *volume) WriteFolder(name string) error {
+	return nil
 }

--- a/engines/mock/payloadschema.go
+++ b/engines/mock/payloadschema.go
@@ -31,6 +31,7 @@ var payloadSchema = schematypes.Object{
 				"false",
 				"write-volume",
 				"read-volume",
+				"get-url",
 				"ping-proxy",
 				"write-log",
 				"write-error-log",

--- a/engines/mock/payloadschema.go
+++ b/engines/mock/payloadschema.go
@@ -29,8 +29,8 @@ var payloadSchema = schematypes.Object{
 			Options: []string{
 				"true",
 				"false",
-				"set-volume",
-				"get-volume",
+				"write-volume",
+				"read-volume",
 				"ping-proxy",
 				"write-log",
 				"write-error-log",

--- a/engines/volume.go
+++ b/engines/volume.go
@@ -1,9 +1,6 @@
 package engines
 
-import (
-	"io"
-	"os"
-)
+import "io"
 
 // The VolumeBuilder interface wraps the process of building a volume.
 // Notably, it permits writing of files and folders into the volume before it
@@ -13,15 +10,17 @@ import (
 // is invalid and resources held by it should be considered transferred or
 // released.
 type VolumeBuilder interface {
-	// Write a file or folder to the Volume being built, may return
-	// ErrFeatureNotSupported, if the kind of os.FileInfo written isn't supported.
+	// Write a folder to the volume being built.
 	//
-	// If writing a folder or other entry without content WriteEntry() may return
-	// nil instead of an io.WriteCloser. In this case the caller would
-	// receive nil, nil from the method call.
+	// Name must be a slash separated path, there is no requirement that
+	// intermediate folders have been created.
+	WriteFolder(name string) error
+
+	// Write a file to the volime being built.
 	//
-	// Non-fatal errors: ErrFeatureNotSupported
-	WriteEntry(info os.FileInfo) (io.WriteCloser, error)
+	// Name must be a slash separated path, there is no requirement that
+	// intermediate folders have been created.
+	WriteFile(name string) io.WriteCloser
 
 	// Build a volume from the information passed in.
 	//

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/taskcluster/taskcluster-worker/engines/qemu"
 	_ "github.com/taskcluster/taskcluster-worker/engines/script"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/artifacts"
+	_ "github.com/taskcluster/taskcluster-worker/plugins/cache"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/env"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/interactive"
 	_ "github.com/taskcluster/taskcluster-worker/plugins/livelog"

--- a/plugins/cache/cache.go
+++ b/plugins/cache/cache.go
@@ -1,0 +1,391 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-client-go/purgecache"
+	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/plugins"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/caching"
+	"github.com/taskcluster/taskcluster-worker/runtime/fetcher"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
+
+// Default max delay before purge-cache requests takes effect. This is in other
+// words the most out of date purge-cache requests can be.
+//
+// Note: this is a variable as it enables tests to set it zero.
+var defaultMaxPurgeCacheDelay = 3 * time.Minute
+
+type provider struct {
+	plugins.PluginProviderBase
+}
+
+type plugin struct {
+	plugins.PluginBase
+	m              sync.Mutex
+	engine         engines.Engine
+	environment    *runtime.Environment
+	monitor        runtime.Monitor
+	sharedCache    *caching.Cache
+	exclusiveCache *caching.Cache
+	lastPurged     time.Time
+	config         config
+}
+
+type taskPlugin struct {
+	plugins.TaskPluginBase
+	plugin         *plugin
+	monitor        runtime.Monitor
+	context        *runtime.TaskContext
+	payloadEntries []payloadEntry
+	cacheHandles   []*caching.Handle // pointing to *cacheVolume
+	cachesError    error
+	cachesReady    atomics.Once
+	cachesDisposed atomics.Once
+}
+
+func init() {
+	plugins.Register("cache", &provider{})
+}
+
+func (p *provider) ConfigSchema() schematypes.Schema {
+	return configSchema
+}
+
+func (p *provider) NewPlugin(options plugins.PluginOptions) (plugins.Plugin, error) {
+	var c config
+	schematypes.MustValidateAndMap(configSchema, options.Config, &c)
+	if c.MaxPurgeCacheDelay == 0 {
+		c.MaxPurgeCacheDelay = defaultMaxPurgeCacheDelay
+	}
+
+	// Added some sanity checks to ensure this plugin won't run without these.
+	// These strings should always be specified, so panic is very appropriate.
+	if options.Environment.ProvisionerID == "" {
+		panic("EngineOptions.Environment.ProvisionerID is empty string, this is a contract violation")
+	}
+	if options.Environment.WorkerType == "" {
+		panic("EngineOptions.Environment.WorkerType is empty string, this is a contract violation")
+	}
+
+	return &plugin{
+		engine:         options.Engine,
+		environment:    options.Environment,
+		monitor:        options.Monitor,
+		sharedCache:    caching.New(constructor, false, options.Environment.GarbageCollector),
+		exclusiveCache: caching.New(constructor, false, options.Environment.GarbageCollector),
+		lastPurged:     time.Now(),
+		config:         c,
+	}, nil
+}
+
+func (p *plugin) PayloadSchema() schematypes.Object {
+	return schematypes.Object{
+		Properties: schematypes.Properties{
+			"caches": schematypes.Array{
+				Items: schematypes.Object{
+					Properties: schematypes.Properties{
+						"name": schematypes.String{ // name in the cache plugin
+							Pattern: "^[\\x20-\\x7e]{1,255}$", // printable ascii
+						},
+						"mountPoint": schematypes.String{},    // path for the engine
+						"options":    p.engine.VolumeSchema(), // engine options
+						"preload":    preloadFetcher.Schema(), // data to be preloaded
+					},
+					Required: []string{"mountPoint", "options"},
+				},
+			},
+		},
+	}
+}
+
+func (p *plugin) getVolume(ctx *runtime.TaskContext, options payloadEntry) (*caching.Handle, error) {
+	readOnly := options.Name == ""
+
+	var err error
+	if options.Name != "" && !ctx.HasScopes([]string{cacheScope(options.Name)}) {
+		err = runtime.NewMalformedPayloadError(fmt.Sprintf(
+			"task.scopes must cover '%s' in-order for the task to use the '%s' cache",
+			cacheScope(options.Name), options.Name,
+		))
+		// Resolve with err
+		return nil, err
+	}
+
+	// Create a context with progress reporting capability
+	progressCtx := progressContext{ctx, options.Name}
+
+	// First we resolve the reference, if there is any
+	var ref fetcher.Reference
+	var refHash string
+	if options.Preload != nil {
+		ref, err = preloadFetcher.NewReference(&progressCtx, options.Preload)
+		if err != nil {
+			if fetcher.IsBrokenReferenceError(err) {
+				err = runtime.NewMalformedPayloadError(fmt.Sprintf(
+					"cache preloading error: %s", err.Error(),
+				))
+			} else {
+				err = errors.Wrap(err, "failed to fetch cache preload data")
+			}
+			return nil, err
+		}
+		// Check that task has scopes for the reference
+		if !ctx.HasScopes(ref.Scopes()...) {
+			if options.Name != "" {
+				err = runtime.NewMalformedPayloadError(fmt.Sprintf(
+					"Can't pre-load cache '%s' as data that requires one of the scope-sets: %s",
+					options.Name, formatScopeSetRequirements(ref.Scopes()),
+				))
+			} else {
+				err = runtime.NewMalformedPayloadError(fmt.Sprintf(
+					"Can't pre-load cache as data requires one of the scope-sets: %s",
+					formatScopeSetRequirements(ref.Scopes()),
+				))
+			}
+			// Resolve with err
+			return nil, err
+		}
+		// Find hash of reference for use in cacheOptions...
+		refHash = ref.HashKey()
+	}
+
+	// Pick a cache
+	cache := p.exclusiveCache
+	if readOnly {
+		cache = p.sharedCache
+	}
+
+	return cache.Require(&progressCtx, cacheOptions{
+		Name:               options.Name,
+		Options:            options.Options,
+		Preload:            options.Preload,
+		ReferenceHash:      refHash,
+		Reference:          ref, // Not used as part of KEY for the hash
+		InitialTaskContext: ctx, // Not used as part of KEY for the hash
+		Plugin:             p,   // Not used as part of KEY for the hash
+	})
+}
+
+func (p *plugin) PurgeCacheAsNeeded(ctx *runtime.TaskContext) {
+	// Lock for concurrent access
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	// Skip if purge-cache have been checked less than maxPurgeCacheDelay time ago
+	// make this a configuration option, defaulting to 3 minutes.
+	if time.Since(p.lastPurged) < p.config.MaxPurgeCacheDelay {
+		return
+	}
+
+	// Store now() for use as lastPurged later
+	requestTime := time.Now()
+
+	// Fetch purge-cache requests since last time purged
+	purgeCache := purgecache.New(nil)
+	if p.config.PurgeCacheBaseURL != "" {
+		purgeCache.BaseURL = p.config.PurgeCacheBaseURL
+	}
+	purgeCache.Authenticate = false
+	purgeCache.Context = ctx
+	result, err := purgeCache.PurgeRequests(
+		p.environment.ProvisionerID, p.environment.WorkerType,
+		p.lastPurged.UTC().Format("2006-01-02T15:04:05.000Z"),
+	)
+	if err != nil && err == ctx.Err() {
+		return
+	}
+	if err != nil {
+		incidentID := p.monitor.ReportWarning(err, "failed to fetch list of cache to purge from purge-cache service")
+		ctx.Log("WARNING: Failed to fetch list of cache to purge from purge-cache service, incidentID: ", incidentID)
+		ctx.Log("If cache purges were request they are being ignored, if not purges have been request this is of no implication.")
+		return
+	}
+
+	// Purge entries as instructed by request
+	filter := func(resource caching.Resource) bool {
+		cache := resource.(*cacheVolume)
+
+		for _, r := range result.Requests {
+			if r.WorkerType != p.environment.WorkerType || r.ProvisionerID != p.environment.ProvisionerID {
+				p.monitor.ReportWarning(fmt.Errorf(
+					"received a purge-cache response for a different provisionerId/workerType: %#v", r,
+				))
+				continue
+			}
+			if cache.Name == r.CacheName && cache.Created.Before(time.Time(r.Before)) {
+				p.monitor.Infof("purging cache: '%s'", cache.Name)
+				return true
+			}
+		}
+		return false
+	}
+	// Purge cache in parallel
+	util.Parallel(func() {
+		p.sharedCache.Purge(filter)
+	}, func() {
+		p.exclusiveCache.Purge(filter)
+	})
+
+	// Update the lastPurged time
+	p.lastPurged = requestTime
+}
+
+func (p *plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
+	var P struct {
+		Caches []payloadEntry `json:"caches"`
+	}
+	schematypes.MustValidateAndMap(p.PayloadSchema(), options.Payload, &P)
+
+	tp := &taskPlugin{
+		plugin:         p,
+		monitor:        options.Monitor,
+		context:        options.TaskContext,
+		payloadEntries: P.Caches,
+	}
+	go tp.cachesReady.Do(tp.getCaches)
+
+	return tp, nil
+}
+
+func (p *plugin) Dispose() error {
+	// Purge everything from caches
+	err1 := p.sharedCache.PurgeAll()
+	err2 := p.exclusiveCache.PurgeAll()
+	if err1 != nil {
+		return errors.Wrap(err1, "unable to purge cache, disposing shared resource failed")
+	}
+	return errors.Wrap(err2, "unable to purge cache, disposing exclusive resource failed")
+}
+
+func (tp *taskPlugin) getCaches() {
+	// ensure that purge cache requests have been fetched recently
+	tp.plugin.PurgeCacheAsNeeded(tp.context)
+
+	// For each cachePayloadEntry we call takeVolumeEntry (concurrently)
+	N := len(tp.payloadEntries)
+	tp.cacheHandles = make([]*caching.Handle, N)
+	errs := make([]error, N)
+	util.Spawn(N, func(i int) {
+		tp.cacheHandles[i], errs[i] = tp.plugin.getVolume(tp.context, tp.payloadEntries[i])
+	})
+
+	// Find malformedPayloadErrors and report internal errors
+	var malformedPayloadErrors []runtime.MalformedPayloadError
+	for _, err := range errs {
+		if e, ok := runtime.IsMalformedPayloadError(err); ok {
+			malformedPayloadErrors = append(malformedPayloadErrors, e)
+		} else if err != nil && tp.context.Err() == nil {
+			incidentID := tp.monitor.ReportError(err, "failed to created cache volume")
+			tp.context.LogError("internal error creating cache volume, incidentID:", incidentID)
+			tp.cachesError = runtime.ErrNonFatalInternalError
+		}
+	}
+	// Merge malformedPayloadErrors, if there is no other more sever error
+	if tp.cachesError == nil && len(malformedPayloadErrors) > 0 {
+		tp.cachesError = runtime.MergeMalformedPayload(malformedPayloadErrors...)
+	}
+
+	// If task was canceled, we use the error to signal that it was canceled
+	if tp.context.Err() != nil {
+		tp.cachesError = tp.context.Err()
+	}
+
+	// Release volumes, if there is an error
+	if tp.cachesError != nil {
+		tp.cachesDisposed.Do(func() {
+			for i, handle := range tp.cacheHandles {
+				if handle != nil {
+					handle.Release()
+				}
+				tp.cacheHandles[i] = nil
+			}
+		})
+	}
+}
+
+func (tp *taskPlugin) BuildSandbox(sandboxBuilder engines.SandboxBuilder) error {
+	// Wait for volumes to be populated
+	select {
+	case <-tp.cachesReady.Done():
+	case <-tp.context.Done():
+		return nil // TODO: In some future consider return tp.context.Err()
+	}
+
+	// if there was an error, we return it
+	if tp.cachesError != nil {
+		return tp.cachesError
+	}
+
+	// Attach volumes to sandboxBuilder
+	var internalError error
+	var malformedPayloadErrors []runtime.MalformedPayloadError
+	for i, entry := range tp.payloadEntries {
+		volume := tp.cacheHandles[i].Resource().(*cacheVolume).Volume
+		readOnly := entry.Name == ""
+		err := sandboxBuilder.AttachVolume(entry.MountPoint, volume, readOnly)
+
+		// Handle potential errors
+		switch err {
+		case runtime.ErrFatalInternalError:
+			internalError = runtime.ErrFatalInternalError
+			err = nil
+		case runtime.ErrNonFatalInternalError:
+			if internalError == nil {
+				internalError = runtime.ErrNonFatalInternalError
+			}
+			err = nil
+		case engines.ErrMutableMountNotSupported:
+			err = runtime.NewMalformedPayloadError("this workerType doesn't support read-write caches, " +
+				"omit the cache 'name' property to make the cache read-only")
+		case engines.ErrImmutableMountNotSupported:
+			err = runtime.NewMalformedPayloadError("this workerType doesn't support read-only caches, " +
+				"you must specify a cache 'name' property to make the cache read-write")
+		case engines.ErrNamingConflict:
+			err = runtime.NewMalformedPayloadError(fmt.Sprintf(
+				"cache mountPoint '%s' is already in use", entry.MountPoint,
+			))
+		case engines.ErrFeatureNotSupported:
+			err = runtime.NewMalformedPayloadError("this workerType doesn't support caches")
+		}
+		if e, ok := runtime.IsMalformedPayloadError(err); ok {
+			malformedPayloadErrors = append(malformedPayloadErrors, e)
+		} else if err != nil {
+			incidentID := tp.monitor.ReportError(err, "SandboxBuilder.AttachVolume() failed")
+			tp.context.LogError("internal error attaching cache volume, incidentID:", incidentID)
+			internalError = runtime.ErrFatalInternalError
+		}
+	}
+
+	// Return internal error, if we have one
+	if internalError != nil {
+		return internalError
+	}
+
+	// Merge malformed payload errors
+	if len(malformedPayloadErrors) > 0 {
+		return runtime.MergeMalformedPayload(malformedPayloadErrors...)
+	}
+
+	return nil
+}
+
+func (tp *taskPlugin) Dispose() error {
+	tp.cachesReady.Wait()
+	tp.cachesDisposed.Do(func() {
+		for i, handle := range tp.cacheHandles {
+			if handle != nil {
+				handle.Release()
+			}
+			tp.cacheHandles[i] = nil
+		}
+	})
+	return nil
+}

--- a/plugins/cache/cache_test.go
+++ b/plugins/cache/cache_test.go
@@ -1,0 +1,458 @@
+package cache
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/worker/workertest"
+
+	_ "github.com/taskcluster/taskcluster-worker/engines/mock"
+	_ "github.com/taskcluster/taskcluster-worker/plugins/livelog"
+	_ "github.com/taskcluster/taskcluster-worker/plugins/success"
+)
+
+const testPluginConfig = `{
+	"disabled": [],
+	"success": {},
+	"livelog": {},
+	"cache": {}
+}`
+
+func TestReadWriteEmptyCache(t *testing.T) {
+	workertest.Case{
+		Concurrency:  0, // runs tasks sequentially
+		Engine:       "mock",
+		EngineConfig: `{}`,
+		PluginConfig: testPluginConfig,
+		Tasks: []workertest.Task{
+			{
+				Title:  "Write hello-world to empty cache volume",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "write-volume",
+					"argument": "my-mount-point/my-folder/my-file.txt:hello-world",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {}
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.AnyArtifact(),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title:  "Read from cache volume",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "some-mount-point/my-folder/my-file.txt",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "some-mount-point",
+							"options": {}
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("hello-world"),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+		},
+	}.TestWithFakeQueue(t) // TODO: Resolve scope issues and test against real queue
+}
+
+func TestReadPreloadCache(t *testing.T) {
+	// Create a tiny tar archive in-memory
+	buf := bytes.NewBuffer(nil)
+	text := []byte("hej verden")
+	a := tar.NewWriter(buf)
+	err := a.WriteHeader(&tar.Header{
+		Name: "min-mappe/min-fil.txt",
+		Mode: 0777,
+		Size: int64(len(text)),
+	})
+	require.NoError(t, err, "failed to create file header in tar archive")
+	_, err = a.Write(text)
+	require.NoError(t, err, "failed to write file body in tar archive")
+	err = a.Close()
+	require.NoError(t, err, "failed to create tar archive")
+	rawtar := buf.Bytes()
+
+	// Create a test server that serves a tar archive
+	var m sync.Mutex
+	count := 0
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.Lock()
+		count++
+		m.Unlock()
+		w.Header().Set("Content-Type", "application/tar")
+		w.Header().Set("Content-Length", strconv.Itoa(len(rawtar)))
+		w.WriteHeader(http.StatusOK)
+		w.Write(rawtar)
+	}))
+	defer s.Close()
+	defer func() {
+		m.Lock()
+		require.Equal(t, 2, count, "expected exactly 2 fetches")
+		m.Unlock()
+	}()
+
+	workertest.Case{
+		Concurrency:  0, // runs tasks sequentially
+		Engine:       "mock",
+		EngineConfig: `{}`,
+		PluginConfig: testPluginConfig,
+		Tasks: []workertest.Task{
+			{
+				Title:  "Read from cache volume",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "my-mount-point/min-mappe/min-fil.txt",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {},
+							"preload": "` + s.URL + `"
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("hej verden"),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title:  "Read from cache volume again",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "my-mount-point/min-mappe/min-fil.txt",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {},
+							"preload": "` + s.URL + `"
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("hej verden"),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title:  "Write to preloaded cache volume",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "write-volume",
+					"argument": "my-mount-point/min-mappe/min-fil.txt:hello-world",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {},
+							"preload": "` + s.URL + `"
+						}
+					]
+				}`,
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title:  "Read from cache volume after write",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "my-mount-point/min-mappe/min-fil.txt",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {},
+							"preload": "` + s.URL + `"
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("hello-world"),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title: "Read from read-only cache volume",
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "my-mount-point/min-mappe/min-fil.txt",
+					"caches": [
+						{
+							"mountPoint": "my-mount-point",
+							"options": {},
+							"preload": "` + s.URL + `"
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("hej verden"),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title: "Read from read-only cache volume again",
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "my-other-mount-point/min-mappe/min-fil.txt",
+					"caches": [
+						{
+							"mountPoint": "my-other-mount-point",
+							"options": {},
+							"preload": "` + s.URL + `"
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("hej verden"),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title: "Write to preloaded read-only cache volume fails",
+				Payload: `{
+					"delay": 5,
+					"function": "write-volume",
+					"argument": "my-mount-point/min-mappe/min-fil.txt:hello-world",
+					"caches": [
+						{
+							"mountPoint": "my-mount-point",
+							"options": {},
+							"preload": "` + s.URL + `"
+						}
+					]
+				}`,
+				AllowAdditional: true,
+				Success:         false,
+			},
+		},
+	}.TestWithFakeQueue(t) // TODO: Resolve scope issues and test against real queue
+}
+
+func TestCacheScopeRequired(t *testing.T) {
+	workertest.Case{
+		Concurrency:  0, // runs tasks sequentially
+		Engine:       "mock",
+		EngineConfig: `{}`,
+		PluginConfig: testPluginConfig,
+		Tasks: []workertest.Task{
+			{
+				Title:  "Write hello-world to empty cache volume",
+				Scopes: []string{"worker:cache:dummy-garbage-wrong-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "write-volume",
+					"argument": "my-mount-point/my-folder/my-file.txt:hello-world",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {}
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("dummy-garbage-my-cache-name"),
+				},
+				AllowAdditional: true,
+				Exception:       runtime.ReasonMalformedPayload,
+				Success:         false,
+			},
+			{
+				Title:  "Access with star-scope",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-*"},
+				Payload: `{
+					"delay": 5,
+					"function": "write-volume",
+					"argument": "my-mount-point/my-folder/my-file.txt:hello-world",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {}
+						}
+					]
+				}`,
+				AllowAdditional: true,
+				Success:         true,
+			},
+		},
+	}.TestWithFakeQueue(t) // TODO: Resolve scope issues and test against real queue
+}
+
+func TestPurgeCache(t *testing.T) {
+	prevDefaultMaxPurgeCacheDelay := defaultMaxPurgeCacheDelay
+	defaultMaxPurgeCacheDelay = 0
+	defer func() {
+		defaultMaxPurgeCacheDelay = prevDefaultMaxPurgeCacheDelay
+	}()
+
+	var purging atomics.Bool
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start-purging" {
+			purging.Set(true)
+			w.WriteHeader(http.StatusOK)
+			w.Write(nil)
+			return
+		}
+
+		parts := strings.Split(r.URL.Path, "/")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		var requests interface{}
+		if purging.Get() {
+			requests = []interface{}{
+				map[string]interface{}{
+					"provisionerId": parts[2],
+					"workerType":    parts[3],
+					"cacheName":     "dummy-garbage-my-cache-name",
+					"before":        time.Now().UTC(),
+				},
+			}
+		} else {
+			requests = []interface{}{
+				map[string]interface{}{
+					"provisionerId": parts[2],
+					"workerType":    parts[3],
+					"cacheName":     "dummy-garbage-wrong-name",
+					"before":        time.Now().UTC(),
+				},
+			}
+		}
+		data, _ := json.Marshal(map[string]interface{}{
+			"requests": requests,
+		})
+		w.Write(data)
+	}))
+	defer s.Close()
+
+	workertest.Case{
+		Concurrency:  0, // runs tasks sequentially
+		Engine:       "mock",
+		EngineConfig: `{}`,
+		PluginConfig: `{
+			"disabled": [],
+			"success": {},
+			"livelog": {},
+			"cache": {
+				"purgeCacheBaseUrl": "` + s.URL + `"
+			}
+		}`,
+		Tasks: []workertest.Task{
+			{
+				Title:  "Write hello-world to empty cache volume",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "write-volume",
+					"argument": "my-mount-point/my-folder/my-file.txt:hello-world",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "my-mount-point",
+							"options": {}
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.AnyArtifact(),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title:  "Read from cache volume",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "some-mount-point/my-folder/my-file.txt",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "some-mount-point",
+							"options": {}
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.GrepArtifact("hello-world"),
+				},
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title: "Ping purge-cache service to start purging",
+				Payload: `{
+					"delay": 5,
+					"function": "get-url",
+					"argument": "` + s.URL + `/start-purging"
+				}`,
+				AllowAdditional: true,
+				Success:         true,
+			},
+			{
+				Title:  "Read from cache volume after purge",
+				Scopes: []string{"worker:cache:dummy-garbage-my-cache-name"},
+				Payload: `{
+					"delay": 5,
+					"function": "read-volume",
+					"argument": "some-mount-point/my-folder/my-file.txt",
+					"caches": [
+						{
+							"name": "dummy-garbage-my-cache-name",
+							"mountPoint": "some-mount-point",
+							"options": {}
+						}
+					]
+				}`,
+				Artifacts: workertest.ArtifactAssertions{
+					"public/logs/live_backing.log": workertest.NotGrepArtifact("hello-world"),
+				},
+				AllowAdditional: true,
+				Success:         false,
+			},
+		},
+	}.TestWithFakeQueue(t) // TODO: Resolve scope issues and test against real queue
+}

--- a/plugins/cache/config.go
+++ b/plugins/cache/config.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"time"
+
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
+
+type config struct {
+	MaxPurgeCacheDelay time.Duration `json:"maxPurgeCacheDelay"`
+	PurgeCacheBaseURL  string        `json:"purgeCacheBaseUrl"`
+}
+
+var configSchema = schematypes.Object{
+	Title: "Cache Plugin",
+	Description: util.Markdown(`
+		Configuration for the cache plugin that manages sandbox caches.
+	`),
+	Properties: schematypes.Properties{
+		"maxPurgeCacheDelay": schematypes.Duration{
+			Title: "Maximum Cache Purge Delay",
+			Description: util.Markdown(`
+				The cache plugin will call the taskcluster-purge-cache service to fetch
+				_purge-cache requests_, these are request that caches should be purged.
+
+				The cache plugin will pull the taskcluster-purge-cache service before
+				every task to ensure that caches requested to be purged are not reused.
+				However, if less than 'maxPurgeCacheDelay' time have passed since the
+				previous request to taskcluster-purge-cache then the request is skipped.
+
+				This defaults to 3 minutes, which is reasonable in most cases.
+			`),
+		},
+		"purgeCacheBaseUrl": schematypes.URI{
+			Title: "BaseUrl for purge-cache service",
+			Description: util.Markdown(`
+				This is the baseUrl for the taskcluster-purge-cache service, which tells
+				what caches should be purged.
+
+				This defaults to the production value from taskcluster-client libraries.
+				You do not need to set this in production.
+			`),
+		},
+	},
+}

--- a/plugins/cache/constructor.go
+++ b/plugins/cache/constructor.go
@@ -1,0 +1,139 @@
+package cache
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/caching"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
+	"github.com/taskcluster/taskcluster-worker/runtime/fetcher"
+)
+
+type cacheOptions struct {
+	Name               string               `json:"name"`
+	Options            interface{}          `json:"options"`
+	Preload            interface{}          `json:"preload"`
+	ReferenceHash      string               `json:"referenceHash"`
+	InitialTaskContext *runtime.TaskContext `json:"-"`
+	Reference          fetcher.Reference    `json:"-"`
+	Plugin             *plugin              `json:"-"`
+}
+
+type preloadFetchContext struct {
+	caching.Context
+	InitialTaskContext *runtime.TaskContext
+}
+
+func (c *preloadFetchContext) Queue() client.Queue {
+	return c.InitialTaskContext.Queue()
+}
+
+type progressContext struct {
+	*runtime.TaskContext
+	Name string
+}
+
+func (c *progressContext) Progress(description string, percent float64) {
+	if c.Name == "" {
+		c.Log(fmt.Sprintf("Fetching cache preload from: %s - %.0f %%", description, percent*100))
+	} else {
+		c.Log(fmt.Sprintf("Fetching cache preload for %s from: %s - %.0f %%", c.Name, description, percent*100))
+	}
+}
+
+func constructor(ctx caching.Context, opts interface{}) (caching.Resource, error) {
+	options := opts.(cacheOptions) // must of this type
+
+	// Define the created timestamp (we do this first to ensure volumes get purged if older)
+	created := time.Now()
+
+	// Log it when we create named (mutable caches)
+	if options.Name != "" {
+		options.Plugin.monitor.Infof("creating cache: '%s'", options.Name)
+	}
+
+	// If there is no reference, we have nothing to fetch and this is easy
+	if options.Reference == nil {
+		// Create a new volume
+		volume, err := options.Plugin.engine.NewVolume(options.Options)
+		if err != nil {
+			if err == engines.ErrFeatureNotSupported {
+				return nil, runtime.NewMalformedPayloadError(
+					"worker engine doesn't support cache volumes",
+				)
+			}
+			return nil, errors.Wrap(err, "failed to create cache volume, engine error")
+		}
+
+		return &cacheVolume{
+			Volume:  volume,
+			Name:    options.Name,
+			Created: created,
+		}, nil
+	}
+	// the rest of this function deals with creating a pre-loaded cache
+
+	// Fetch pre-load data to temporary file
+	file, err := options.Plugin.environment.TemporaryStorage.NewFile()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create temporary file to fetch cache pre-load")
+	}
+	defer file.Close() // remove the temporary file whatever happens
+	err = options.Reference.Fetch(&preloadFetchContext{
+		Context:            ctx,
+		InitialTaskContext: options.InitialTaskContext,
+	}, &fetcher.FileReseter{File: file})
+	if err != nil {
+		if fetcher.IsBrokenReferenceError(err) {
+			err = runtime.NewMalformedPayloadError(fmt.Sprintf(
+				"cache pre-loading error: %s", err.Error(),
+			))
+		} else {
+			err = errors.Wrap(err, "failed to fetch cache preload data")
+		}
+		return nil, err
+	}
+
+	// Seek to start of file (after download)
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		incidentID := options.Plugin.monitor.ReportError(err, "failed to seek to start of temporary file after download")
+		ctx.Progress(fmt.Sprintf("internal error downloading, incidentId: %s", incidentID), 1)
+		return nil, runtime.ErrFatalInternalError // if we can't seek start that's pretty critical
+	}
+
+	// Create a new volume builder
+	volumeBuilder, err := options.Plugin.engine.NewVolumeBuilder(options.Options)
+	if err != nil {
+		if err == engines.ErrFeatureNotSupported {
+			return nil, runtime.NewMalformedPayloadError(
+				"worker engine doesn't support pre-loaded cache volumes",
+			)
+		}
+		return nil, errors.Wrap(err, "failed to create VolumeBuilder for a pre-loaded cache")
+	}
+
+	// Extract the pre-load archive
+	if err = extractArchive(file, volumeBuilder); err != nil {
+		if verr := volumeBuilder.Discard(); verr != nil {
+			options.Plugin.monitor.ReportError(verr, "VolumeBuilder.Discard() failed, after failed archive extraction")
+		}
+		return nil, err
+	}
+
+	// Build the volume
+	volume, err := volumeBuilder.BuildVolume()
+	if err != nil {
+		return nil, errors.Wrap(err, "VolumeBuilder.BuildVolume() failed")
+	}
+
+	return &cacheVolume{
+		Volume:  volume,
+		Name:    options.Name,
+		Created: created,
+	}, nil
+}

--- a/plugins/cache/doc.go
+++ b/plugins/cache/doc.go
@@ -1,0 +1,6 @@
+// Package cache provides a cache plugin for taskcluster-worker
+package cache
+
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
+
+var debug = util.Debug("cache")

--- a/plugins/cache/extract.go
+++ b/plugins/cache/extract.go
@@ -19,7 +19,7 @@ type fileSystem interface {
 
 // extractArchive detects archive type from source and extracts to target
 // If this fails due to archive format then it returns MalformedPayloadError
-func extractArchive(source io.ReadSeeker, target fileSystem) error {
+func extractArchive(source io.Reader, target fileSystem) error {
 	// Ensure we do buffered I/O
 	br := bufio.NewReaderSize(source, 4096)
 	head, _ := br.Peek(512)

--- a/plugins/cache/extract.go
+++ b/plugins/cache/extract.go
@@ -1,0 +1,111 @@
+package cache
+
+import (
+	"archive/tar"
+	"bufio"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"gopkg.in/h2non/filetype.v1"
+	"gopkg.in/h2non/filetype.v1/matchers"
+)
+
+type fileSystem interface {
+	WriteFolder(name string) error
+	WriteFile(name string) io.WriteCloser
+}
+
+// extractArchive detects archive type from source and extracts to target
+// If this fails due to archive format then it returns MalformedPayloadError
+func extractArchive(source io.ReadSeeker, target fileSystem) error {
+	// Ensure we do buffered I/O
+	br := bufio.NewReaderSize(source, 4096)
+	head, _ := br.Peek(512)
+
+	// If not a TAR archive we return a MalformedPayloadError
+	// TODO: support other archive formats:
+	//        golang.org/pkg/archive/zip
+	//        github.com/nwaples/rardecode
+	//        github.com/mkrautz/goar
+	// TODO: support decompression from:
+	//        golang.org/pkg/compress/gzip/
+	//        golang.org/pkg/compress/bzip2/
+	//        github.com/DataDog/zstd
+	//        github.com/MediaMath/go-lzop
+	//        lzma/xz, brotli, lz4, maybe too
+	if !matchers.Tar(head) {
+		kind, _ := filetype.Match(head)
+		if kind.MIME.Value == "" {
+			return runtime.NewMalformedPayloadError(
+				"unable to detect cache preload data format, try TAR archives instead",
+			)
+		}
+		return runtime.NewMalformedPayloadError(fmt.Sprintf(
+			"caches cannot be pre-loaded with '%s', try TAR archives instead",
+			kind.MIME.Value,
+		))
+	}
+
+	// Wrap reader, so we can detect internal input errors, vs. tar-ball errors
+	ebr := errorCapturingReader{Reader: br}
+	tr := tar.NewReader(&ebr)
+
+	// Extract tar-ball
+	for {
+		// Read an entry
+		header, err := tr.Next()
+		if ebr.Err != nil { // if there was an error reading from source it's internal
+			return errors.Wrap(ebr.Err, "error reading from buffered archive")
+		}
+		if err == io.EOF { // if EOF, then we're done
+			return nil
+		}
+		// If there was an error otherwise, it's a tar-ball error
+		if err != nil {
+			return runtime.NewMalformedPayloadError(fmt.Sprintf(
+				"error reading TAR arcive: %s", err.Error(),
+			))
+		}
+
+		info := header.FileInfo()
+		if info.IsDir() {
+			debug("extracting folder: '%s'", header.Name)
+
+			err = target.WriteFolder(header.Name)
+			if err != nil {
+				return errors.Wrap(err, "Volume.WriteFolder() failed")
+			}
+		} else if info.Mode().IsRegular() {
+			debug("extracting file: '%s'", header.Name)
+
+			w := target.WriteFile(header.Name)
+			// We capture errors from the reader, because we don't want these to become
+			// internal errors.
+			er := errorCapturingReader{Reader: tr}
+			_, err = io.Copy(w, &er)
+			if ebr.Err != nil {
+				return errors.Wrap(ebr.Err, "error reading from buffered archive")
+			}
+			if er.Err != nil {
+				w.Close()
+				return runtime.NewMalformedPayloadError(fmt.Sprintf(
+					"error reading TAR arcive: %s", er.Err.Error(),
+				))
+			}
+			if err != nil {
+				w.Close()
+				return errors.Wrap(err, "failed to write file to io.WriteCloser from Volume.WriteFile()")
+			}
+			if err = w.Close(); err != nil {
+				return errors.Wrap(err, "Volume.WriteFile().Close() failed")
+			}
+		} else {
+			return runtime.NewMalformedPayloadError(fmt.Sprintf(
+				"archive entry '%s' with fileMode: %s is not supported",
+				info.Name(), info.Mode().String(),
+			))
+		}
+	}
+}

--- a/plugins/cache/payload.go
+++ b/plugins/cache/payload.go
@@ -1,0 +1,22 @@
+package cache
+
+import "github.com/taskcluster/taskcluster-worker/runtime/fetcher"
+
+type payloadEntry struct {
+	Name       string      `json:"name"`
+	MountPoint string      `json:"mountPoint"`
+	Options    interface{} `json:"options"`
+	Preload    interface{} `json:"preload"`
+}
+
+// A fetcher for pre-loading caches
+var preloadFetcher = fetcher.Combine(
+	// Allow fetching from URL
+	fetcher.URL,
+	// Allow fetching from queue artifacts
+	fetcher.Artifact,
+	// Allow fetching from queue referenced by index namespace
+	fetcher.Index,
+	// Allow fetching from URL + hash
+	fetcher.URLHash,
+)

--- a/plugins/cache/util.go
+++ b/plugins/cache/util.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// cacheScope returns the scope required to use a cache with a given name
+func cacheScope(name string) string {
+	return fmt.Sprintf("worker:cache:%s", name)
+}
+
+// format scopeSets for usage in an error message.
+//
+// Scope-sets will be formatteded as: ['a', 'b', 'c'] or ['d', 'e']
+func formatScopeSetRequirements(scopeSets [][]string) string {
+	sets := make([]string, len(scopeSets))
+	for i, scopes := range scopeSets {
+		sets[i] = "'" + strings.Join(scopes, "', '") + "'"
+	}
+	return strings.Join(sets, " or ")
+}
+
+// errorCapturingReader will wrap a Reader such that it returns io.EOF instead
+// of any error from the reader. Any errors from the reader will be assigned
+// to the Err property.
+type errorCapturingReader struct {
+	Reader io.Reader
+	Err    error
+}
+
+func (r *errorCapturingReader) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	if err != nil && err != io.EOF {
+		r.Err = err
+		err = io.EOF
+	}
+	return
+}

--- a/plugins/cache/volume.go
+++ b/plugins/cache/volume.go
@@ -1,0 +1,35 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/caching"
+)
+
+// cacheVolume is the resource type passed to caching.Cache
+type cacheVolume struct {
+	Volume   engines.Volume
+	Name     string
+	Created  time.Time
+	disposed atomics.Once
+}
+
+func (v *cacheVolume) MemorySize() (uint64, error) {
+	// TODO: Add memory size support to cache volumes
+	return 0, caching.ErrDisposableSizeNotSupported
+}
+
+func (v *cacheVolume) DiskSize() (uint64, error) {
+	// TODO: Add disk size support to cache volumes
+	return 0, caching.ErrDisposableSizeNotSupported
+}
+
+func (v *cacheVolume) Dispose() error {
+	var err error
+	v.disposed.Do(func() {
+		err = v.Volume.Dispose()
+	})
+	return err
+}

--- a/plugins/plugintest/plugintest.go
+++ b/plugins/plugintest/plugintest.go
@@ -316,6 +316,10 @@ func newTestEnvironment() runtime.Environment {
 		TemporaryStorage: folder,
 		Monitor:          mocks.NewMockMonitor(true),
 		Worker:           &runtime.LifeCycleTracker{},
+		ProvisionerID:    "dummy-provisioner",
+		WorkerType:       "dummy-worker-type",
+		WorkerGroup:      "dummy-worker-group",
+		WorkerID:         "dummy-worker-id",
 	}
 }
 

--- a/plugins/plugintest/plugintest_test.go
+++ b/plugins/plugintest/plugintest_test.go
@@ -18,6 +18,10 @@ func (pluginProvider) NewPlugin(options plugins.PluginOptions) (plugins.Plugin, 
 	assert(e.Monitor != nil, "PluginOptions.Environment.Monitor is nil!")
 	assert(e.TemporaryStorage != nil, "PluginOptions.Environment.TemporaryStorage is nil!")
 	assert(e.WebHookServer != nil, "PluginOptions.Environment.WebHookServer is nil!")
+	assert(e.ProvisionerID != "", "PluginOptions.Environment.ProvisionerID is empty string")
+	assert(e.WorkerType != "", "PluginOptions.Environment.WorkerType is empty string")
+	assert(e.WorkerGroup != "", "PluginOptions.Environment.WorkerGroup is empty string")
+	assert(e.WorkerID != "", "PluginOptions.Environment.WorkerID is empty string")
 	return plugin{}, nil
 }
 

--- a/runtime/caching/cache.go
+++ b/runtime/caching/cache.go
@@ -1,0 +1,213 @@
+package caching
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+)
+
+// A Constructor is function that given options creates a resource.
+//
+// Notice, options must be JSON serializable, as they will be hashed to
+// determine resource equivalence.
+type Constructor func(ctx Context, options interface{}) (Resource, error)
+
+// A Cache is an object that wraps a constructor and manages the life-cycle of
+// objects. At creation a cache is given a Constructor, a ResourceTracker and
+// the option of being an exclusive or shared-cache, meaning if resources may be
+// re-used before they are released.
+type Cache struct {
+	m           sync.Mutex
+	shared      bool
+	entries     []*cacheEntry
+	constructor Constructor
+	tracker     gc.ResourceTracker
+}
+
+// New returns a Cache wrapping constructor such that resources
+// returned from Require are shared between all calls to Require with the same
+// options, if shared is set to true. Otherwise, resources are exclusive.
+func New(constructor Constructor, shared bool, tracker gc.ResourceTracker) *Cache {
+	return &Cache{
+		constructor: constructor,
+		tracker:     tracker,
+		shared:      shared,
+	}
+}
+
+func (c *Cache) remove(e *cacheEntry) {
+	// Lock cache entries
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	// Remove from cache
+	entries := c.entries[:0]
+	for _, entry := range c.entries {
+		if entry != e {
+			entries = append(entries, entry)
+		}
+	}
+	c.entries = entries
+}
+
+// Require returns a resource for the given options
+//
+// If the Cache is exclusive the resource will not be re-used before it is
+// returned with a call to Release(resource). If the cache is shared the cache
+// will only every create one instance of the resource, unless purged or freed
+// by the ResourceTracker.
+func (c *Cache) Require(ctx Context, options interface{}) (*Handle, error) {
+	optionsHash := hashJSON(options)
+
+	// Lock the entries list
+	c.m.Lock()
+
+	// find cache entry, if present
+	var entry *cacheEntry
+	for _, e := range c.entries {
+		e.m.Lock()
+		// Ignore if: scheduled to be purged, disposed or options mismatch
+		if e.purge || e.disposed || e.optionsHash != optionsHash {
+			e.m.Unlock()
+			continue
+		}
+		// Skip if this isn't a shared cache and entry is in-use
+		if !c.shared && e.refCount > 0 {
+			e.m.Unlock()
+			continue
+		}
+		// Skip if we are too late to join the context (ie. it was canceled), and
+		// the resource haven't been created. There is a race here that could
+		// cause us to ignore a successfully created resource, but it's unlikely,
+		// mostly this is ignoring resource creations that haven't finished, but
+		// have been canceled (since we can't uncancel)
+		if !e.ctx.AddContext(ctx) && !e.created.IsDone() {
+			e.m.Unlock()
+			continue
+		}
+
+		// Take the entry
+		debug("cache entry '%s' found in cache, refCount: %d", optionsHash, e.refCount+1)
+		entry = e
+		e.refCount++
+		e.m.Unlock()
+		break
+	}
+
+	// Create new resource
+	if entry == nil {
+		debug("cache entry '%s' is being created", optionsHash)
+		entry = &cacheEntry{
+			optionsHash: optionsHash,
+			refCount:    1,
+			lastUsed:    time.Now(),
+			ctx:         newContextConjunction(ctx),
+			cache:       c,
+		}
+
+		// Insert in cache so we can find it again, and re-use the resource
+		c.entries = append(c.entries, entry)
+
+		go entry.created.Do(func() {
+			defer entry.ctx.dispose() // ensure resources are cleanup when constructor is done
+
+			entry.resource, entry.err = c.constructor(entry.ctx, options)
+			if entry.err != nil {
+				// Set the entry to be purged, so others will ignore it
+				entry.m.Lock()
+				entry.purge = true
+				entry.disposed = true
+				entry.m.Unlock()
+				// Remove it from entries, so we don't cache error results
+				c.remove(entry)
+			} else {
+				debug("cache entry '%s' ready with resource type: %T", entry.optionsHash, entry.resource)
+				// Insert in garbage collector
+				c.tracker.Register(entry)
+			}
+		})
+	}
+
+	// Unlock the entries list, while we wait for the entry to be created
+	c.m.Unlock()
+
+	// Wait for the entry to be created
+	select {
+	case <-entry.created.Done():
+		if entry.err != nil {
+			entry.release()
+			return nil, entry.err
+		}
+		return &Handle{entry: entry}, nil
+	case <-ctx.Done():
+		entry.release()
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		panic(errors.New("expected context.Err() != nil when context.Done() is closed"))
+	}
+}
+
+// Purge cached resources, notice that these resources may be in use.
+// The filter function should return true if the resource should be purged,
+// then it'll purged when it is no-longer in use.
+func (c *Cache) Purge(filter func(r Resource) bool) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	// find entries to delete
+	for _, entry := range c.entries {
+		entry.m.Lock()
+		ignore := !entry.created.IsDone() || entry.purge || entry.disposed
+		entry.m.Unlock()
+
+		if !ignore && filter(entry.resource) {
+			// Set the bit for it to be disposed when given back to Release
+			entry.m.Lock()
+			entry.purge = true
+			entry.m.Unlock()
+
+			// Remove entry from ResourceTracker
+			c.tracker.Unregister(entry)
+
+			if err := entry.Dispose(); err != nil && err != gc.ErrDisposableInUse {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// PurgeAll will purge all resources returning the first error, then proceeding
+// and purging everything else, before returning the first error, if any.
+func (c *Cache) PurgeAll() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	// find entries to delete
+	var err error
+	for _, entry := range c.entries {
+		entry.m.Lock()
+		ignore := !entry.created.IsDone() || entry.purge || entry.disposed
+		entry.m.Unlock()
+
+		if !ignore {
+			// Set the bit for it to be disposed when given back to Release
+			entry.m.Lock()
+			entry.purge = true
+			entry.m.Unlock()
+
+			// Remove entry from ResourceTracker
+			c.tracker.Unregister(entry)
+
+			if derr := entry.Dispose(); derr != nil && derr != gc.ErrDisposableInUse && err == nil {
+				err = derr // return only the first error
+			}
+		}
+	}
+
+	return err
+}

--- a/runtime/caching/cache_test.go
+++ b/runtime/caching/cache_test.go
@@ -1,0 +1,471 @@
+package caching
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+)
+
+type opts struct {
+	Sleep int  `json:"sleep"`
+	Value int  `json:"value"`
+	Error bool `json:"error"`
+}
+
+type res struct {
+	sync.Mutex
+	Value    int
+	Disposed bool
+}
+
+func (r *res) MemorySize() (uint64, error) {
+	return 0, ErrDisposableSizeNotSupported
+}
+
+func (r *res) DiskSize() (uint64, error) {
+	return 0, ErrDisposableSizeNotSupported
+}
+
+func (r *res) Dispose() error {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.Disposed {
+		panic("resource disposed twice!!!")
+	}
+	r.Disposed = true
+	return nil
+}
+
+func constructor(ctx Context, options interface{}) (Resource, error) {
+	opt, ok := options.(opts)
+	if !ok {
+		return nil, errors.New("invalid options")
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(time.Duration(opt.Sleep) * time.Millisecond):
+	}
+
+	if opt.Error {
+		return nil, errors.New("some error")
+	}
+
+	return &res{Value: opt.Value}, nil
+}
+
+type tracker struct {
+	sync.Mutex
+	resources []gc.Disposable
+}
+
+func (t *tracker) Register(resource gc.Disposable) {
+	t.Lock()
+	defer t.Unlock()
+
+	t.resources = append(t.resources, resource)
+}
+
+func (t *tracker) Unregister(resource gc.Disposable) bool {
+	t.Lock()
+	defer t.Unlock()
+
+	found := false
+	res := t.resources[:0]
+	for _, r := range t.resources {
+		if r != resource {
+			res = append(res, r)
+		} else {
+			found = true
+		}
+	}
+	t.resources = res
+
+	return found
+}
+
+type mockctx struct {
+	context.Context
+}
+
+func (c *mockctx) Progress(description string, percent float64) {
+	debug("progress: %s -- %f %%", description, percent)
+}
+
+func TestSharedCache(t *testing.T) {
+	var tr tracker
+	c := New(constructor, true, &tr)
+	require.Equal(t, 0, len(tr.resources), "expected zero resources")
+
+	t.Run("single resource", func(t *testing.T) {
+		debug("creating resource")
+		handle, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 0,
+			Value: 0,
+		})
+		require.NoError(t, err)
+
+		debug("reading resource")
+		r, ok := handle.Resource().(*res)
+		require.True(t, ok)
+		r.Lock()
+		require.Equal(t, 0, r.Value)
+		r.Value++
+		r.Unlock()
+
+		require.Equal(t, 1, len(tr.resources), "expected one resource")
+		handle.Release()
+		handle.Release() // sanity check, why not
+
+		debug("loading resource")
+		handle, err = c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 0,
+			Value: 0,
+		})
+		require.NoError(t, err)
+
+		debug("reading resource")
+		r, ok = handle.Resource().(*res)
+		require.True(t, ok)
+		r.Lock()
+		require.Equal(t, 1, r.Value)
+		r.Unlock()
+
+		require.Equal(t, 1, len(tr.resources), "expected one resource")
+		handle.Release()
+		handle.Release() // sanity check, why not
+
+		debug("purging")
+		c.Purge(func(r Resource) bool {
+			debug("deciding to purge: %#v", r)
+			return true
+		})
+		time.Sleep(10 * time.Millisecond)
+
+		debug("checking things were disposed")
+		r.Lock()
+		require.True(t, r.Disposed)
+		r.Unlock()
+		tr.Lock()
+		require.Equal(t, 0, len(tr.resources), "expected zero resources")
+		tr.Unlock()
+	})
+
+	t.Run("two resources", func(t *testing.T) {
+		var hA *Handle
+		var err2 error
+
+		debug("creating resourceA")
+		var done atomics.Once
+		go done.Do(func() {
+			hA, err2 = c.Require(&mockctx{context.Background()}, opts{
+				Sleep: 100,
+				Value: 0,
+			})
+			debug("created resourceA")
+		})
+		debug("creating resourceB")
+		hB, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 100,
+			Value: 0,
+		})
+		require.NoError(t, err)
+		debug("waiting for resourceA")
+		done.Wait()
+		require.NoError(t, err2)
+
+		debug("comparing resources")
+		require.Equal(t, hA.Resource(), hB.Resource())
+		require.True(t, hA.Resource() == hB.Resource())
+
+		debug("releasing resources")
+		hA.Release()
+		hB.Release()
+	})
+
+	t.Run("purge while in use", func(t *testing.T) {
+		handle, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 1,
+			Value: 10,
+		})
+		require.NoError(t, err)
+
+		debug("reading resource")
+		r, ok := handle.Resource().(*res)
+		require.True(t, ok)
+		r.Lock()
+		require.Equal(t, 10, r.Value)
+		r.Unlock()
+
+		// Increment to try and make a race condition
+		var incremented atomics.Once
+		go incremented.Do(func() {
+			r.Value += 2
+			time.Sleep(5 * time.Millisecond)
+			r.Value += 2
+			time.Sleep(5 * time.Millisecond)
+			r.Value += 2
+			r.Lock()
+			require.False(t, r.Disposed)
+			r.Unlock()
+		})
+
+		debug("purging")
+		c.Purge(func(r Resource) bool {
+			return true
+		})
+		time.Sleep(10 * time.Millisecond)
+
+		debug("Wait for incremented to be done")
+		incremented.Wait()
+
+		debug("checking things were NOT disposed")
+		r.Lock()
+		require.False(t, r.Disposed)
+		r.Unlock()
+
+		debug("release resource")
+		handle.Release()
+		handle.Release() // sanity check, why not
+		time.Sleep(10 * time.Millisecond)
+
+		debug("checking things were disposed")
+		r.Lock()
+		require.True(t, r.Disposed)
+		r.Unlock()
+	})
+
+	t.Run("two resources, create-error", func(t *testing.T) {
+		var err2 error
+
+		debug("creating resourceA")
+		var done atomics.Once
+		go done.Do(func() {
+			_, err2 = c.Require(&mockctx{context.Background()}, opts{
+				Sleep: 100,
+				Value: 0,
+				Error: true,
+			})
+			debug("created resourceA")
+		})
+		debug("creating resourceB")
+		_, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 100,
+			Value: 0,
+			Error: true,
+		})
+		require.Error(t, err)
+		debug("waiting for resourceA")
+		done.Wait()
+		require.Error(t, err2)
+
+		debug("comparing errors")
+		require.Equal(t, err, err2)
+		require.True(t, err == err2)
+
+		tr.Lock()
+		require.Equal(t, 0, len(tr.resources), "expected zero resources")
+		tr.Unlock()
+	})
+
+	t.Run("one resource, create-canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		time.AfterFunc(10*time.Millisecond, cancel)
+
+		debug("creating resourceA")
+		_, err := c.Require(&mockctx{ctx}, opts{
+			Sleep: 50,
+			Value: 0,
+		})
+		require.Error(t, err)
+
+		debug("comparing errors")
+		require.Equal(t, context.Canceled, err)
+
+		tr.Lock()
+		require.Equal(t, 0, len(tr.resources), "expected zero resources")
+		tr.Unlock()
+	})
+}
+
+func TestExclusiveCache(t *testing.T) {
+	var tr tracker
+	c := New(constructor, false, &tr)
+	require.Equal(t, 0, len(tr.resources), "expected zero resources")
+
+	t.Run("single resource", func(t *testing.T) {
+		handle, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 0,
+			Value: 0,
+		})
+		require.NoError(t, err)
+
+		debug("reading resource")
+		r, ok := handle.Resource().(*res)
+		require.True(t, ok)
+		r.Lock()
+		require.Equal(t, 0, r.Value)
+		r.Unlock()
+
+		require.Equal(t, 1, len(tr.resources), "expected one resource")
+		handle.Release()
+		handle.Release() // sanity check, why not
+
+		debug("purging")
+		c.Purge(func(r Resource) bool {
+			debug("deciding to purge: %#v", r)
+			return true
+		})
+		time.Sleep(10 * time.Millisecond)
+
+		debug("checking things were disposed")
+		r.Lock()
+		require.True(t, r.Disposed)
+		r.Unlock()
+		tr.Lock()
+		require.Equal(t, 0, len(tr.resources), "expected zero resources")
+		tr.Unlock()
+	})
+
+	t.Run("two resources", func(t *testing.T) {
+		var hA *Handle
+		var err2 error
+
+		debug("creating resourceA")
+		var done atomics.Once
+		go done.Do(func() {
+			hA, err2 = c.Require(&mockctx{context.Background()}, opts{
+				Sleep: 100,
+				Value: 0,
+			})
+			debug("created resourceA")
+		})
+		debug("creating resourceB")
+		hB, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 100,
+			Value: 0,
+		})
+		require.NoError(t, err)
+		debug("waiting for resourceA")
+		done.Wait()
+		require.NoError(t, err2)
+
+		debug("comparing resources")
+		require.False(t, hA.Resource() == hB.Resource())
+
+		debug("releasing resources")
+		hA.Release()
+		hB.Release()
+	})
+
+	t.Run("purge while in use", func(t *testing.T) {
+		handle, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 1,
+			Value: 10,
+		})
+		require.NoError(t, err)
+
+		debug("reading resource")
+		r, ok := handle.Resource().(*res)
+		require.True(t, ok)
+		r.Lock()
+		require.Equal(t, 10, r.Value)
+		r.Unlock()
+
+		// Increment to try and make a race condition
+		var incremented atomics.Once
+		go incremented.Do(func() {
+			r.Value += 2
+			time.Sleep(5 * time.Millisecond)
+			r.Value += 2
+			time.Sleep(5 * time.Millisecond)
+			r.Value += 2
+			r.Lock()
+			require.False(t, r.Disposed)
+			r.Unlock()
+		})
+
+		debug("purging")
+		c.Purge(func(r Resource) bool {
+			return true
+		})
+		time.Sleep(10 * time.Millisecond)
+
+		debug("Wait for incremented to be done")
+		incremented.Wait()
+
+		debug("checking things were NOT disposed")
+		r.Lock()
+		require.False(t, r.Disposed)
+		r.Unlock()
+
+		debug("release resource")
+		handle.Release()
+		handle.Release() // sanity check, why not
+		time.Sleep(10 * time.Millisecond)
+
+		debug("checking things were disposed")
+		r.Lock()
+		require.True(t, r.Disposed)
+		r.Unlock()
+	})
+
+	t.Run("two resources, create-error", func(t *testing.T) {
+		var err2 error
+
+		debug("creating resourceA")
+		var done atomics.Once
+		go done.Do(func() {
+			_, err2 = c.Require(&mockctx{context.Background()}, opts{
+				Sleep: 100,
+				Value: 0,
+				Error: true,
+			})
+			debug("created resourceA")
+		})
+		debug("creating resourceB")
+		_, err := c.Require(&mockctx{context.Background()}, opts{
+			Sleep: 100,
+			Value: 0,
+			Error: true,
+		})
+		require.Error(t, err)
+		debug("waiting for resourceA")
+		done.Wait()
+		require.Error(t, err2)
+
+		debug("comparing errors")
+		require.False(t, err == err2)
+
+		tr.Lock()
+		require.Equal(t, 0, len(tr.resources), "expected zero resources")
+		tr.Unlock()
+	})
+
+	t.Run("one resource, create-canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		time.AfterFunc(10*time.Millisecond, cancel)
+
+		debug("creating resourceA")
+		_, err := c.Require(&mockctx{ctx}, opts{
+			Sleep: 50,
+			Value: 0,
+		})
+		require.Error(t, err)
+
+		debug("comparing errors")
+		require.Equal(t, context.Canceled, err)
+
+		tr.Lock()
+		require.Equal(t, 0, len(tr.resources), "expected zero resources")
+		tr.Unlock()
+	})
+}

--- a/runtime/caching/cacheentry.go
+++ b/runtime/caching/cacheentry.go
@@ -1,0 +1,95 @@
+package caching
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/gc"
+)
+
+type cacheEntry struct {
+	m           sync.Mutex
+	optionsHash string
+	created     atomics.Once
+	refCount    uint32
+	lastUsed    time.Time
+	ctx         *contextConjunction
+	resource    Resource
+	err         error
+	cache       *Cache
+	purge       bool // true, if removed from GC, should not be used and disposed when refCount == 0
+	disposed    bool // true, if disposed and just waiting to be removed from cache.entries
+}
+
+func (e *cacheEntry) MemorySize() (uint64, error) {
+	return e.resource.MemorySize()
+}
+
+func (e *cacheEntry) DiskSize() (uint64, error) {
+	return e.resource.DiskSize()
+}
+
+func (e *cacheEntry) LastUsed() time.Time {
+	return e.lastUsed
+}
+
+func (e *cacheEntry) Dispose() error {
+	e.m.Lock()
+
+	if e.refCount > 0 {
+		e.m.Unlock()
+		return gc.ErrDisposableInUse
+	}
+
+	disposed := e.disposed
+	e.purge = true
+	e.disposed = true
+	e.m.Unlock() // unlock before attempting to remove from cache to avoid deadlock
+
+	// Schedule e to be removed from the cache
+	go e.cache.remove(e)
+
+	// Avoid disposing twice
+	if disposed {
+		return nil
+	}
+
+	// Dispose the resource
+	return e.resource.Dispose()
+}
+
+func (e *cacheEntry) release() {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	debug("cache entry '%s' released to cache, refCount: %d", e.optionsHash, e.refCount-1)
+
+	// Decrement reference count
+	e.refCount--
+	e.lastUsed = time.Now()
+
+	// Make sure we don't go negative
+	if e.refCount < 0 {
+		panic(fmt.Errorf("cacheEntry had refCount < 0 for resource type: %T", e.resource))
+	}
+
+	// If refCount is zero and this entry is scheduled to be purge, we dispose of it
+	if e.refCount == 0 && e.purge {
+		disposed := e.disposed
+		e.purge = true
+		e.disposed = true
+
+		// Schedule e to be removed from the cache
+		go e.cache.remove(e)
+
+		// Avoid disposing twice
+		if disposed {
+			return
+		}
+
+		// TODO: Report errors (ignore them for now)
+		go e.resource.Dispose()
+	}
+}

--- a/runtime/caching/cacheentry.go
+++ b/runtime/caching/cacheentry.go
@@ -66,14 +66,14 @@ func (e *cacheEntry) release() {
 
 	debug("cache entry '%s' released to cache, refCount: %d", e.optionsHash, e.refCount-1)
 
+	// Make sure we don't go negative
+	if e.refCount == 0 {
+		panic(fmt.Errorf("cacheEntry had refCount == 0 when decremented for resource type: %T", e.resource))
+	}
+
 	// Decrement reference count
 	e.refCount--
 	e.lastUsed = time.Now()
-
-	// Make sure we don't go negative
-	if e.refCount < 0 {
-		panic(fmt.Errorf("cacheEntry had refCount < 0 for resource type: %T", e.resource))
-	}
 
 	// If refCount is zero and this entry is scheduled to be purge, we dispose of it
 	if e.refCount == 0 && e.purge {

--- a/runtime/caching/context.go
+++ b/runtime/caching/context.go
@@ -1,0 +1,9 @@
+package caching
+
+import "context"
+
+// Context for creation of resources
+type Context interface {
+	context.Context
+	Progress(description string, percent float64)
+}

--- a/runtime/caching/contextconjunction.go
+++ b/runtime/caching/contextconjunction.go
@@ -1,0 +1,108 @@
+package caching
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+	"github.com/taskcluster/taskcluster-worker/runtime/util"
+)
+
+// a contextConjunction is conjunction of contexts, so which additional contexts
+// may be added later... When all the contexts have been canceled or dispose()
+// have been called, the contextConjunction will also be canceled.
+//
+// Notice: dispose() must be called to avoid leaking resources.
+type contextConjunction struct {
+	m        sync.Mutex
+	resolved atomics.Once
+	contexts []Context
+	err      error
+}
+
+// newContextConjunction creates a new contextConjunction starting with ctx
+//
+// Notice: dispose() must be called to avoid leaking resources.
+func newContextConjunction(ctx Context) *contextConjunction {
+	c := &contextConjunction{
+		contexts: []Context{ctx},
+	}
+
+	go c.awaitContexts()
+
+	return c
+}
+
+// dispose() cancels the context and cleanups resources, this must be called.
+func (c *contextConjunction) dispose() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.resolved.Do(func() {
+		c.err = context.Canceled
+	})
+}
+
+func (c *contextConjunction) awaitContexts() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	var err error
+	for i := 0; i < len(c.contexts); i++ {
+		ctx := c.contexts[i]
+		c.m.Unlock()
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case <-c.resolved.Done():
+		}
+		c.m.Lock()
+	}
+
+	c.resolved.Do(func() {
+		c.err = err
+	})
+}
+
+// AddContext to the conjunction, returns false if the contextConjunction was
+// canceled before ctx could be added.
+func (c *contextConjunction) AddContext(ctx Context) bool {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if c.resolved.IsDone() {
+		return false
+	}
+
+	c.contexts = append(c.contexts, ctx)
+	return true
+}
+
+func (c *contextConjunction) Progress(description string, percent float64) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	util.Spawn(len(c.contexts), func(i int) {
+		c.contexts[i].Progress(description, percent)
+	})
+}
+
+func (c *contextConjunction) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (c *contextConjunction) Done() <-chan struct{} {
+	return c.resolved.Done()
+}
+
+func (c *contextConjunction) Err() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	return c.err
+}
+
+func (c *contextConjunction) Value(key interface{}) interface{} {
+	return nil
+}

--- a/runtime/caching/doc.go
+++ b/runtime/caching/doc.go
@@ -1,0 +1,7 @@
+// Package caching provides an easy to make a cache on top of the gc package
+// used to track idle resources in taskcluster-worker.
+package caching
+
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
+
+var debug = util.Debug("caching")

--- a/runtime/caching/handle.go
+++ b/runtime/caching/handle.go
@@ -1,0 +1,37 @@
+package caching
+
+import (
+	"errors"
+	"sync"
+)
+
+// Handle holds a reference to a Resource until Release() is called
+type Handle struct {
+	m        sync.Mutex
+	entry    *cacheEntry
+	released bool
+}
+
+// Resource returns the resource held by the Handle
+func (h *Handle) Resource() Resource {
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	if h.released {
+		panic(errors.New("caching.Handle.Release() have been called releasing the resource"))
+	}
+
+	return h.entry.resource
+}
+
+// Release releases the resource held by the Handle, it safe to call this repeatedly
+func (h *Handle) Release() {
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	if h.released {
+		return // Don't release twice!
+	}
+	h.released = true
+	h.entry.release()
+}

--- a/runtime/caching/resource.go
+++ b/runtime/caching/resource.go
@@ -1,0 +1,14 @@
+package caching
+
+import "github.com/taskcluster/taskcluster-worker/runtime/gc"
+
+// ErrDisposableSizeNotSupported should be returned from DiskSize() and
+// MemorySize() if said feature is not supported
+var ErrDisposableSizeNotSupported = gc.ErrDisposableSizeNotSupported
+
+// A Resource that can be cached must also be disposable
+type Resource interface {
+	MemorySize() (uint64, error)
+	DiskSize() (uint64, error)
+	Dispose() error
+}

--- a/runtime/caching/utils.go
+++ b/runtime/caching/utils.go
@@ -1,0 +1,20 @@
+package caching
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// hashJSON takes interface{} as decoded by json.Unmarshal and returns a
+// hash of the data with all keys sorted.
+func hashJSON(data interface{}) string {
+	b, err := json.Marshal(data)
+	if err != nil {
+		panic(errors.Wrap(err, "expected data to be JSON serializable"))
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -14,7 +14,9 @@ type Environment struct {
 	TemporaryStorage
 	webhookserver.WebHookServer // Optional, may be nil if not available
 	Monitor
-	Worker      Stoppable
-	WorkerGroup string
-	WorkerID    string
+	Worker        Stoppable
+	ProvisionerID string
+	WorkerType    string
+	WorkerGroup   string
+	WorkerID      string
 }

--- a/runtime/fetcher/filereseter.go
+++ b/runtime/fetcher/filereseter.go
@@ -1,10 +1,17 @@
 package fetcher
 
-import "os"
+import "io"
+
+// File interface as implemented by *os.File
+type File interface {
+	Truncate(size int64) error
+	io.Seeker
+	io.Writer
+}
 
 // FileReseter implements WriteReseter for an *os.File instance
 type FileReseter struct {
-	*os.File
+	File
 }
 
 // Reset will truncate the file and seek to the beginning.

--- a/runtime/gc/gc.go
+++ b/runtime/gc/gc.go
@@ -79,7 +79,7 @@ func (gc *GarbageCollector) Register(resource Disposable) {
 // maybe have been disposed of while waiting for the GC lock. Say if the GC was
 // running when you made this call.
 //
-// Note, you don't have to use this method. When you resouce is in a state
+// Note, you don't have to use this method. When you resource is in a state
 // where you don't want it to be disposed just ensure that Dispose() returns
 // ErrDisposableInUse.
 func (gc *GarbageCollector) Unregister(resource Disposable) bool {

--- a/runtime/taskcontext.go
+++ b/runtime/taskcontext.go
@@ -187,6 +187,8 @@ func (c *TaskContext) Err() error {
 	// NOTE: This method is implemented to support the context.Context interface
 	//       and may not return anything but context.Canceled or
 	//       context.DeadlineExceeded.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if c.status == Aborted || c.status == Cancelled {
 		return context.Canceled
 	}
@@ -203,13 +205,13 @@ func (c *TaskContext) Abort() {
 	// TODO: (jonasfj): Remove this method TaskContext
 	// TODO (garndt): add abort/cancel channels for plugins to listen on
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.status = Aborted
 	select {
 	case <-c.done:
 	default:
 		close(c.done)
 	}
-	c.mu.Unlock()
 }
 
 // IsAborted returns true if the current status is Aborted

--- a/runtime/tempfolder.go
+++ b/runtime/tempfolder.go
@@ -29,6 +29,7 @@ type TemporaryFolder interface {
 
 // TemporaryFile is a temporary file that will be removed when closed.
 type TemporaryFile interface {
+	Truncate(size int64) error
 	io.ReadWriteSeeker
 	io.Closer
 	Path() string

--- a/runtime/webhookserver/webhooktunnel.go
+++ b/runtime/webhookserver/webhooktunnel.go
@@ -1,10 +1,10 @@
 package webhookserver
 
 import (
-	"errors"
 	"net/http"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/auth"
@@ -25,7 +25,7 @@ func NewWebhookTunnel(credentials *tcclient.Credentials) (*WebhookTunnel, error)
 		authClient := auth.New(credentials)
 		whresp, err := authClient.WebhooktunnelToken()
 		if err != nil {
-			return whclient.Config{}, errors.New("could not get token from tc-auth")
+			return whclient.Config{}, errors.Wrap(err, "could not get token from tc-auth")
 		}
 
 		return whclient.Config{

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,22 +3,6 @@
 	"ignore": "test",
 	"package": [
 		{
-			"path": "Add",
-			"revision": ""
-		},
-		{
-			"path": "fetch",
-			"revision": ""
-		},
-		{
-			"path": "folder",
-			"revision": ""
-		},
-		{
-			"path": "from",
-			"revision": ""
-		},
-		{
 			"checksumSHA1": "2avCvSn0XonfApKKuTMyiQmk7s0=",
 			"path": "github.com/Sirupsen/logrus",
 			"revision": "3ec0642a7fb6488f65b06f9040adc67e3990296a",
@@ -394,22 +378,28 @@
 			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
-			"checksumSHA1": "R32NrZ6Q3DDlu+LNdi4AnnjTsAg=",
+			"checksumSHA1": "8li21JoI/8M5rZySD68A7d10vac=",
 			"path": "github.com/taskcluster/taskcluster-client-go/index",
-			"revision": "ccd1bb49e35fb0bd48c510d144fd5f2d054e815a",
-			"revisionTime": "2017-06-12T10:23:26Z"
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
-			"checksumSHA1": "bNFuBG/RryZaHXV9krlZyU7KrGQ=",
+			"checksumSHA1": "jcRqERO5lLkfVZNLNGHOuJTbNXc=",
+			"path": "github.com/taskcluster/taskcluster-client-go/purgecache",
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
+		},
+		{
+			"checksumSHA1": "2ejtALFm/1HFJnQNZ1km6luvmB8=",
 			"path": "github.com/taskcluster/taskcluster-client-go/queue",
-			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
-			"revisionTime": "2017-04-13T22:51:09Z"
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
-			"checksumSHA1": "VIDHtEubzOxKcii86F5bSwcPMw8=",
+			"checksumSHA1": "ESepjdHscCzf9sKlXSBAGRNN5kA=",
 			"path": "github.com/taskcluster/taskcluster-client-go/secrets",
-			"revision": "23a058fed14aecf11e5f0a57c9f3bc7f31adc725",
-			"revisionTime": "2017-04-13T22:51:09Z"
+			"revision": "0adb988569ffd40f68ed3422835325cfb03581c5",
+			"revisionTime": "2017-07-06T18:25:07Z"
 		},
 		{
 			"checksumSHA1": "SeU/g0O6sCj2Ce+hdBHMDWlL3oc=",
@@ -562,6 +552,24 @@
 			"revisionTime": "2016-07-24T20:26:31Z"
 		},
 		{
+			"checksumSHA1": "EWPoHd6k70ZxvNR2zKUdcIYNl3k=",
+			"path": "gopkg.in/h2non/filetype.v1",
+			"revision": "22e255079ab40241c671d457081831d972f0436b",
+			"revisionTime": "2017-08-03T09:23:50Z"
+		},
+		{
+			"checksumSHA1": "OmK2aAXxzKRJ9xNhXCcC43fpwqI=",
+			"path": "gopkg.in/h2non/filetype.v1/matchers",
+			"revision": "22e255079ab40241c671d457081831d972f0436b",
+			"revisionTime": "2017-08-03T09:23:50Z"
+		},
+		{
+			"checksumSHA1": "vPleg/8tgVv8jnMqT7zEQ0jWW2M=",
+			"path": "gopkg.in/h2non/filetype.v1/types",
+			"revision": "22e255079ab40241c671d457081831d972f0436b",
+			"revisionTime": "2017-08-03T09:23:50Z"
+		},
+		{
 			"checksumSHA1": "hiOUviIMDKo7y918uBiEhfJyOkk=",
 			"path": "gopkg.in/tylerb/graceful.v1",
 			"revision": "50a48b6e73fcc75b45e22c05b79629a67c79e938",
@@ -572,34 +580,6 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "31c299268d302dd0aa9a0dcf765a3d58971ac83f",
 			"revisionTime": "2016-09-12T16:56:03Z"
-		},
-		{
-			"path": "new",
-			"revision": ""
-		},
-		{
-			"path": "or",
-			"revision": ""
-		},
-		{
-			"path": "packages",
-			"revision": ""
-		},
-		{
-			"path": "remote",
-			"revision": ""
-		},
-		{
-			"path": "repository.",
-			"revision": ""
-		},
-		{
-			"path": "update",
-			"revision": ""
-		},
-		{
-			"path": "vendor",
-			"revision": ""
 		}
 	],
 	"rootPath": "github.com/taskcluster/taskcluster-worker"

--- a/worker/taskrun/taskrun_test.go
+++ b/worker/taskrun/taskrun_test.go
@@ -32,6 +32,10 @@ func TestTaskRun(t *testing.T) {
 		GarbageCollector: gc,
 		TemporaryStorage: storage,
 		WebHookServer:    server,
+		ProvisionerID:    "taskrun-tests",
+		WorkerType:       "taskrun-worker",
+		WorkerGroup:      "taskrun-tests",
+		WorkerID:         "localhost",
 	}
 
 	options := Options{

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -98,6 +98,8 @@ func New(config interface{}) (w *Worker, err error) {
 		Worker:           &w.lifeCycleTracker,
 		WorkerGroup:      c.WorkerOptions.WorkerGroup,
 		WorkerID:         c.WorkerOptions.WorkerID,
+		ProvisionerID:    c.WorkerOptions.ProvisionerID,
+		WorkerType:       c.WorkerOptions.WorkerType,
 	}
 
 	// Create engine

--- a/worker/workertest/artifactassertions.go
+++ b/worker/workertest/artifactassertions.go
@@ -21,6 +21,14 @@ func GrepArtifact(substring string) func(t *testing.T, a Artifact) {
 	}
 }
 
+// NotGrepArtifact creates an assertion that holds if the artifact does not
+// contain the given substring.
+func NotGrepArtifact(substring string) func(t *testing.T, a Artifact) {
+	return func(t *testing.T, a Artifact) {
+		assert.NotContains(t, string(a.Data), substring, "Expected substring to NOT be in artifact: %s", a.Name)
+	}
+}
+
 // LogArtifact creates an assetion that logs the artifact, to test log.
 // This is mostly useful when developing integration tests.
 func LogArtifact() func(t *testing.T, a Artifact) {

--- a/worker/workertest/workertest.go
+++ b/worker/workertest/workertest.go
@@ -38,6 +38,7 @@ type Case struct {
 // A Task to be included in a worker test case
 type Task struct {
 	Title           string                  // Optional title (for debugging)
+	Scopes          []string                // Task scopes
 	Payload         string                  // Task payload as JSON
 	Success         bool                    // True, if task should be successfully
 	Exception       runtime.ExceptionReason // Reason, if exception is expected
@@ -239,6 +240,7 @@ func (c Case) testWithQueue(t *testing.T, q *queue.Queue, l fakequeue.Listener) 
 		if title == "" {
 			title = fmt.Sprintf("Task %d", i)
 		}
+		tdef.Scopes = task.Scopes
 		tdef.Metadata.Name = title
 		tdef.Metadata.Description = "Task from taskcluster-worker integration tests"
 		tdef.Metadata.Source = "https://github.com/taskcluster/taskcluster-worker/tree/master/worker/workertest/workertest.go"


### PR DESCRIPTION
Focus on the `engines/engine.go` and `engines/volume.go`

This is the changes to the abstractions... the idea is that when a volume is created you can pass an object matching an engine specific `VolumeSchema` with options...

For `docker` engine options might be whether to use a ramdisk or block device disk.

For `qemu` engine options might be disk size and file system format.

For `native` engine options might be nothing...

Note:
  * `Volume` an object created by an engine, and consumed by an engine using the `AttachVolume` method.
    * For `docker` engine a `Volume` is probably just a folder, maybe a ramdisk
    * For `native` engine a `Volume` is probably just a folder
  * `Volume` is attached at a `mountPoint`, this is engine specific:
    * For `docker` engine the `mountPoint` is a file-system path
    * For `native` engine the `mountPoint` is probably the name of a symlink to the folder
    * For `qemu` engine the `mountPoint` is a string communicated to the guest-tools (they probably expect it as a file-system mount-point for drive letter, depending on platform).
  * `VolumeBuilder` is an engine specific abstraction that allows injection of file **before** a volume is created
  * engines can choose to only support empty volume by only implementing `NewVolume(options)`

In the future the `cache` plugin will probably expect a list of caches as:
```js
task.payload.caches = [
  {
    // Name used to identify cache across tasks, protected by scope, and used by purge-cache
    "name":    "my-cache-name",
    // Mount-point depending on engine this could be a file-path, drive-letter or a symlink name
    "path":    "d:",
    // Options passed to NewVolume(...) or NewVolumeBuilder(...), these are engine-specific
    // the cache plugin just exposes whatever schema the engine provides, and passes the
    // options through to the engine. Could be ram-disk/hard-disk, max-disk-size, file-system 
    "options": {"size": 20, "format": "ntfs"},
    // Optional, reference to something that should be loaded into the cache
    // See runtime/fetcher/ for the various schemas that can be used to reference something
    "content": {"taskId": ..., "artifact": "..."},
  }, ....
]
```

Notice that in the scheme above:
  * `name` would be optional, if present the volume is read-write, if not present the volume is read-only.
  * `content` is optional, if `name` is present; otherwise required as volume would be read-only.

The reasoning for the above is that if a volume is read-only, then it can be identified by the hash of the `content` reference that it was loaded from. `runtime/fetcher` already supports hashing references.
And obviously, a read-only volume only makes sense if some content is initially loaded into it :)