### PR TITLE
Bug 1467211: Fix relengapi proxy

### DIFF
--- a/plugins/relengapi/token.go
+++ b/plugins/relengapi/token.go
@@ -7,8 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
-
-	"github.com/taskcluster/httpbackoff"
 )
 
 type relengapiTokenJSON struct {
@@ -45,7 +43,10 @@ func getTmpToken(urlPrefix string, issuingToken string, expires time.Time, perms
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", issuingToken))
-	resp, _, err := httpbackoff.ClientDo(client, req)
+
+	// Issuing a token is improbable to need a retry, but anyway better to
+	// use httpbackoff package when it is fixed
+	resp, err := client.Do(req)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The httpbackoff package has a bug that returns trash data. Since the
request is short enough to make a retry improbably, we remove it.