### PR TITLE
Fix client ID validation pattern

### DIFF
--- a/worker/config.go
+++ b/worker/config.go
@@ -144,7 +144,7 @@ var credentialsSchema schematypes.Schema = schematypes.Object{
 		"clientId": schematypes.String{
 			Title:       "ClientId",
 			Description: `ClientId for credentials`,
-			Pattern:     `^[A-Za-z0-9@/:._-]+$`,
+			Pattern:     `^[A-Za-z0-9@/:._|-]+$`,
 		},
 		"accessToken": schematypes.String{
 			Title:       "AccessToken",


### PR DESCRIPTION
Client IDs with LDAP portions in its composition may include the '|'
character.