### PR TITLE
Change watchdog informational message level to debug.

### DIFF
--- a/plugins/watchdog/watchdog.go
+++ b/plugins/watchdog/watchdog.go
@@ -87,7 +87,7 @@ func (p *plugin) waitForTimeout() {
 }
 
 func (p *plugin) Touch() {
-	p.Monitor.Info("watchdog touched")
+	p.Monitor.Debug("watchdog touched")
 
 	p.m.Lock()
 	defer p.m.Unlock()


### PR DESCRIPTION
taskcluster-worker is flooding papertrail with "watchdog touched"
messages and making it difficult to make a realtime following of the log
messages.