### PR TITLE
Wrap error from failure to create log file, this should provide bette…

### DIFF
--- a/runtime/taskcontext.go
+++ b/runtime/taskcontext.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +10,7 @@ import (
 
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
 	"github.com/taskcluster/taskcluster-worker/runtime/ioext"
 
@@ -86,7 +86,7 @@ type TaskContextController struct {
 func NewTaskContext(tempLogFile string, task TaskInfo) (*TaskContext, *TaskContextController, error) {
 	logStream, err := stream.New(tempLogFile)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "failed to create temporary file for storing log")
 	}
 	ctx := &TaskContext{
 		logStream:   logStream,


### PR DESCRIPTION
…r error messages

I suspect this is what ends up as:
https://sentry.prod.mozaws.net/operations/taskcluster-worker/issues/673624/events/12678540/

This won't fix, but it'll force highlight quite a bit more. My guess that something is wrong with the folder we use for temporary files...