### PR TITLE
Volume support for docker-engine

### DIFF
--- a/engines/docker/engine.go
+++ b/engines/docker/engine.go
@@ -127,6 +127,25 @@ func (e *engine) NewSandboxBuilder(options engines.SandboxOptions) (engines.Sand
 	return newSandboxBuilder(&p, e, e.Environment.Monitor, options.TaskContext), nil
 }
 
+func (e *engine) VolumeSchema() schematypes.Schema {
+	return volumeSchema
+}
+
+func (e *engine) NewVolumeBuilder(options interface{}) (engines.VolumeBuilder, error) {
+	var opts volumeOptions
+	schematypes.MustValidateAndMap(e.VolumeSchema(), options, &opts)
+
+	return newVolumeBuilder(e, &opts)
+}
+
+func (e *engine) NewVolume(options interface{}) (engines.Volume, error) {
+	vb, err := e.NewVolumeBuilder(options)
+	if err != nil {
+		return nil, err
+	}
+	return vb.BuildVolume()
+}
+
 func (e *engine) Dispose() error {
 	// Dispose network.Pool
 	err := e.networks.Dispose()

--- a/engines/docker/engine_test.go
+++ b/engines/docker/engine_test.go
@@ -176,3 +176,26 @@ func TestPrivileged(t *testing.T) {
 
 	c.Test()
 }
+
+func TestVolumes(t *testing.T) {
+	c := enginetest.VolumeTestCase{
+		EngineProvider: provider,
+		Mountpoint:     "/mnt/my-volume/",
+		WriteVolumePayload: `{
+			"image": {
+				"repository": "` + dockerImageRepository + `",
+				"tag": "` + dockerImageTag + `"
+			},
+			"command": ["sh", "-c", "echo 'hello-cache-volume' > /mnt/my-volume/cache-file.txt"]
+		}`,
+		CheckVolumePayload: `{
+			"image": {
+				"repository": "` + dockerImageRepository + `",
+				"tag": "` + dockerImageTag + `"
+			},
+			"command": ["sh", "-c", "cat /mnt/my-volume/cache-file.txt | grep 'hello-cache-volume'"]
+		}`,
+	}
+
+	c.Test()
+}

--- a/engines/docker/resultset.go
+++ b/engines/docker/resultset.go
@@ -244,8 +244,9 @@ func (r *resultSet) Dispose() error {
 
 	// Remove the container
 	err := r.docker.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    r.containerID,
-		Force: true,
+		ID:            r.containerID,
+		Force:         true, // Kill anything still running in the container
+		RemoveVolumes: true, // Remove any volumes automatically created with the container (VOLUME in docker image)
 	})
 	if err != nil {
 		r.monitor.ReportError(err, "failed to remove container in disposal of resultSet")

--- a/engines/docker/sandbox.go
+++ b/engines/docker/sandbox.go
@@ -240,8 +240,9 @@ func (s *sandbox) dispose() error {
 
 	// Remove the container
 	err := s.docker.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    s.containerID,
-		Force: true,
+		ID:            s.containerID,
+		Force:         true, // Kill anything still running in the container
+		RemoveVolumes: true, // Remove any volumes automatically created with the container (VOLUME in docker image)
 	})
 	if err != nil {
 		s.monitor.ReportError(err, "failed to remove container in disposal of sandbox")

--- a/engines/docker/sandbox.go
+++ b/engines/docker/sandbox.go
@@ -62,6 +62,7 @@ func newSandbox(sb *sandboxBuilder) (*sandbox, error) {
 			// gateway IP is also the host machine that we're listening for requests
 			// to the proxies added to proxyMux above..
 			ExtraHosts: []string{fmt.Sprintf("taskcluster:%s", networkHandle.Gateway())},
+			Mounts:     sb.mounts,
 		},
 		NetworkingConfig: &docker.NetworkingConfig{
 			EndpointsConfig: map[string]*docker.EndpointConfig{

--- a/engines/docker/sandboxbuilder.go
+++ b/engines/docker/sandboxbuilder.go
@@ -2,8 +2,10 @@ package dockerengine
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"sync"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -27,6 +29,7 @@ type sandboxBuilder struct {
 	discarded   bool
 	cancelPull  context.CancelFunc
 	imageHandle *caching.Handle
+	mounts      []docker.HostMount
 }
 
 func newSandboxBuilder(payload *payloadType, e *engine, monitor runtime.Monitor,
@@ -104,6 +107,99 @@ func (sb *sandboxBuilder) AttachProxy(hostname string, handler http.Handler) err
 
 	// Otherwise set the handler
 	sb.proxies[hostname] = handler
+	return nil
+}
+
+// mountPointPattern is a pattern all mount-points must match. Picked to avoid
+// characters that are illegal on Windows / OS X as well as Linux.
+var mountPointPattern = regexp.MustCompile(`^(?:/[^/\0\\:*"<>|]+)+/$`)
+
+func validateMountPoint(mountPoint string) error {
+	// We require all mount-points to be absolute paths
+	if !strings.HasPrefix(mountPoint, "/") {
+		return runtime.NewMalformedPayloadError(fmt.Sprintf(
+			"mount-point: '%s' does not start with slash, all mount-points must be absolute",
+			mountPoint,
+		))
+	}
+
+	// In ExtractFolder we require paths to folders to end in slash, so for
+	// consistency we require the same here.
+	if !strings.HasSuffix(mountPoint, "/") {
+		return runtime.NewMalformedPayloadError(fmt.Sprintf(
+			"mount-point: '%s' does not end with slash, all mount-points must end with "+
+				"a slash to indicate a folder being mounted", mountPoint,
+		))
+	}
+
+	// Restrict arbitrary characters, notably \0 will cause problems. But forbidding
+	// other characters is just good preparation for future Windows / OS X support.
+	// It's also a good sanity protection from evil tasks trying to trick docker
+	// into doing something we don't want it to do.
+	if !mountPointPattern.MatchString(mountPoint) {
+		return runtime.NewMalformedPayloadError(fmt.Sprintf(
+			"mount-point: '%s' is not allowed for docker engine, mount-points must match: %s",
+			mountPoint, mountPointPattern.String(),
+		))
+	}
+
+	// For sanity we forbid mount-points that contain /./ and /../, who knows what
+	// that would do to docker (which is not designed to handle evil input)
+	if strings.Contains(mountPoint, "/./") || strings.Contains(mountPoint, "/../") {
+		return runtime.NewMalformedPayloadError(fmt.Sprintf(
+			"mount-point: '%s' may not contain '/./' or '/../'", mountPoint,
+		))
+	}
+
+	return nil
+}
+
+func (sb *sandboxBuilder) AttachVolume(mountPoint string, vol engines.Volume, readOnly bool) error {
+	// We may assert that vol is a result from engine.NewVolume()
+	v, ok := vol.(*volume)
+	if !ok {
+		sb.monitor.Panicf("AttachVolume() was passed volume of type: %T", vol)
+	}
+
+	// Validate mount-point
+	if err := validateMountPoint(mountPoint); err != nil {
+		return err
+	}
+
+	// Obtain an exclusive lock
+	sb.m.Lock()
+	defer sb.m.Unlock()
+
+	// remove the last slash from mountPoint and we have target as supplied to docker
+	target := mountPoint[:len(mountPoint)-1]
+
+	// Check for naming conflicts
+	for _, mount := range sb.mounts {
+		// If mount-point is the same as another mount, then we have a conflict
+		if target == mount.Target {
+			return engines.ErrNamingConflict
+		}
+		// If mount-point is a strict prefix for the mount-point of an earlier
+		// volume, then this volume will completely overwrite the previous one.
+		// That seems bad... If these calls make from different plugins this could
+		// happen intermittently depending on who calls AttachVolume() first.
+		// Hence, we check if target is inside another mount-point, if as this
+		// causes an error regardless of the AttachVolume() ordering.
+		// The cache plugin calls AttachVolume in the order caches are given, so
+		// we could loosen up this restriction with a slight risk of intermittence.
+		if strings.HasPrefix(mount.Target, mountPoint) || strings.HasPrefix(target, mount.Target+"/") {
+			return engines.ErrNamingConflict
+		}
+	}
+
+	// Add a HostMount
+	sb.mounts = append(sb.mounts, docker.HostMount{
+		Target:   target,
+		Source:   v.GetName(),
+		Type:     "volume",
+		ReadOnly: readOnly,
+	})
+
 	return nil
 }
 

--- a/engines/docker/sandboxbuilder_test.go
+++ b/engines/docker/sandboxbuilder_test.go
@@ -1,0 +1,45 @@
+package dockerengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateMountPoint(t *testing.T) {
+	invalidMountPoints := []string{
+		"",
+		"/",
+		"//",
+		"/test",
+		"test",
+		"test/",
+		"/test/a",
+		"/test/./",
+		"../",
+		"/..",
+		"/test/../",
+		string([]byte{'/', 't', 0, 't', '/'}), // try with \0
+		"/test\\something/",
+	}
+	validMountPoints := []string{
+		"/test/",
+		"/test/test/",
+		"/tmp/",
+		"/var/lib/docker/",
+		"/mnt/my-folder/",
+	}
+
+	for _, mountPoint := range invalidMountPoints {
+		t.Run(`"`+mountPoint+`"`, func(t *testing.T) {
+			err := validateMountPoint(mountPoint)
+			assert.Error(t, err, "expected '"+mountPoint+"' to be valid")
+		})
+	}
+	for _, mountPoint := range validMountPoints {
+		t.Run(`"`+mountPoint+`"`, func(t *testing.T) {
+			err := validateMountPoint(mountPoint)
+			assert.NoError(t, err, "expected '%s' to be valid", mountPoint)
+		})
+	}
+}

--- a/engines/docker/volume.go
+++ b/engines/docker/volume.go
@@ -1,0 +1,266 @@
+package dockerengine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	schematypes "github.com/taskcluster/go-schematypes"
+	"github.com/taskcluster/slugid-go/slugid"
+	"github.com/taskcluster/taskcluster-worker/engines"
+	"github.com/taskcluster/taskcluster-worker/runtime"
+)
+
+// dockerVolumeCreateTimeout is the maximum amount of time we allow the docker
+// volume creation to take. This ensures that request timeouts doesn't cause the
+// worker to hang.
+const dockerVolumeCreateTimeout = 5 * time.Minute
+
+// dockerVolumeRemoveTimeout is the maximum amount of time we allow the docker
+// volume removal to take. This a bit longer than dockerVolumeCreateTimeout
+// in order to give the OS time to remove a lot of files.
+const dockerVolumeRemoveTimeout = 25 * time.Minute
+
+var volumeSchema = schematypes.Object{
+	Title:                "Docker Volume Options",
+	Description:          "Options for docker volumes at this time no options are supported.",
+	AdditionalProperties: false, // We just require an empty object to ensure forward-compatibility
+}
+
+type volumeOptions struct{}
+
+type volumeBuilder struct {
+	engines.VolumeBuilderBase
+	m       sync.Mutex
+	v       *volume
+	invalid bool
+}
+
+type volume struct {
+	engines.VolumeBase
+	m        sync.Mutex
+	name     string
+	engine   *engine
+	options  *volumeOptions
+	volume   *docker.Volume
+	monitor  runtime.Monitor
+	disposed bool
+}
+
+func newVolumeBuilder(e *engine, options *volumeOptions) (*volumeBuilder, error) {
+	name := slugid.Nice()
+
+	// Create a monitor to follow this volume for it's life-cycle
+	monitor := e.monitor.WithTag("volume-name", name)
+
+	// Ensure we have a timeout on the CreateVolume for sanity, this ensures that
+	// the entire worker doesn't deadlock if docker has an issue
+	context, cancel := context.WithTimeout(context.Background(), dockerVolumeCreateTimeout)
+	defer cancel()
+
+	debug("creating volume name: '%s'", name)
+	vol, err := e.docker.CreateVolume(docker.CreateVolumeOptions{
+		Context: context,
+		Name:    name,
+		Driver:  "local",
+		Labels: map[string]string{
+			"created": time.Now().UTC().Format(time.RFC3339),
+			"owner":   "taskcluster-worker",
+		},
+	})
+	if err != nil {
+		monitor.ReportError(err, "docker.CreateVolume failed")
+		return nil, runtime.ErrFatalInternalError
+	}
+
+	return &volumeBuilder{
+		v: &volume{
+			name:    name,
+			engine:  e,
+			options: options,
+			volume:  vol,
+			monitor: monitor,
+		},
+	}, nil
+}
+
+func (vb *volumeBuilder) WriteFolder(name string) error {
+	vb.m.Lock()
+	defer vb.m.Unlock()
+
+	// Ensure that this VolumeBuilder instance is still valid
+	if vb.invalid {
+		vb.v.monitor.Panic("VolumeBuilder.WriteFolder() was called after BuildVolume()/Discard()")
+	}
+
+	// Find path to folder
+	p := filepath.Join(vb.v.volume.Mountpoint, filepath.FromSlash(name))
+
+	// Forbid file paths that reaches out-side the docker volume mount-point
+	if !strings.HasPrefix(p, filepath.Clean(vb.v.volume.Mountpoint)) {
+		vb.v.monitor.WithTags(map[string]string{
+			"folderName": name,
+			"mountPoint": vb.v.volume.Mountpoint,
+		}).ReportError(errors.New(
+			"VolumeBuilder.WriteFolder() for docker-engine attempted to create folder outside the volume",
+		))
+		return runtime.ErrFatalInternalError
+	}
+
+	// Create folder
+	err := os.MkdirAll(p, 0777)
+	if err != nil {
+		vb.v.monitor.WithTags(map[string]string{
+			"folderName": name,
+			"mountPoint": vb.v.volume.Mountpoint,
+		}).ReportError(err, "VolumeBuilder.WriteFolder() for docker-engine failed to create folder")
+		return runtime.ErrFatalInternalError // we can't really continue if we failed to create a folder
+	}
+
+	return nil
+}
+
+func (vb *volumeBuilder) WriteFile(name string) io.WriteCloser {
+	vb.m.Lock()
+	defer vb.m.Unlock()
+
+	// Ensure that this VolumeBuilder instance is still valid
+	if vb.invalid {
+		vb.v.monitor.Panic("VolumeBuilder.WriteFile() was called after BuildVolume()/Discard()")
+	}
+
+	// Find path to file
+	p := filepath.Join(vb.v.volume.Mountpoint, filepath.FromSlash(name))
+	d := filepath.Clean(filepath.Dir(p)) // folder path that we should ensure exists
+
+	// Forbid file paths that reaches out-side the docker volume mount-point
+	if !strings.HasPrefix(d, filepath.Clean(vb.v.volume.Mountpoint)) {
+		vb.v.monitor.WithTags(map[string]string{
+			"fileName":   name,
+			"mountPoint": vb.v.volume.Mountpoint,
+		}).ReportError(errors.New(
+			"VolumeBuilder.WriteFile() for docker-engine attempted to create file outside the volume",
+		))
+		return &errWriteCloser{Err: runtime.ErrFatalInternalError}
+	}
+
+	// Create all the necessary folders
+	err := os.MkdirAll(d, 0777)
+	if err != nil {
+		vb.v.monitor.WithTags(map[string]string{
+			"fileName":   name,
+			"mountPoint": vb.v.volume.Mountpoint,
+		}).ReportError(err, "VolumeBuilder.WriteFile() for docker-engine failed to necessary folders for file")
+		return &errWriteCloser{Err: runtime.ErrFatalInternalError}
+	}
+
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
+	if err != nil {
+		vb.v.monitor.WithTags(map[string]string{
+			"fileName":   name,
+			"mountPoint": vb.v.volume.Mountpoint,
+		}).ReportError(err, "VolumeBuilder.WriteFile() for docker-engine failed to create file")
+		// we can't really continue if we failed to create a file
+		return &errWriteCloser{Err: runtime.ErrFatalInternalError}
+	}
+
+	return f // Note it is the callers responsibility to close the file
+}
+
+func (vb *volumeBuilder) BuildVolume() (engines.Volume, error) {
+	vb.m.Lock()
+	defer vb.m.Unlock()
+
+	// Ensure that this VolumeBuilder instance is still valid
+	if vb.invalid {
+		vb.v.monitor.Panic("VolumeBuilder.BuildVolume() was called after BuildVolume()/Discard()")
+	}
+
+	// Mark the VolumeBuilder as invalid
+	vb.invalid = true
+
+	return vb.v, nil
+}
+
+func (vb *volumeBuilder) Discard() error {
+	vb.m.Lock()
+	defer vb.m.Unlock()
+
+	// Ensure that this VolumeBuilder instance is still valid
+	if vb.invalid {
+		vb.v.monitor.Panic("VolumeBuilder.Discard() was called after BuildVolume()/Discard()")
+	}
+
+	// Mark the VolumeBuilder as invalid
+	vb.invalid = true
+
+	// Discard the underlying volume
+	return vb.v.Dispose()
+}
+
+// GetName returns the name for mounting it in docker containers
+func (v *volume) GetName() string {
+	v.m.Lock()
+	defer v.m.Unlock()
+
+	// Validate that this haven't been disposed yet
+	if v.disposed {
+		v.monitor.Panic("Volume cannot be used after Dispose()")
+	}
+
+	return v.name
+}
+
+func (v *volume) Dispose() error {
+	v.m.Lock()
+	defer v.m.Unlock()
+
+	// Ignore double Dispose() there is no risk here
+	if v.disposed {
+		// Send a warning regardless
+		v.monitor.Warn("Volume.Discard() was called twice!")
+		return nil
+	}
+
+	// Ensure that we don't dispose twice
+	v.disposed = true
+
+	// Ensure we have some timeout, this should be large as there could be many
+	// files to delete. Most linux file systems will be fast at this, but no promises.
+	context, cancel := context.WithTimeout(context.Background(), dockerVolumeRemoveTimeout)
+	defer cancel()
+
+	debug("removing volume name: '%s'", v.name)
+	err := v.engine.docker.RemoveVolumeWithOptions(docker.RemoveVolumeOptions{
+		Context: context,
+		Name:    v.name,
+	})
+	// If there is an error, we report it and return ErrNonFatalInternalError.
+	// (non-fatal because leaking a single volume isn't the end of the world)
+	if err != nil {
+		v.monitor.ReportError(err, "Volume.Dispose() failed to remove a volume")
+		return runtime.ErrNonFatalInternalError
+	}
+
+	return nil
+}
+
+// errWriteCloser is a simple io.WriteCloser implementation that returns Err
+// for all operations.
+type errWriteCloser struct {
+	Err error
+}
+
+func (e *errWriteCloser) Write(p []byte) (int, error) {
+	return 0, e.Err
+}
+
+func (e *errWriteCloser) Close() error {
+	return e.Err
+}

--- a/engines/volume.go
+++ b/engines/volume.go
@@ -16,7 +16,7 @@ type VolumeBuilder interface {
 	// intermediate folders have been created.
 	WriteFolder(name string) error
 
-	// Write a file to the volime being built.
+	// Write a file to the volume being built.
 	//
 	// Name must be a slash separated path, there is no requirement that
 	// intermediate folders have been created.


### PR DESCRIPTION
This adds support for volumes, read-only, and read-write volumes.
As well as the `VolumeBuilder` pattern that enables the `cache` plugin
to make pre-loaded caches.