### PR TITLE
Fixing #366 by adding fetcher.FetchAsStream()

### DIFF
--- a/runtime/fetcher/artifactfetcher_test.go
+++ b/runtime/fetcher/artifactfetcher_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestArtifactFetcherScopesPublic(t *testing.T) {
-	ctx := &mockContext{Context: context.Background()}
+	ctx := &fakeContext{Context: context.Background()}
 	ref, err := Artifact.NewReference(ctx, map[string]interface{}{
 		"taskId":   "H6SAIKUFT2mewKH-qHzXjQ",
 		"runId":    0,
@@ -19,7 +19,7 @@ func TestArtifactFetcherScopesPublic(t *testing.T) {
 }
 
 func TestArtifactFetcherScopesPrivate(t *testing.T) {
-	ctx := &mockContext{Context: context.Background()}
+	ctx := &fakeContext{Context: context.Background()}
 	ref, err := Artifact.NewReference(ctx, map[string]interface{}{
 		"taskId":   "H6SAIKUFT2mewKH-qHzXjQ",
 		"runId":    0,

--- a/runtime/fetcher/fakes_test.go
+++ b/runtime/fetcher/fakes_test.go
@@ -11,36 +11,36 @@ import (
 	"github.com/taskcluster/taskcluster-worker/runtime/client"
 )
 
-type mockContext struct {
+type fakeContext struct {
 	context.Context
 	queue           client.Queue
 	m               sync.Mutex
 	progressReports []float64
 }
 
-func (c *mockContext) Queue() client.Queue {
+func (c *fakeContext) Queue() client.Queue {
 	return c.queue
 }
 
-func (c *mockContext) Progress(description string, percent float64) {
+func (c *fakeContext) Progress(description string, percent float64) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	debug("Progress: %s - %.02f %%", description, percent*100)
 	c.progressReports = append(c.progressReports, percent)
 }
 
-func (c *mockContext) ProgressReports() []float64 {
+func (c *fakeContext) ProgressReports() []float64 {
 	c.m.Lock()
 	defer c.m.Unlock()
 	return c.progressReports
 }
 
-type mockWriteReseter struct {
+type fakeWriteReseter struct {
 	offset int64
 	buffer []byte
 }
 
-func (w *mockWriteReseter) Write(p []byte) (int, error) {
+func (w *fakeWriteReseter) Write(p []byte) (int, error) {
 	offset := w.offset + int64(len(p))
 	if int64(len(w.buffer)) < offset {
 		w.buffer = append(w.buffer, make([]byte, offset-int64(len(w.buffer)))...)
@@ -50,18 +50,18 @@ func (w *mockWriteReseter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (w *mockWriteReseter) Reset() error {
+func (w *fakeWriteReseter) Reset() error {
 	w.offset = 0
 	w.buffer = nil
 	return nil
 }
 
-func (w *mockWriteReseter) String() string {
+func (w *fakeWriteReseter) String() string {
 	return string(w.buffer)
 }
 
-func TestMockWriteSeekReseter(t *testing.T) {
-	w := &mockWriteReseter{}
+func TestFakeWriteSeekReseter(t *testing.T) {
+	w := &fakeWriteReseter{}
 	_, err := io.Copy(w, bytes.NewBufferString("test"))
 	require.NoError(t, err)
 	require.Equal(t, w.String(), "test")

--- a/runtime/fetcher/fakes_test.go
+++ b/runtime/fetcher/fakes_test.go
@@ -3,6 +3,8 @@ package fetcher
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"errors"
 	"io"
 	"sync"
 	"testing"
@@ -75,4 +77,152 @@ func TestFakeWriteSeekReseter(t *testing.T) {
 	_, err = io.Copy(w, bytes.NewBufferString(" test again"))
 	require.NoError(t, err)
 	require.Equal(t, w.String(), "test again test again")
+}
+
+type fakeReference struct {
+	ScopesValue  [][]string
+	HashKeyValue string
+	Data         []byte
+	Reset        bool
+	Err          error
+}
+
+func (r *fakeReference) HashKey() string {
+	return r.HashKeyValue
+}
+
+func (r *fakeReference) Scopes() [][]string {
+	return r.ScopesValue
+}
+
+func (r *fakeReference) Fetch(context Context, target WriteReseter) error {
+	i := 0
+	// Write a few small blocks
+	if i+1 < len(r.Data) {
+		n, err := target.Write(r.Data[i : i+1])
+		if err != nil {
+			return err
+		}
+		if n != 1 {
+			panic(errors.New("Expected n = 1 when no error was returned"))
+		}
+		i += n
+	}
+	if i+7 < len(r.Data) {
+		n, err := target.Write(r.Data[i : i+7])
+		if err != nil {
+			return err
+		}
+		if n != 7 {
+			panic(errors.New("Expected n = 7 when no error was returned"))
+		}
+		i += n
+	}
+	if i+3 < len(r.Data) {
+		n, err := target.Write(r.Data[i : i+3])
+		if err != nil {
+			return err
+		}
+		if n != 3 {
+			panic(errors.New("Expected n = 3 when no error was returned"))
+		}
+		i += n
+	}
+	if i < len(r.Data) {
+		n, err := target.Write(r.Data[i:])
+		if err != nil {
+			return err
+		}
+		if n != len(r.Data)-i {
+			panic(errors.New("Expected n = len(r.Data)-i when no error was returned"))
+		}
+	}
+	if r.Reset {
+		r.Reset = false
+		if err := target.Reset(); err != nil {
+			return nil
+		}
+		return r.Fetch(context, target)
+	}
+	return r.Err
+}
+
+func TestFakeReference(t *testing.T) {
+	ctx := &fakeContext{Context: context.Background()}
+	// Create a random blob
+	blob := make([]byte, 16*1024+27)
+	_, rerr := rand.Read(blob)
+	require.NoError(t, rerr, "failed to created random data for testing")
+
+	t.Run("Empty String without Reset", func(t *testing.T) {
+		r := &fakeReference{
+			Data:  []byte(""),
+			Reset: false,
+			Err:   nil,
+		}
+		w := &fakeWriteReseter{}
+		err := r.Fetch(ctx, w)
+		require.NoError(t, err)
+		require.Equal(t, "", w.String())
+	})
+
+	t.Run("hello-world without Reset", func(t *testing.T) {
+		r := &fakeReference{
+			Data:  []byte("hello-world"),
+			Reset: false,
+			Err:   nil,
+		}
+		w := &fakeWriteReseter{}
+		err := r.Fetch(ctx, w)
+		require.NoError(t, err)
+		require.Equal(t, "hello-world", w.String())
+	})
+
+	t.Run("blob without Reset", func(t *testing.T) {
+		r := &fakeReference{
+			Data:  blob,
+			Reset: false,
+			Err:   nil,
+		}
+		w := &fakeWriteReseter{}
+		err := r.Fetch(ctx, w)
+		require.NoError(t, err)
+		require.True(t, bytes.Compare(blob, w.buffer) == 0, "expected blob == w.buffer")
+	})
+
+	t.Run("Empty String with Reset", func(t *testing.T) {
+		r := &fakeReference{
+			Data:  []byte(""),
+			Reset: true,
+			Err:   nil,
+		}
+		w := &fakeWriteReseter{}
+		err := r.Fetch(ctx, w)
+		require.NoError(t, err)
+		require.Equal(t, "", w.String())
+	})
+
+	t.Run("hello-world with Reset", func(t *testing.T) {
+		r := &fakeReference{
+			Data:  []byte("hello-world"),
+			Reset: true,
+			Err:   nil,
+		}
+		w := &fakeWriteReseter{}
+		err := r.Fetch(ctx, w)
+		require.NoError(t, err)
+		require.Equal(t, "hello-world", w.String())
+	})
+
+	t.Run("blob with Reset", func(t *testing.T) {
+		r := &fakeReference{
+			Data:  blob,
+			Reset: true,
+			Err:   nil,
+		}
+		w := &fakeWriteReseter{}
+		err := r.Fetch(ctx, w)
+		require.NoError(t, err)
+		require.True(t, bytes.Compare(blob, w.buffer) == 0, "expected blob == w.buffer")
+	})
 }

--- a/runtime/fetcher/fakes_test.go
+++ b/runtime/fetcher/fakes_test.go
@@ -38,22 +38,15 @@ func (c *fakeContext) ProgressReports() []float64 {
 }
 
 type fakeWriteReseter struct {
-	offset int64
 	buffer []byte
 }
 
 func (w *fakeWriteReseter) Write(p []byte) (int, error) {
-	offset := w.offset + int64(len(p))
-	if int64(len(w.buffer)) < offset {
-		w.buffer = append(w.buffer, make([]byte, offset-int64(len(w.buffer)))...)
-	}
-	copy(w.buffer[w.offset:], p)
-	w.offset = offset
+	w.buffer = append(w.buffer, p...)
 	return len(p), nil
 }
 
 func (w *fakeWriteReseter) Reset() error {
-	w.offset = 0
 	w.buffer = nil
 	return nil
 }

--- a/runtime/fetcher/fakes_test.go
+++ b/runtime/fetcher/fakes_test.go
@@ -187,7 +187,7 @@ func TestFakeReference(t *testing.T) {
 		w := &fakeWriteReseter{}
 		err := r.Fetch(ctx, w)
 		require.NoError(t, err)
-		require.True(t, bytes.Compare(blob, w.buffer) == 0, "expected blob == w.buffer")
+		require.True(t, bytes.Equal(blob, w.buffer), "expected blob == w.buffer")
 	})
 
 	t.Run("Empty String with Reset", func(t *testing.T) {
@@ -223,6 +223,6 @@ func TestFakeReference(t *testing.T) {
 		w := &fakeWriteReseter{}
 		err := r.Fetch(ctx, w)
 		require.NoError(t, err)
-		require.True(t, bytes.Compare(blob, w.buffer) == 0, "expected blob == w.buffer")
+		require.True(t, bytes.Equal(blob, w.buffer), "expected blob == w.buffer")
 	})
 }

--- a/runtime/fetcher/fetchasstream.go
+++ b/runtime/fetcher/fetchasstream.go
@@ -28,7 +28,7 @@ func FetchAsStream(context Context, reference Reference, target StreamHandler) e
 
 	// fetch and close after fetching
 	ferr := reference.Fetch(context, s)
-	cerr := s.Close()
+	cerr := s.CloseWithError(ferr)
 
 	if ferr != nil {
 		return ferr
@@ -88,12 +88,12 @@ func (s *streamReseter) Reset() error {
 	return nil
 }
 
-func (s *streamReseter) Close() error {
+func (s *streamReseter) CloseWithError(err error) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 
 	// Ensure that the writer pipe is closed
-	s.writer.Close() // ignore error, we don't care if it's closed twice
+	s.writer.CloseWithError(err) // ignore error, we don't care if it's closed twice
 
 	// Wait for the most recent handler call to be finished
 	s.m.Unlock()

--- a/runtime/fetcher/fetchasstream.go
+++ b/runtime/fetcher/fetchasstream.go
@@ -27,7 +27,7 @@ func FetchAsStream(context Context, reference Reference, target StreamHandler) e
 	s.Reset() // initialize
 
 	// fetch and close after fetching
-	ferr := reference.Fetch(context, s)
+	ferr := reference.Fetch(context, s) // Notice that Fetch() may invoke s.Reset()
 	cerr := s.CloseWithError(ferr)
 
 	if ferr != nil {

--- a/runtime/fetcher/fetchasstream.go
+++ b/runtime/fetcher/fetchasstream.go
@@ -1,0 +1,104 @@
+package fetcher
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/taskcluster/taskcluster-worker/runtime/atomics"
+)
+
+// ErrStreamReset returned from io.Reader when the fetch process is reset
+var ErrStreamReset = errors.New("stream was reset by fetcher")
+
+// A StreamHandler is a function that handles a stream, the stream maybe a
+// aborted in which case io.Reader will return ErrStreamReset and the Context
+// will be canceled.
+type StreamHandler func(context.Context, io.Reader) error
+
+// FetchAsStream gets a reference as a stream.
+//
+// Notice that target StreamHandler may be invoked multiple times, if the
+// connection breaks while fetching it might be retried. In which case the
+// Context passed to the target StreamHandler will be canceled.
+func FetchAsStream(context Context, reference Reference, target StreamHandler) error {
+	s := &streamReseter{handler: target}
+	s.Reset() // initialize
+
+	// fetch and close after fetching
+	ferr := reference.Fetch(context, s)
+	cerr := s.Close()
+
+	if ferr != nil {
+		return ferr
+	}
+	return cerr
+}
+
+type streamReseter struct {
+	m       sync.Mutex
+	handler StreamHandler
+	reader  *io.PipeReader
+	writer  *io.PipeWriter
+	ctx     context.Context
+	cancel  func()
+	done    atomics.Once // covers err
+	err     error
+}
+
+func (s *streamReseter) Write(p []byte) (n int, err error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	return s.writer.Write(p)
+}
+
+func (s *streamReseter) Reset() error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	// Discard current state if any
+	if s.cancel != nil {
+		s.cancel()
+		s.writer.CloseWithError(ErrStreamReset)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reader, writer := io.Pipe()
+	s.reader = reader
+	s.writer = writer
+	s.ctx = ctx
+	s.cancel = cancel
+
+	go func() {
+		defer cancel()
+
+		err := s.handler(ctx, reader)
+		reader.CloseWithError(err)
+
+		s.m.Lock()
+		defer s.m.Unlock()
+		if ctx.Err() == nil {
+			s.err = err
+			s.done.Do(nil)
+		}
+	}()
+
+	return nil
+}
+
+func (s *streamReseter) Close() error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	// Ensure that the writer pipe is closed
+	s.writer.Close() // ignore error, we don't care if it's closed twice
+
+	// Wait for the most recent handler call to be finished
+	s.m.Unlock()
+	s.done.Wait()
+	s.m.Lock()
+
+	return s.err
+}

--- a/runtime/fetcher/fetchasstream_test.go
+++ b/runtime/fetcher/fetchasstream_test.go
@@ -66,7 +66,7 @@ func TestFetchAsStream(t *testing.T) {
 			return cerr
 		})
 		require.NoError(t, err)
-		require.True(t, bytes.Compare(blob, result) == 0, "expected blob == result")
+		require.True(t, bytes.Equal(blob, result), "expected blob == result")
 	})
 
 	t.Run("blob with Reset", func(t *testing.T) {
@@ -85,11 +85,10 @@ func TestFetchAsStream(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
-		require.True(t, bytes.Compare(blob, result) == 0, "expected blob == result")
+		require.True(t, bytes.Equal(blob, result), "expected blob == result")
 	})
 
 	t.Run("Reference with Err", func(t *testing.T) {
-		var result string
 		berr := errors.New("my bad error")
 		err := FetchAsStream(ctx, &fakeReference{
 			Data:  []byte("hello-world"),
@@ -101,8 +100,7 @@ func TestFetchAsStream(t *testing.T) {
 			if cerr != nil {
 				return cerr
 			}
-			result = b.String()
-			return nil
+			panic("this should not be reachable, as fetching failed, so should reading from io.Reader")
 		})
 		require.Equal(t, berr, err)
 	})

--- a/runtime/fetcher/fetchasstream_test.go
+++ b/runtime/fetcher/fetchasstream_test.go
@@ -1,0 +1,109 @@
+package fetcher
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchAsStream(t *testing.T) {
+	ctx := &fakeContext{Context: context.Background()}
+	// Create a random blob
+	blob := make([]byte, 16*1024+27)
+	_, rerr := rand.Read(blob)
+	require.NoError(t, rerr, "failed to created random data for testing")
+
+	t.Run("hello-world", func(t *testing.T) {
+		var result string
+		err := FetchAsStream(ctx, &fakeReference{
+			Data:  []byte("hello-world"),
+			Reset: false,
+			Err:   nil,
+		}, func(_ context.Context, r io.Reader) error {
+			b := bytes.NewBuffer(nil)
+			_, cerr := io.Copy(b, r)
+			result = b.String()
+			return cerr
+		})
+		require.NoError(t, err)
+		require.Equal(t, "hello-world", result)
+	})
+
+	t.Run("hello-world with Reset", func(t *testing.T) {
+		var result string
+		err := FetchAsStream(ctx, &fakeReference{
+			Data:  []byte("hello-world"),
+			Reset: true,
+			Err:   nil,
+		}, func(ctx context.Context, r io.Reader) error {
+			b := bytes.NewBuffer(nil)
+			_, cerr := io.Copy(b, r)
+			if cerr != nil {
+				return cerr
+			}
+			result = b.String()
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "hello-world", result)
+	})
+
+	t.Run("blob", func(t *testing.T) {
+		var result []byte
+		err := FetchAsStream(ctx, &fakeReference{
+			Data:  blob,
+			Reset: false,
+			Err:   nil,
+		}, func(_ context.Context, r io.Reader) error {
+			b := bytes.NewBuffer(nil)
+			_, cerr := io.Copy(b, r)
+			result = b.Bytes()
+			return cerr
+		})
+		require.NoError(t, err)
+		require.True(t, bytes.Compare(blob, result) == 0, "expected blob == result")
+	})
+
+	t.Run("blob with Reset", func(t *testing.T) {
+		var result []byte
+		err := FetchAsStream(ctx, &fakeReference{
+			Data:  blob,
+			Reset: true,
+			Err:   nil,
+		}, func(ctx context.Context, r io.Reader) error {
+			b := bytes.NewBuffer(nil)
+			_, cerr := io.Copy(b, r)
+			if cerr != nil {
+				return cerr
+			}
+			result = b.Bytes()
+			return nil
+		})
+		require.NoError(t, err)
+		require.True(t, bytes.Compare(blob, result) == 0, "expected blob == result")
+	})
+
+	t.Run("Reference with Err", func(t *testing.T) {
+		var result string
+		berr := errors.New("my bad error")
+		err := FetchAsStream(ctx, &fakeReference{
+			Data:  []byte("hello-world"),
+			Reset: false,
+			Err:   berr,
+		}, func(ctx context.Context, r io.Reader) error {
+			b := bytes.NewBuffer(nil)
+			_, cerr := io.Copy(b, r)
+			if cerr != nil {
+				return cerr
+			}
+			result = b.String()
+			return nil
+		})
+		require.Equal(t, berr, err)
+	})
+}

--- a/runtime/fetcher/urlfetcher_test.go
+++ b/runtime/fetcher/urlfetcher_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestUrlFetcher(t *testing.T) {
-	ctx := &mockContext{
+	ctx := &fakeContext{
 		Context: context.Background(),
 	}
 
@@ -77,24 +77,26 @@ func TestUrlFetcher(t *testing.T) {
 
 	t.Run("status-ok", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx, s.URL+"/ok")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx, w)
 		require.NoError(t, err)
 		require.Equal(t, "status-ok", w.String())
 		require.Equal(t, 1, count)
+
 	})
 
 	t.Run("streaming-ok", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx, s.URL+"/streaming")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx, w)
 		require.NoError(t, err)
 		require.Contains(t, w.String(), "hello")
 		require.Equal(t, 1, count)
+
 	})
 
 	t.Run("slow progress reports", func(t *testing.T) {
@@ -105,9 +107,9 @@ func TestUrlFetcher(t *testing.T) {
 			progressReportInterval = origProgressReportInterval
 		}()
 
-		ctx2 := &mockContext{Context: context.Background()}
+		ctx2 := &fakeContext{Context: context.Background()}
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx2, s.URL+"/slow")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx2, w)
@@ -123,7 +125,7 @@ func TestUrlFetcher(t *testing.T) {
 
 	t.Run("client-error", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx, s.URL+"/client-error")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx, w)
@@ -135,7 +137,7 @@ func TestUrlFetcher(t *testing.T) {
 
 	t.Run("unauthorized", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx, s.URL+"/unauthorized")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx, w)
@@ -147,7 +149,7 @@ func TestUrlFetcher(t *testing.T) {
 
 	t.Run("forbidden", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx, s.URL+"/forbidden")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx, w)
@@ -159,7 +161,7 @@ func TestUrlFetcher(t *testing.T) {
 
 	t.Run("not-found", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx, s.URL+"/not-found")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx, w)
@@ -171,7 +173,7 @@ func TestUrlFetcher(t *testing.T) {
 
 	t.Run("server-error", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URL.NewReference(ctx, s.URL+"/server-error")
 		require.NoError(t, err)
 		err = ref.Fetch(ctx, w)

--- a/runtime/fetcher/urlhash_test.go
+++ b/runtime/fetcher/urlhash_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestUrlHashFetcher(t *testing.T) {
-	ctx := &mockContext{
+	ctx := &fakeContext{
 		Context: context.Background(),
 	}
 
@@ -95,7 +95,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("status-ok", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/ok",
 		})
@@ -108,7 +108,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("status-ok with md5", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/ok",
 			"md5": md5ok,
@@ -122,7 +122,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("status-ok with sha1", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url":  s.URL + "/ok",
 			"sha1": sha1ok,
@@ -136,7 +136,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("status-ok with sha256", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url":    s.URL + "/ok",
 			"sha256": sha256ok,
@@ -150,7 +150,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("status-ok with wrong sha256", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url":    s.URL + "/ok",
 			"sha256": sha256ok[:60] + "ffff",
@@ -165,7 +165,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("status-ok with sha512", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url":    s.URL + "/ok",
 			"sha512": sha512ok,
@@ -179,7 +179,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("status-ok with hashes", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url":    s.URL + "/ok",
 			"md5":    md5ok,
@@ -196,7 +196,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("streaming-ok", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/streaming",
 		})
@@ -215,9 +215,9 @@ func TestUrlHashFetcher(t *testing.T) {
 			progressReportInterval = origProgressReportInterval
 		}()
 
-		ctx2 := &mockContext{Context: context.Background()}
+		ctx2 := &fakeContext{Context: context.Background()}
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx2, map[string]interface{}{
 			"url": s.URL + "/slow",
 		})
@@ -235,7 +235,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("client-error", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/client-error",
 		})
@@ -249,7 +249,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("unauthorized", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/unauthorized",
 		})
@@ -263,7 +263,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("forbidden", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/forbidden",
 		})
@@ -277,7 +277,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("not-found", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/not-found",
 		})
@@ -291,7 +291,7 @@ func TestUrlHashFetcher(t *testing.T) {
 
 	t.Run("server-error", func(t *testing.T) {
 		count = 0
-		w := &mockWriteReseter{}
+		w := &fakeWriteReseter{}
 		ref, err := URLHash.NewReference(ctx, map[string]interface{}{
 			"url": s.URL + "/server-error",
 		})


### PR DESCRIPTION
This will ideally make it easier to use the `fetcher.Fetcher` interface
in cases where you want to process the output with a stream.
So long as the stream can be aborted and started over again, it should be fine.