### PR TITLE
document artifacts for script-engine

### DIFF
--- a/engines/script/config.go
+++ b/engines/script/config.go
@@ -22,7 +22,18 @@ var configSchema = schematypes.Object{
 			Title: "Command to Execute",
 			Description: util.Markdown(`
 				Script and arguments to execute. This script will be fed
-				a JSON string that matches the schema configured over stdin.
+				a JSON string that matches the schema configured over 'stdin'.
+
+				Output from the script over 'stdout' will be uploaded as task log.
+				Output from the script over 'stderr' will be prefixed "[worker:error]"
+				and merged with task log.
+				The script will be executed with a temporary folder as
+				_working directory_, this folder can be used for temporary storage and
+				will be cleared between tasks. Files and folder stored in './artifacts/'
+				relative to the _working directory_ will be uploaded as artifacts from
+				the script. Hence, to make a public tar-ball artifact you create
+				'./artifact/public/my-build.tar.gz' which will be uploaded as an
+				artifact named 'public/my-build.tar.gz'.
 			`),
 			Items: schematypes.String{},
 		},


### PR DESCRIPTION
This is just documenting existing behavior for @bclary.

I think we need some more general documentation that also explains the difference between script-engine and native-engine.
In my mind native-engine let's the `task.payload` control the machine using the user account configured, and you must trust the task author to not do bad things (or isolate your machine appropriately).
With script-engine you don't have to trust the `task.payload` author because the payload is always passed to a script. So instead you trust the script... if the script allows arbitrary behavior then clearly you're back to trusting the task author. But the script could take mitigating steps.

The aim of script-engine is to allow running trusted commands only, if you allow the task author to control the machine then native-engine is just as good.

Anyways, we'll probably document that in more details later... 