### PR TITLE
Added per-container network to docker-engine

### DIFF
--- a/engines/docker/sandboxbuilder.go
+++ b/engines/docker/sandboxbuilder.go
@@ -46,18 +46,6 @@ func newSandboxBuilder(payload *payloadType, e *engine, monitor runtime.Monitor,
 	return sb
 }
 
-func (sb *sandboxBuilder) generateDockerConfig() *docker.Config {
-	image := buildImageName(sb.image.Repository, sb.image.Tag)
-	conf := &docker.Config{
-		Cmd:          sb.command,
-		Image:        image,
-		Env:          *sb.env,
-		AttachStdout: true,
-		AttachStderr: true,
-	}
-	return conf
-}
-
 func (sb *sandboxBuilder) asyncFetchImage(ctx caching.Context) {
 	handle, err := sb.e.cache.Require(ctx, sb.image)
 	if handle != nil {


### PR DESCRIPTION
This is written on top of `fix-docker-kill`, but otherwise it should be merged into the `docker-engine` branch..

There is a few renames and cleanups, etc...

Notable fix is that containers can't talk to each other anymore. And we're prepared for adding proxy support, which I'll play with later...