### PR TITLE
Test empty artifact

### DIFF
--- a/test/scripttest/artifact_test.go
+++ b/test/scripttest/artifact_test.go
@@ -22,6 +22,16 @@ func TestArtifacts(t *testing.T) {
 				"public/logs/live_backing.log": workertest.AnyArtifact(),
 				"public/build/test-output.txt": workertest.GrepArtifact("hello-world"),
 			},
+		}, {
+			Title:           "empty artifact",
+			Success:         true,
+			Payload:         `{"result": "pass", "artifacts": {"public/build/test-output.txt": ""}}`,
+			AllowAdditional: false,
+			Artifacts: workertest.ArtifactAssertions{
+				"public/logs/live.log":         workertest.AnyArtifact(),
+				"public/logs/live_backing.log": workertest.AnyArtifact(),
+				"public/build/test-output.txt": workertest.MatchArtifact("", "text/plain; charset=utf-8"),
+			},
 		}},
 	}.Test(t)
 }


### PR DESCRIPTION
Fixing #342 as @bclary reported issues with empty artifacts, it seems
only fair to actually test for this... This adds an empty artifact to
script-engine integration tests, and shows that it indeed does work.