### PR TITLE
Add tasklog plugin fixing #351

### DIFF
--- a/plugins/livelog/doc.go
+++ b/plugins/livelog/doc.go
@@ -1,6 +1,9 @@
 // Package livelog provides a taskcluster-worker plugin that makes the task log
 // available as a live log during task execution and finally uploads it as a
 // static log.
+//
+// This plugin should not be used in combination with the 'tasklog' plugin, as
+// this plugin provides strictly more features.
 package livelog
 
 import "github.com/taskcluster/taskcluster-worker/runtime/util"

--- a/plugins/livelog/livelog.go
+++ b/plugins/livelog/livelog.go
@@ -1,5 +1,3 @@
-// Package livelog implements a webhook handler for serving up livelogs of a task
-// sandbox.
 package livelog
 
 import (

--- a/plugins/plugintest/plugintest.go
+++ b/plugins/plugintest/plugintest.go
@@ -77,7 +77,7 @@ type Case struct {
 
 	// ClientID to be passed to TaskContext
 	ClientID string
-	// AccessToken to be assed to TaskContext
+	// AccessToken to be passed to TaskContext
 	AccessToken string
 	// Certificate to be passed to TaskContext
 	Certificate string
@@ -324,8 +324,8 @@ func newTestEnvironment() runtime.Environment {
 }
 
 func parsePluginConfig(provider plugins.PluginProvider, data string) interface{} {
-	if data == "" {
-		return nil
+	if provider.ConfigSchema() == nil {
+		return nil // don't attempt to create pluginPlugin if none is required
 	}
 	var j interface{}
 	err := json.Unmarshal([]byte(data), &j)

--- a/plugins/tasklog/doc.go
+++ b/plugins/tasklog/doc.go
@@ -1,0 +1,13 @@
+// Package tasklog provides a taskcluster-worker plugin that uploads a static
+// task.log when the task is finished.
+//
+// This plugin should not be used in combination with the 'livelog' plugin, but
+// is instead an alternative to the 'livelog' plugin. This plugin provides a
+// strict subset of features offered by the 'livelog' plugin, however, this
+// plugin will not offer any interactive aspects, hence, some might consider it
+// more secure.
+package tasklog
+
+import "github.com/taskcluster/taskcluster-worker/runtime/util"
+
+var debug = util.Debug("tasklog")

--- a/plugins/tasklog/tasklog.go
+++ b/plugins/tasklog/tasklog.go
@@ -94,7 +94,7 @@ func (tp *taskPlugin) uploadLog() error {
 
 	// Upload gzipped task.log
 	debug("uploading 'public/logs/task.log'")
-	tp.context.UploadS3Artifact(runtime.S3Artifact{
+	err = tp.context.UploadS3Artifact(runtime.S3Artifact{
 		Name:     "public/logs/task.log",
 		Mimetype: "text/plain; charset=utf-8",
 		Expires:  tp.context.TaskInfo.Expires,

--- a/plugins/tasklog/tasklog.go
+++ b/plugins/tasklog/tasklog.go
@@ -1,0 +1,113 @@
+package tasklog
+
+import (
+	"compress/gzip"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/taskcluster/taskcluster-worker/plugins"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+)
+
+type pluginProvider struct {
+	plugins.PluginProviderBase
+}
+
+type plugin struct {
+	plugins.PluginBase
+	monitor     runtime.Monitor
+	environment *runtime.Environment
+}
+
+type taskPlugin struct {
+	plugins.TaskPluginBase
+	parent   *plugin
+	context  *runtime.TaskContext
+	monitor  runtime.Monitor
+	uploaded atomics.Once // ensure we only upload once
+}
+
+func init() {
+	plugins.Register("tasklog", &pluginProvider{})
+}
+
+func (pluginProvider) NewPlugin(options plugins.PluginOptions) (plugins.Plugin, error) {
+	debug("Created tasklog plugin")
+	return &plugin{
+		monitor:     options.Monitor,
+		environment: options.Environment,
+	}, nil
+}
+
+func (p *plugin) NewTaskPlugin(options plugins.TaskPluginOptions) (plugins.TaskPlugin, error) {
+	debug("Created tasklog taskPlugin")
+	return &taskPlugin{
+		parent:  p,
+		context: options.TaskContext,
+		monitor: options.Monitor,
+	}, nil
+}
+
+func (tp *taskPlugin) Finished(success bool) error {
+	var err error
+	tp.uploaded.Do(func() {
+		err = tp.uploadLog()
+	})
+	return err
+}
+
+func (tp *taskPlugin) Exception(runtime.ExceptionReason) error {
+	var err error
+	tp.uploaded.Do(func() {
+		err = tp.uploadLog()
+	})
+	return err
+}
+
+func (tp *taskPlugin) uploadLog() error {
+	// Get the log
+	logFile, err := tp.context.ExtractLog()
+	if err != nil {
+		return errors.Wrap(err, "tasklog: TaskContext.extractLog() failed")
+	}
+	defer logFile.Close()
+
+	// Create temporary file for gzipping
+	tempFile, err := tp.parent.environment.TemporaryStorage.NewFile()
+	if err != nil {
+		return errors.Wrap(err, "tasklog: failed to create temporary file")
+	}
+	defer tempFile.Close()
+
+	// gzip the log
+	zip := gzip.NewWriter(tempFile)
+	if _, err = io.Copy(zip, logFile); err != nil {
+		return errors.Wrap(err, "tasklog: failed to read log-file")
+	}
+	if err = zip.Close(); err != nil {
+		return errors.Wrap(err, "tasklog: failed to gzip log-file")
+	}
+	if _, err = tempFile.Seek(0, io.SeekStart); err != nil {
+		return errors.Wrap(err, "tasklog: failed to seek start of temp file")
+	}
+
+	// Upload gzipped task.log
+	debug("uploading 'public/logs/task.log'")
+	tp.context.UploadS3Artifact(runtime.S3Artifact{
+		Name:     "public/logs/task.log",
+		Mimetype: "text/plain; charset=utf-8",
+		Expires:  tp.context.TaskInfo.Expires,
+		Stream:   tempFile,
+		AdditionalHeaders: map[string]string{
+			"Content-Encoding": "gzip",
+		},
+	})
+	if err != nil {
+		tp.monitor.Error(errors.Wrap(err, "failed to update task.log"))
+		// Upload error isn't fatal, could just be bad network
+		return runtime.ErrNonFatalInternalError
+	}
+
+	return nil
+}

--- a/plugins/tasklog/tasklog_test.go
+++ b/plugins/tasklog/tasklog_test.go
@@ -1,0 +1,65 @@
+package tasklog
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/slugid-go/slugid"
+	"github.com/taskcluster/taskcluster-client-go/tcqueue"
+	"github.com/taskcluster/taskcluster-worker/plugins/plugintest"
+	"github.com/taskcluster/taskcluster-worker/runtime/client"
+)
+
+func TestTaskLog(t *testing.T) {
+	taskID := slugid.Nice()
+
+	// Simulated S3 server
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := gzip.NewReader(r.Body)
+		require.NoError(t, err, "failed to read gzipped body (simulated s3 server)")
+		data, err := ioutil.ReadAll(body)
+		require.NoError(t, err, "failed to read body (simulated s3 server)")
+
+		debug("got data: '%s'", string(data))
+		require.Contains(t, string(data), "magic-words-to-look-for")
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+
+	s3resp, _ := json.Marshal(tcqueue.S3ArtifactResponse{
+		PutURL: s3.URL,
+	})
+	resp := tcqueue.PostArtifactResponse(s3resp)
+	queueMock := &client.MockQueue{}
+	queueMock.On(
+		"CreateArtifact",
+		taskID,
+		"0",
+		"public/logs/task.log",
+		client.PostS3ArtifactRequest,
+	).Return(&resp, nil)
+
+	// Define test case
+	plugintest.Case{
+		TaskID:    taskID,
+		QueueMock: queueMock,
+		Payload: `{
+			"delay": 0,
+			"function": "write-log",
+			"argument": "magic-words-to-look-for"
+		}`,
+		Plugin:        "tasklog",
+		PluginConfig:  `{}`,
+		PluginSuccess: true,
+		EngineSuccess: true,
+	}.Test()
+
+	// test mock assertions
+	queueMock.AssertExpectations(t)
+}


### PR DESCRIPTION
This adds a simple `tasklog` plugin, that just does static logs.
Maybe I should have called it `staticlog`, but `tasklog` also works.
There is no reason to run this next to `livelog`, it's a strict subset
of the features offered by the `livelog`.

**Motivation**, ability to better lock down security critical workers,
that you don't want to handle requests, even if they are proxied through
`webhooktunnel`. Other motivation is that I suspect some of the bugs
@bclary is hitting could be related to `livelog` or `webhooktunnel`,
if using this plugin instead of `livelog` fixes his problems, then
we know for sure we have a bug in `livelog`. Right now, bugs in `livelog`
is pure speculation.