### PR TITLE
Add syslog name to errors

### DIFF
--- a/runtime/monitoring/monitor.go
+++ b/runtime/monitoring/monitor.go
@@ -73,7 +73,7 @@ func NewMonitor(project string, auth client.Auth, logLevel string, tags map[stri
 
 	if syslogName != "" {
 		if err := setupSyslog(logger, syslogName); err != nil {
-			m.ReportError(err, "Cannot set up syslog output")
+			m.ReportError(err, fmt.Sprintf("Cannot set up syslog output, syslog name configured: '%s'", syslogName))
 		}
 	}
 


### PR DESCRIPTION
Improving error messages from syslog errors...

----
I figure no harm can come from adding additional information.